### PR TITLE
Integrate refactored OpenEvolve with COMMANDMENT-based evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ geak-oe/
 
 # AITER repo (cloned at runtime for test suite)
 aiter/
+
+# Profiler data
+.rocprofv3/
+
+# OpenEvolve intermediate outputs
+optimization_output/
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ RUN pip install -e mcp_tools/mcp-client/ && \
     pip install -e mcp_tools/kernel-evolve/ && \
     pip install -e mcp_tools/automated-test-discovery/
 
+# Install OpenEvolve (refactored: multi-file COMMANDMENT-based evaluation with GPU isolation)
+RUN git clone -b optimizer-geak-openevolve https://github.com/AMD-AGI/GEAK.git /workspace/geak-oe \
+    && cd /workspace/geak-oe && pip install -e . --no-build-isolation \
+    && cd /workspace
+
 # Verify core imports (metrix is ROCm runtime dependency)
 RUN python3 -c "from geak_agent.cli import main; from geakagent.optimizer import optimize_kernel; from mcp_client import MCPClient; print('✅ Core imports verified')"
 
@@ -37,5 +42,6 @@ COPY entrypoint.sh /workspace/entrypoint.sh
 RUN chmod +x /workspace/entrypoint.sh
 
 ENV HIP_VISIBLE_DEVICES=0
+ENV GEAK_OE_ROOT=/workspace/geak-oe
 ENTRYPOINT ["/workspace/entrypoint.sh"]
 CMD ["tail", "-f", "/dev/null"]

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,244 @@
+# GEAK Agent Pipeline Instructions
+
+READ THIS FILE COMPLETELY before starting any work. It contains the exact
+commands, rules, and patterns for every tool in the pipeline.
+
+All paths below use `KERNEL_DIR` as a placeholder. Replace it with the
+actual kernel directory (e.g., `/workspace/AIG-Eval/tasks/geak_eval/gemm`).
+
+---
+
+## Tool CLI Reference
+
+### kernel-profile (Metrix hardware profiler)
+```
+kernel-profile [-h] [--gpu-devices GPU_DEVICES] [--filter FILTER]
+               [--replays REPLAYS] [--auto-select] [--quick]
+               command
+
+positional arguments:
+  command               Command to profile (e.g., "python3 kernel.py --profile")
+
+options:
+  --gpu-devices GPU_DEVICES   GPU device ID(s): "0" or "0,1,2" (default: 3)
+  --filter FILTER             Kernel name filter (e.g., "*topk*")
+  --replays REPLAYS           Number of profiling replays (default: 3)
+  --auto-select               Automatically select main kernel
+  --quick                     Fast profiling (3 metrics, 1 pass)
+```
+
+### run_openevolve.py (evolutionary kernel optimizer)
+```
+python3 /workspace/geak-oe/examples/geak_eval/run_openevolve.py [-h]
+        [--iterations ITERATIONS] [--gpu GPU] [--output OUTPUT]
+        [--config CONFIG] [--api-key API_KEY] [--skip-profiling]
+        [--commandment COMMANDMENT] [--baseline-metrics BASELINE_METRICS]
+        kernel_path
+
+positional arguments:
+  kernel_path                   Path to the kernel file to optimise
+
+options:
+  --iterations N, -n N          Max evolution iterations (default: 10)
+  --gpu GPU, -g GPU             GPU device ID (default: 0)
+  --output OUTPUT, -o OUTPUT    Output directory (default: <kernel_dir>/optimization_output)
+  --config CONFIG, -c CONFIG    Path to OpenEvolve config.yaml
+  --api-key API_KEY             LLM API key (default: from AMD_LLM_API_KEY env)
+  --skip-profiling              Skip Metrix baseline profiling
+  --commandment COMMANDMENT     Path to pre-built COMMANDMENT.md (skips auto-build)
+  --baseline-metrics BASELINE_METRICS  Path to baseline_metrics.json
+```
+
+IMPORTANT: The output flag is `--output` (or `-o`), NOT `--output-dir`.
+
+---
+
+## 1. DISCOVER: Analyze the Kernel
+
+Read `kernel.py` and identify:
+- Triton JIT functions (`@triton.jit`)
+- Python wrappers (`triton_op`, `torch_op`)
+- Evaluation configs (`EVAL_CONFIGS`)
+- Whether `--profile` flag is supported
+- Supported activations, data types, etc.
+
+Quick discovery command:
+```bash
+python3 -c "
+from geak_agent.mcp_tools.discovery import discover
+result = discover(workspace='KERNEL_DIR')
+print(f'Kernels: {len(result.kernels)}')
+print(f'Tests: {len(result.tests)}')
+print(f'Benchmarks: {len(result.benchmarks)}')
+"
+```
+
+Also run the kernel evaluation to verify correctness:
+```bash
+cd KERNEL_DIR && python3 kernel.py
+```
+
+---
+
+## 2. BENCHMARKING: Profile with Metrix (kernel-profile)
+
+### Command
+```bash
+kernel-profile "python3 KERNEL_DIR/kernel.py --profile" \
+  --gpu-devices 0 --auto-select --replays 5
+```
+
+### Saving Baseline Metrics
+To save metrics as JSON for OpenEvolve (pre-built mode only):
+```bash
+mkdir -p KERNEL_DIR/optimization_output
+python3 -c "
+from geak_agent.mcp_tools.metrix import MetrixTool
+import json
+tool = MetrixTool(gpu_devices='0')
+result = tool.profile(
+    command='python3 KERNEL_DIR/kernel.py --profile',
+    auto_select=True,
+    num_replays=5,
+    quick=False
+)
+metrics = result.get('metrics', result)
+with open('KERNEL_DIR/optimization_output/baseline_metrics.json', 'w') as f:
+    json.dump(metrics, f, indent=2)
+print(json.dumps(metrics, indent=2))
+"
+```
+
+### Key Metrics
+- `duration_us` — kernel execution time in microseconds (PRIMARY metric for scoring)
+- `memory.hbm_bandwidth_utilization` — HBM bandwidth usage (%)
+- `memory.l2_hit_rate` — L2 cache hit rate (%)
+- `memory.coalescing_efficiency` — memory access pattern quality (%)
+- Bottleneck classification: memory-bound, compute-bound, latency-bound, etc.
+
+---
+
+## 3. OPTIMIZATION: Run OpenEvolve
+
+There are two modes. Choose ONE.
+
+### Option A: Auto-build mode (RECOMMENDED for standard AIG-Eval kernels)
+
+Use this when the kernel has `triton_op()`, `torch_op()`, `EVAL_CONFIGS`, and
+a `--profile` flag. This covers all kernels in `AIG-Eval/tasks/geak_eval/`.
+
+```bash
+cd KERNEL_DIR && python3 /workspace/geak-oe/examples/geak_eval/run_openevolve.py \
+  kernel.py \
+  --iterations 10 \
+  --gpu 0 \
+  --output optimization_output
+```
+
+What auto-build does for you:
+1. Detects `triton_op`, `torch_op`, `EVAL_CONFIGS`, `--profile` in kernel.py
+2. Builds SETUP, CORRECTNESS, and PROFILE commands automatically
+3. Validates all commands on the baseline kernel first
+4. Writes a frozen COMMANDMENT.md
+5. Profiles baseline with Metrix to get baseline_metrics.json
+6. Runs OpenEvolve evolutionary optimization
+
+You do NOT need to create COMMANDMENT.md or baseline_metrics.json — it's all automatic.
+
+### Option B: Pre-built COMMANDMENT mode (for non-standard / custom kernels)
+
+Use this when the kernel does NOT follow the standard AIG-Eval interface, or
+you need custom correctness checking or profiling commands.
+
+**Step 1:** Profile baseline (see Section 2 above) and save baseline_metrics.json
+
+**Step 2:** Write COMMANDMENT.md (see Section 4 below for format rules)
+
+**Step 3:** Run OpenEvolve with pre-built files:
+```bash
+cd KERNEL_DIR && python3 /workspace/geak-oe/examples/geak_eval/run_openevolve.py \
+  kernel.py \
+  --iterations 10 \
+  --gpu 0 \
+  --output optimization_output \
+  --commandment optimization_output/COMMANDMENT.md \
+  --baseline-metrics optimization_output/baseline_metrics.json
+```
+
+### OpenEvolve Output Files
+- `optimization_output/best_kernel.py` — the best optimized kernel found
+- `optimization_output/openevolve_result.json` — final results with best score
+- `optimization_output/progress.log` — iteration-by-iteration progress
+- `optimization_output/COMMANDMENT.md` — the frozen evaluation contract
+- `optimization_output/evals/` — per-candidate evaluation directories
+
+---
+
+## 4. COMMANDMENT.md Format (CRITICAL RULES)
+
+COMMANDMENT.md is the contract between the agent and OpenEvolve's evaluator.
+If you use auto-build mode (Option A), you do NOT need to write this file.
+Only read this section if you are using pre-built mode (Option B).
+
+### Environment Variables Set Automatically by the Evaluator
+These are available in every command — do NOT set them yourself:
+- `${GEAK_WORK_DIR}` — the eval temp directory. The candidate kernel.py is ALREADY here.
+- `${GEAK_GPU_DEVICE}` — the GPU device ID for this evaluation
+- `${GEAK_KERNEL_DIR}` — the original kernel directory
+
+### CRITICAL RULES
+1. Only three section headers are recognized: `## SETUP`, `## CORRECTNESS`, `## PROFILE`
+2. Any other `##` header ends the current section (content after it is ignored)
+3. **NEVER put a `cp` command in SETUP** — OpenEvolve writes kernel.py into `${GEAK_WORK_DIR}` automatically before running any section
+4. Always use `${GEAK_WORK_DIR}/kernel.py` to reference the candidate kernel
+5. Always use `${GEAK_GPU_DEVICE}` instead of hardcoded GPU IDs
+6. Include TWO warm-up runs before actual profiling (Triton JIT compilation + GPU power ramp)
+7. Lines starting with `#` (comments) and empty lines are skipped
+8. Lines starting with ``` are skipped (don't wrap commands in code fences)
+9. Commands run with `cwd=${GEAK_WORK_DIR}`
+
+### Template (replace KERNEL_DIR with actual path)
+
+```
+## SETUP
+export HIP_VISIBLE_DEVICES=${GEAK_GPU_DEVICE}
+export PYTHONPATH=${GEAK_WORK_DIR}:${PYTHONPATH}
+
+## CORRECTNESS
+python3 /workspace/geak-oe/examples/geak_eval/correctness_check.py --baseline KERNEL_DIR/kernel.py --generated ${GEAK_WORK_DIR}/kernel.py
+
+## PROFILE
+python3 ${GEAK_WORK_DIR}/kernel.py --profile > /dev/null 2>&1 || true
+python3 ${GEAK_WORK_DIR}/kernel.py --profile > /dev/null 2>&1 || true
+kernel-profile "python3 ${GEAK_WORK_DIR}/kernel.py --profile" --gpu-devices ${GEAK_GPU_DEVICE} --auto-select --replays 5
+```
+
+### Common Mistakes to Avoid
+- Adding `cp $GEAK_CANDIDATE_PATH ...` in SETUP — this variable does not exist
+- Hardcoding GPU IDs (use `${GEAK_GPU_DEVICE}`)
+- Referencing `${GEAK_WORK_DIR}` as the optimization_output dir — it's actually a per-eval temp dir
+- Wrapping commands in markdown code fences inside the COMMANDMENT file
+- Adding sections like `## SCORING` or `## BASELINE METRICS` — they end the PROFILE section
+- Using `--output-dir` instead of `--output` for run_openevolve.py
+
+---
+
+## 5. Saving Final Results
+
+After OpenEvolve completes:
+```bash
+cd KERNEL_DIR
+cp optimization_output/best_kernel.py kernel_optimized.py
+cat optimization_output/openevolve_result.json
+```
+
+---
+
+## 6. Environment Reference
+
+- `AMD_LLM_API_KEY` — required for LLM calls (already set in container)
+- `HIP_VISIBLE_DEVICES` — GPU selection (set by COMMANDMENT automatically)
+- `GEAK_OE_ROOT` — OpenEvolve root (default: /workspace/geak-oe)
+- Correctness checker: `/workspace/geak-oe/examples/geak_eval/correctness_check.py`
+- OpenEvolve runner: `/workspace/geak-oe/examples/geak_eval/run_openevolve.py`
+- kernel-profile: `/opt/venv/bin/kernel-profile`

--- a/README.md
+++ b/README.md
@@ -4,111 +4,183 @@ GPU Evolutionary Agent for Kernels - A simple AI agent for GPU kernel optimizati
 
 Based on [mini-swe-agent](https://github.com/SWE-agent/mini-SWE-agent) architecture: the LLM generates bash commands and MCP tool calls to optimize GPU kernels.
 
-## 🚀 Quick Start
+## Quick Start
+
+### Docker Setup (Recommended)
 
 ```bash
-# Auto-detect environment and run agent (recommended)
-python3 -m geakagent.run.mini -m claude-sonnet-4.5 \
-  -t "Optimize kernel at /path/to/kernel.py" \
-  --yolo
+# Build and run the Docker container
+cd GEAK    # this repo (branch: msa)
+export AMD_LLM_API_KEY=<your-key>
+bash scripts/run-docker.sh
+```
 
-# Force Docker with default image
-python3 -m geakagent.run.mini -m claude-sonnet-4.5 \
-  -t "Optimize kernel" \
-  --runtime docker \
-  --workspace /path/to/kernels \
+This builds a container with all tools pre-installed (OpenEvolve, Metrix, MCP servers).
+
+### Run the Agent
+
+```bash
+# Inside Docker container:
+python3 -m geakagent.run.mini \
+  -m claude-opus-4-5 \
+  -t "Complete GEAK Agent Pipeline for examples/add_kernel/kernel.py
+1. DISCOVER: Analyze the kernel
+2. TEST GENERATION: Create test cases
+3. BENCHMARKING: Profile baseline with Metrix and create COMMANDMENT.md
+4. OPTIMIZATION: Use OpenEvolve MCP with max_iterations=10
+5. Save optimized kernel and metrics" \
   --yolo
 ```
 
-**💡 New:** Auto-detects GPU environment, defaults to Docker `lmsysorg/sglang:v0.5.6.post1-rocm700-mi35x` if needed.
+### Run on AIG-Eval Kernels
 
-📖 See [RUNTIME_QUICKSTART.md](RUNTIME_QUICKSTART.md) | [RUNTIME_ENV.md](RUNTIME_ENV.md) for details.
+```bash
+# Clone AIG-Eval (inside container or mounted)
+git clone -b geak-eval-kernels git@github.com:AMD-AGI/AIG-Eval.git
+
+# Run optimization on a single kernel
+cd AIG-Eval/tasks/geak_eval
+bash run.sh fused_qkv_rope --optimize --gpu 0 --iterations 5
+
+# Run on all 8 kernels
+bash run.sh --all --optimize --gpu 0 --iterations 10
+```
+
+### Direct OpenEvolve Invocation
+
+```bash
+# Auto-build mode (generates COMMANDMENT.md from kernel)
+python3 $GEAK_OE_ROOT/examples/geak_eval/run_openevolve.py \
+  /path/to/kernel.py \
+  --iterations 10 --gpu 0 --output /path/to/output
+
+# Pre-built COMMANDMENT mode (for custom evaluation pipelines)
+python3 $GEAK_OE_ROOT/examples/geak_eval/run_openevolve.py \
+  /path/to/kernel.py \
+  --iterations 10 --gpu 0 --output /path/to/output \
+  --commandment /path/to/COMMANDMENT.md \
+  --baseline-metrics /path/to/baseline_metrics.json
+```
 
 ---
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                      GEAK AGENT                             │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  LLM generates:                                             │
-│    - Bash commands (edit files, run tests, benchmark)       │
-│    - MCP tool calls (profile, evolve, discover)             │
-│                                                             │
-│  Execute → Observe → Repeat                                 │
-│                                                             │
-├─────────────────────────────────────────────────────────────┤
-│  Available MCPs:                                            │
-│    - automated-test-discovery  (find tests/benchmarks)      │
-│    - kernel-profiler          (rocprof-compute profiling)   │
-│    - kernel-evolve            (LLM mutation/crossover)      │
-│    - kernel-ercs              (evaluation/reflection)       │
-└─────────────────────────────────────────────────────────────┘
+GEAK-MSA Pipeline (mini-SWE-agent)
+====================================
+
+1. DISCOVER    --> Find kernel files
+2. TEST GEN    --> Generate test cases / correctness checks
+3. BASELINE    --> Profile with Metrix, validate evaluation commands
+4. FREEZE      --> Write COMMANDMENT.md (immutable during optimization)
+5. OPTIMIZE    --> OpenEvolve evolutionary optimization
+6. REPORT      --> Best kernel + speedup metrics
+
+COMMANDMENT.md = Universal Contract
+=====================================
+  SETUP:        Environment setup, GPU warmup
+  CORRECTNESS:  Deterministic correctness check vs baseline
+  PROFILE:      Metrix hardware profiling (warm-up + measurement)
+
+  - Written ONLY after all commands validated on baseline
+  - Frozen during OpenEvolve evolution (never changes)
+  - Each candidate evaluated with exact same commands
+  - GPU isolation: one GPU per evaluation, no contention
 ```
+
+### MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `openevolve-mcp` | OpenEvolve optimizer (COMMANDMENT-based, multi-file) |
+| `kernel-profiler` | Metrix hardware profiling (rocprofv3) |
+| `kernel-evolve` | LLM mutation/crossover strategies |
+| `kernel-ercs` | Evaluation/reflection |
+| `automated-test-discovery` | Find tests/benchmarks |
+
+### OpenEvolve Integration
+
+OpenEvolve is auto-installed in the Docker container from the
+[`optimizer-geak-openevolve`](https://github.com/AMD-AGI/GEAK/tree/optimizer-geak-openevolve) branch.
+
+Key features:
+- **Multi-file support**: Kernels can span multiple files (no SEPARATOR format)
+- **COMMANDMENT.md**: Frozen, deterministic evaluation contract
+- **GPU isolation**: GPUPool ensures exclusive GPU per concurrent evaluation
+- **Metrix profiler**: Hardware-level metrics (bandwidth, cache hit rates, compute utilization)
+- **Warm-up passes**: Stable baseline measurements (not cold-start inflated)
+- **Baseline profiling in prompts**: LLM receives hardware metrics to guide optimization
 
 ## Installation
 
-```bash
-# Clone the repository
-git clone -b msa2 https://github.com/AMD-AGI/GEAK-agent.git
-cd GEAK-agent
+### Docker (Recommended)
 
+```bash
+git clone -b msa https://github.com/AMD-AGI/GEAK.git
+cd GEAK
+export AMD_LLM_API_KEY=<your-key>
+bash scripts/run-docker.sh
+```
+
+The Dockerfile handles all dependencies:
+- GEAK-agent (this package)
+- OpenEvolve (optimizer-geak-openevolve branch)
+- Metrix (hardware profiler from AMD intellikit)
+- All MCP servers
+
+### Manual Installation
+
+```bash
 # 1. Install main package
 pip install -e .
 
 # 2. Clone and install OpenEvolve
-git clone -b geak-openevolve https://github.com/AMD-AGI/GEAK-agent.git geak-oe
-cd geak-oe && PIP_USER=1 python3 -m pip install -e . --no-build-isolation && cd ..
+git clone -b optimizer-geak-openevolve https://github.com/AMD-AGI/GEAK.git geak-oe
+cd geak-oe && pip install -e . --no-build-isolation && cd ..
+export GEAK_OE_ROOT=$(pwd)/geak-oe
 
 # 3. Install MCP servers
 pip install -e mcp_tools/openevolve-mcp/
-python3 -m pip install -e mcp_tools/mcp-client/ --no-build-isolation
+pip install -e mcp_tools/mcp-client/
+pip install -e mcp_tools/kernel-profiler/
+pip install -e mcp_tools/kernel-evolve/
+pip install -e mcp_tools/kernel-ercs/
+
+# 4. Install Metrix (requires ROCm)
+git clone https://github.com/AMDResearch/intellikit.git
+cd intellikit/metrix && pip install -e . && cd ../..
 ```
 
-## Usage
+## Environment Variables
 
-### Example: Full Pipeline Command
-
-```bash
-export ANTHROPIC_API_KEY="your-api-key"
-python3 -m geakagent.run.mini \
-  -m claude-sonnet-4.5 \
-  -t "Complete GEAK Agent Pipeline for examples/add_kernel/kernel.py
-
-1. DISCOVER: Analyze the kernel
-2. TEST GENERATION: Create test cases in examples/add_kernel/tests/
-3. BENCHMARKING: Save baseline metrics to benchmark/baseline/metrics.json
-4. OPTIMIZATION: Use OpenEvolve MCP (mcp_tools/openevolve-mcp) with max_iterations=10
-5. Save optimized kernel to kernel_optimized.py and metrics to benchmark/optimized/metrics.json" \
-  --yolo
-```
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `AMD_LLM_API_KEY` | API key for AMD LLM gateway | Yes |
+| `GEAK_OE_ROOT` | Path to OpenEvolve repo (default: `/workspace/geak-oe`) | No |
+| `OPENAI_API_KEY` | Set to `AMD_LLM_API_KEY` value for OpenEvolve | For optimization |
+| `HIP_VISIBLE_DEVICES` | GPU devices to use (default: `0`) | No |
 
 ## Project Structure
 
 ```
-GEAK-agent/
-├── src/geakagent/          # Main agent (minswe-based)
-│   ├── agents/             # Agent implementations
-│   ├── config/             # Configuration files
-│   ├── environments/       # Execution environments
-│   ├── models/             # LLM interfaces
-│   ├── optimizer/          # Optimizer interface
-│   └── run/                # CLI entry points
-├── mcp_tools/              # MCP servers & client (consolidated)
-│   ├── automated-test-discovery/   # MCP: test discovery
-│   ├── kernel-profiler/            # MCP: GPU profiling
-│   ├── kernel-evolve/              # MCP: optimization strategies
-│   ├── kernel-ercs/                # MCP: evaluation/reflection
-│   ├── openevolve-mcp/             # MCP: OpenEvolve optimizer
-│   └── mcp-client/                 # MCP: Protocol client (JSON-RPC)
-├── geak_agent/             # Discovery pipeline
-├── examples/               # Example kernels
-├── reference/              # Reference files from old agent
-│   ├── optimization_strategies.py
-│   └── state.py
-└── docs/
+GEAK/  (branch: msa)
+|-- src/geakagent/          # Main agent (minswe-based)
+|   |-- agents/             # Agent implementations
+|   |-- config/             # Configuration files (mini.yaml)
+|   |-- environments/       # Execution environments (local, docker)
+|   |-- models/             # LLM interfaces (AMD LLM gateway)
+|   |-- optimizer/          # Optimizer interface
+|   +-- run/                # CLI entry points
+|-- mcp_tools/              # MCP servers
+|   |-- openevolve-mcp/     # OpenEvolve optimizer (subprocess-based)
+|   |-- kernel-profiler/    # Metrix hardware profiling
+|   |-- kernel-evolve/      # LLM mutation strategies
+|   |-- kernel-ercs/        # Evaluation/reflection
+|   +-- mcp-client/         # MCP protocol client
+|-- examples/               # Example kernels (add_kernel)
+|-- scripts/                # Docker setup (run-docker.sh)
++-- docs/                   # Documentation
 ```
 
 ## Reference

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,6 +59,23 @@ else
     FAILED_CHECKS=$((FAILED_CHECKS + 1))
 fi
 
+# Check OpenEvolve installation
+if python3 -c "from openevolve import OpenEvolve; print('OK')" > /dev/null 2>&1; then
+    echo "✅ openevolve: OK"
+else
+    echo "❌ openevolve: Not importable"
+    FAILED_CHECKS=$((FAILED_CHECKS + 1))
+fi
+
+# Check run_openevolve.py exists
+GEAK_OE_ROOT="${GEAK_OE_ROOT:-/workspace/geak-oe}"
+if [ -f "${GEAK_OE_ROOT}/examples/geak_eval/run_openevolve.py" ]; then
+    echo "✅ run_openevolve.py: OK (${GEAK_OE_ROOT})"
+else
+    echo "❌ run_openevolve.py: Not found at ${GEAK_OE_ROOT}/examples/geak_eval/"
+    FAILED_CHECKS=$((FAILED_CHECKS + 1))
+fi
+
 # Summary
 echo ""
 if [ $FAILED_CHECKS -eq 0 ]; then

--- a/mcp_tools/openevolve-mcp/src/openevolve_mcp/server.py
+++ b/mcp_tools/openevolve-mcp/src/openevolve_mcp/server.py
@@ -1,13 +1,19 @@
 """
-OpenEvolve Optimizer MCP Server - Minimal & Modular
+OpenEvolve Optimizer MCP Server - COMMANDMENT-based Multi-file Evaluation
 
-Provides GPU kernel optimization using LLM-guided evolution.
+Provides GPU kernel optimization using LLM-guided evolution via run_openevolve.py.
+Supports multi-file kernels with deterministic COMMANDMENT.md evaluation.
+
+The server invokes run_openevolve.py as a subprocess, which:
+1. Auto-detects GPUs and builds COMMANDMENT.md (or uses pre-built)
+2. Validates commands on baseline kernel
+3. Freezes COMMANDMENT.md (immutable during evolution)
+4. Runs OpenEvolve evolutionary optimization with GPU-isolated evaluation
 """
 
 import json
-import sys
-import tempfile
-import asyncio
+import os
+import subprocess
 import logging
 from pathlib import Path
 from typing import Optional
@@ -24,332 +30,268 @@ logging.basicConfig(
 # Create MCP server
 mcp = FastMCP(
     name="openevolve-optimizer",
-    instructions="GPU kernel optimization using LLM-guided evolution (OpenEvolve)"
+    instructions=(
+        "GPU kernel optimization using LLM-guided evolution (OpenEvolve). "
+        "Uses COMMANDMENT.md for deterministic, reproducible evaluation with "
+        "Metrix hardware profiling and GPU isolation."
+    )
 )
 
-# Constants
-SEPARATOR = "#" * 146
-# Relative to msa/ root: msa/geak-oe
-DEFAULT_GEAK_OE_PATH = str(Path(__file__).parent.parent.parent.parent.parent / "geak-oe")
-DEFAULT_DOCKER_IMAGE = "lmsysorg/sglang:v0.5.6.post1-rocm700-mi35x"
+# Auto-detect GEAK_OE_ROOT from environment or common locations
+GEAK_OE_ROOT = os.environ.get("GEAK_OE_ROOT", "")
+if not GEAK_OE_ROOT:
+    for candidate in [
+        "/workspace/geak-oe",
+        str(Path(__file__).parent.parent.parent.parent.parent / "geak-oe"),
+        os.path.join(os.path.expanduser("~"), "geak-oe-fresh"),
+    ]:
+        if os.path.isdir(candidate) and os.path.isfile(
+            os.path.join(candidate, "examples", "geak_eval", "run_openevolve.py")
+        ):
+            GEAK_OE_ROOT = candidate
+            break
+
+RUN_OPENEVOLVE_SCRIPT = os.path.join(
+    GEAK_OE_ROOT, "examples", "geak_eval", "run_openevolve.py"
+) if GEAK_OE_ROOT else ""
 
 
-def prepare_kernel_file(
-    kernel_code: str,
-    test_code: Optional[str] = None
-) -> str:
-    """
-    Merge kernel and test code into OpenEvolve format.
-    
-    Format: <kernel> + SEPARATOR + <tests>
-    """
-    logger.debug("Preparing kernel file with separator")
-    test_section = test_code or _default_test_template()
-    merged = f"{kernel_code.strip()}\n\n{SEPARATOR}\n\n{test_section.strip()}"
-    logger.debug(f"Merged file size: {len(merged)} chars")
-    return merged
+def _find_run_openevolve() -> str:
+    """Locate run_openevolve.py, raising if not found."""
+    if RUN_OPENEVOLVE_SCRIPT and os.path.isfile(RUN_OPENEVOLVE_SCRIPT):
+        return RUN_OPENEVOLVE_SCRIPT
 
+    # Try environment again at call time (may have been set after import)
+    oe_root = os.environ.get("GEAK_OE_ROOT", "")
+    if oe_root:
+        script = os.path.join(oe_root, "examples", "geak_eval", "run_openevolve.py")
+        if os.path.isfile(script):
+            return script
 
-def _default_test_template() -> str:
-    """Minimal test template (fallback)."""
-    logger.debug("Using default test template")
-    return """
-import torch
-import pytest
-
-def test_kernel_runs():
-    assert True, "Kernel test placeholder"
-
-def test_save_results():
-    print("Test results saved")
-
-def test_save_performance_results():
-    print("Performance results saved")
-"""
-
-
-async def run_openevolve(
-    merged_file: Path,
-    evaluator_path: Path,
-    max_iterations: int,
-    output_dir: Path,
-    config: dict
-) -> dict:
-    """
-    Run OpenEvolve optimization asynchronously.
-    
-    Returns:
-        {
-            "optimized_code": str,
-            "metrics": dict,
-            "speedup": float,
-            "iterations": int,
-            "success": bool
-        }
-    """
-    try:
-        logger.info(f"Starting OpenEvolve optimization")
-        logger.info(f"  Input file: {merged_file}")
-        logger.info(f"  Max iterations: {max_iterations}")
-        logger.info(f"  Output dir: {output_dir}")
-        
-        # Add geak-oe to path
-        geak_oe_path = Path(DEFAULT_GEAK_OE_PATH)
-        if str(geak_oe_path) not in sys.path:
-            sys.path.insert(0, str(geak_oe_path))
-            logger.debug(f"Added to sys.path: {geak_oe_path}")
-        
-        # Import OpenEvolve
-        logger.debug("Importing OpenEvolve")
-        from openevolve import OpenEvolve
-        from openevolve.config import Config
-        
-        # Create config using from_dict (proper way for OpenEvolve)
-        logger.debug("Creating OpenEvolve config")
-        oe_config = Config.from_dict(config)
-        
-        # Run OpenEvolve
-        logger.info("Initializing OpenEvolve...")
-        openevolve = OpenEvolve(
-            initial_program_path=str(merged_file),
-            evaluation_file=str(evaluator_path),
-            config=oe_config,
-            output_dir=str(output_dir)
-        )
-        
-        logger.info("Running OpenEvolve optimization (this may take a while)...")
-        best_program = await openevolve.run()
-        
-        speedup = best_program.metrics.get("final_score", 1.0)
-        logger.info(f"✓ OpenEvolve completed successfully!")
-        logger.info(f"  Best iteration: {best_program.generation}")
-        logger.info(f"  Speedup: {speedup:.2f}x")
-        logger.info(f"  Metrics: {best_program.metrics}")
-        
-        return {
-            "optimized_code": best_program.code,
-            "metrics": best_program.metrics,
-            "speedup": speedup,
-            "iterations": best_program.generation,
-            "success": True,
-            "error": None
-        }
-        
-    except Exception as e:
-        logger.error(f"OpenEvolve optimization failed: {e}", exc_info=True)
-        return {
-            "optimized_code": None,
-            "metrics": {},
-            "speedup": 1.0,
-            "iterations": 0,
-            "success": False,
-            "error": str(e)
-        }
-
-
-def _optimize_kernel_impl(
-    kernel_path: str,
-    test_path: Optional[str] = None,
-    max_iterations: int = 50,
-    config: Optional[dict] = None,
-    docker_image: str = DEFAULT_DOCKER_IMAGE
-) -> dict:
-    """
-    Optimize a GPU kernel using OpenEvolve LLM-guided evolution.
-    
-    Args:
-        kernel_path: Path to kernel file (.py)
-        test_path: Optional path to test file (pytest format)
-        max_iterations: Max evolution iterations (default: 50)
-        config: Optional OpenEvolve config override
-        docker_image: Docker image for GPU execution
-    
-    Returns:
-        {
-            "success": bool,
-            "optimized_code": str,
-            "speedup": float,
-            "iterations": int,
-            "metrics": dict,
-            "baseline_metrics_path": str,
-            "optimized_metrics_path": str
-        }
-    """
-    try:
-        logger.info("="*60)
-        logger.info("OpenEvolve MCP Tool Called")
-        logger.info("="*60)
-        logger.info(f"Kernel path: {kernel_path}")
-        logger.info(f"Test path: {test_path}")
-        logger.info(f"Max iterations: {max_iterations}")
-        logger.info(f"Docker image: {docker_image}")
-        
-        kernel_path = Path(kernel_path)
-        
-        # Read kernel code
-        logger.info(f"Reading kernel file: {kernel_path}")
-        kernel_code = kernel_path.read_text()
-        logger.debug(f"Kernel code length: {len(kernel_code)} chars")
-        
-        # Read test code if provided
-        test_code = None
-        if test_path:
-            logger.info(f"Reading test file: {test_path}")
-            test_code = Path(test_path).read_text()
-            logger.debug(f"Test code length: {len(test_code)} chars")
-        else:
-            logger.info("No test file provided, will use default template")
-        
-        # Prepare merged file
-        logger.info("Merging kernel and test code...")
-        merged_code = prepare_kernel_file(kernel_code, test_code)
-        
-        # Write to temp file
-        with tempfile.NamedTemporaryFile(
-            mode='w', suffix='.py', delete=False
-        ) as f:
-            f.write(merged_code)
-            temp_file = Path(f.name)
-        logger.info(f"Created temporary merged file: {temp_file}")
-        
-        # Setup paths
-        geak_oe_path = Path(DEFAULT_GEAK_OE_PATH)
-        evaluator_path = geak_oe_path / "examples" / "tb" / "rocm_evaluator.py"
-        output_dir = kernel_path.parent / "openevolve_output"
-        output_dir.mkdir(exist_ok=True)
-        logger.info(f"Output directory: {output_dir}")
-        logger.info(f"Evaluator: {evaluator_path}")
-        
-        # Default config (properly structured for OpenEvolve Config)
-        default_config = {
-            "max_iterations": max_iterations,
-            "database": {
-                "population_size": 20,
-                "num_islands": 4
-            },
-            "llm": {
-                "models": [{"name": "claude-sonnet-4", "weight": 1.0}]
-            },
-            "evaluator": {
-                "timeout": 1800
-            }
-        }
-        
-        # Merge with user config (if provided)
-        if config:
-            logger.info(f"Merging custom config: {config}")
-            for key, value in config.items():
-                if key in default_config and isinstance(default_config[key], dict) and isinstance(value, dict):
-                    default_config[key].update(value)
-                else:
-                    default_config[key] = value
-        
-        # Run OpenEvolve (async)
-        logger.info("Starting OpenEvolve async execution...")
-        result = asyncio.run(run_openevolve(
-            temp_file,
-            evaluator_path,
-            max_iterations,
-            output_dir,
-            default_config
-        ))
-        
-        # Clean up
-        logger.debug(f"Cleaning up temporary file: {temp_file}")
-        temp_file.unlink(missing_ok=True)
-        
-        if result["success"]:
-            logger.info("Optimization succeeded! Processing results...")
-            
-            # Save optimized code
-            optimized_path = kernel_path.parent / f"{kernel_path.stem}_optimized.py"
-            optimized_path.write_text(result["optimized_code"])
-            logger.info(f"Saved optimized kernel: {optimized_path}")
-            
-            # Convert metrics to StandardBenchmark format
-            baseline_metrics_path = kernel_path.parent / "benchmark" / "baseline" / "metrics.json"
-            optimized_metrics_path = kernel_path.parent / "benchmark" / "optimized" / "metrics.json"
-            
-            # Create metrics in standard format
-            standard_metrics = {
-                "speedup": result["speedup"],
-                "latency_ms": result["metrics"].get("latency_ms", 0),
-                "tflops": result["metrics"].get("tflops", 0),
-                "bandwidth_gb_s": result["metrics"].get("bandwidth", 0)
-            }
-            
-            # Save baseline (speedup=1.0)
-            baseline_metrics_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(baseline_metrics_path, 'w') as f:
-                json.dump({**standard_metrics, "speedup": 1.0}, f, indent=2)
-            logger.info(f"Saved baseline metrics: {baseline_metrics_path}")
-            
-            # Save optimized
-            optimized_metrics_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(optimized_metrics_path, 'w') as f:
-                json.dump(standard_metrics, f, indent=2)
-            logger.info(f"Saved optimized metrics: {optimized_metrics_path}")
-            
-            logger.info("="*60)
-            logger.info(f"✓ Optimization Complete!")
-            logger.info(f"  Speedup: {result['speedup']:.2f}x")
-            logger.info(f"  Iterations: {result['iterations']}")
-            logger.info(f"  Output: {optimized_path}")
-            logger.info("="*60)
-            
-            return {
-                "success": True,
-                "optimized_code": result["optimized_code"],
-                "optimized_path": str(optimized_path),
-                "speedup": result["speedup"],
-                "iterations": result["iterations"],
-                "metrics": standard_metrics,
-                "baseline_metrics_path": str(baseline_metrics_path),
-                "optimized_metrics_path": str(optimized_metrics_path)
-            }
-        else:
-            logger.error(f"Optimization failed: {result['error']}")
-            return {
-                "success": False,
-                "error": result["error"],
-                "optimized_code": None,
-                "speedup": 1.0
-            }
-            
-    except Exception as e:
-        logger.error(f"MCP tool execution failed: {e}", exc_info=True)
-        return {
-            "success": False,
-            "error": str(e),
-            "optimized_code": None
-        }
+    raise FileNotFoundError(
+        "run_openevolve.py not found. Set GEAK_OE_ROOT environment variable "
+        "to the OpenEvolve repository root (e.g. /workspace/geak-oe)."
+    )
 
 
 @mcp.tool()
 def optimize_kernel(
     kernel_path: str,
-    test_path: Optional[str] = None,
-    max_iterations: int = 50,
-    config: Optional[dict] = None,
-    docker_image: str = DEFAULT_DOCKER_IMAGE
+    max_iterations: int = 10,
+    gpu: int = 0,
+    output_dir: Optional[str] = None,
+    commandment_path: Optional[str] = None,
+    baseline_metrics_path: Optional[str] = None,
 ) -> dict:
     """
     Optimize a GPU kernel using OpenEvolve LLM-guided evolution.
-    
-    MCP tool wrapper - calls implementation function.
+
+    Uses COMMANDMENT.md for deterministic evaluation with Metrix hardware profiling.
+    Supports multi-file kernels (directories) and single-file kernels.
+
+    Args:
+        kernel_path: Path to kernel file (.py) or directory containing kernel files.
+        max_iterations: Max evolution iterations (default: 10).
+        gpu: Primary GPU device ID for baseline profiling (default: 0).
+        output_dir: Output directory for results. Defaults to <kernel_dir>/optimization_output.
+        commandment_path: Optional path to pre-built COMMANDMENT.md (skips auto-build).
+        baseline_metrics_path: Optional path to pre-computed baseline metrics JSON.
+
+    Returns:
+        {
+            "success": bool,
+            "speedup": float,
+            "best_score": float,
+            "iterations_completed": int,
+            "baseline_latency_us": float,
+            "best_latency_us": float,
+            "output_dir": str,
+            "best_kernel_path": str,
+            "commandment_path": str,
+            "error": str | None
+        }
     """
-    return _optimize_kernel_impl(
-        kernel_path=kernel_path,
-        test_path=test_path,
-        max_iterations=max_iterations,
-        config=config,
-        docker_image=docker_image
-    )
+    try:
+        logger.info("=" * 60)
+        logger.info("OpenEvolve MCP Tool: optimize_kernel")
+        logger.info("=" * 60)
+
+        # Validate kernel path
+        kernel_path = os.path.abspath(kernel_path)
+        if not os.path.exists(kernel_path):
+            return {"success": False, "error": f"Kernel not found: {kernel_path}"}
+
+        # Find run_openevolve.py
+        script = _find_run_openevolve()
+        logger.info(f"Using run_openevolve.py: {script}")
+
+        # Determine output directory
+        if not output_dir:
+            if os.path.isdir(kernel_path):
+                output_dir = os.path.join(kernel_path, "optimization_output")
+            else:
+                output_dir = os.path.join(
+                    os.path.dirname(kernel_path), "optimization_output"
+                )
+        output_dir = os.path.abspath(output_dir)
+        os.makedirs(output_dir, exist_ok=True)
+        logger.info(f"Output directory: {output_dir}")
+
+        # Build command
+        cmd = [
+            "python3", script,
+            kernel_path,
+            "--iterations", str(max_iterations),
+            "--gpu", str(gpu),
+            "--output", output_dir,
+        ]
+
+        if commandment_path:
+            cmd.extend(["--commandment", os.path.abspath(commandment_path)])
+        if baseline_metrics_path:
+            cmd.extend(["--baseline-metrics", os.path.abspath(baseline_metrics_path)])
+
+        logger.info(f"Command: {' '.join(cmd)}")
+
+        # Set up environment (pass through API keys, don't hardcode)
+        env = os.environ.copy()
+        if GEAK_OE_ROOT:
+            env["GEAK_OE_ROOT"] = GEAK_OE_ROOT
+        # Ensure PYTHONPATH includes OpenEvolve
+        oe_root = env.get("GEAK_OE_ROOT", GEAK_OE_ROOT)
+        if oe_root:
+            existing_pp = env.get("PYTHONPATH", "")
+            if oe_root not in existing_pp:
+                env["PYTHONPATH"] = f"{oe_root}:{existing_pp}" if existing_pp else oe_root
+
+        # Run the subprocess
+        logger.info("Starting OpenEvolve optimization (this may take a while)...")
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=7200,  # 2 hour max
+            env=env,
+            cwd=oe_root if oe_root else None,
+        )
+
+        logger.info(f"Process exited with code: {proc.returncode}")
+        if proc.stdout:
+            # Log last 50 lines of stdout
+            lines = proc.stdout.strip().split("\n")
+            for line in lines[-50:]:
+                logger.info(f"  [stdout] {line}")
+        if proc.stderr:
+            lines = proc.stderr.strip().split("\n")
+            for line in lines[-20:]:
+                logger.warning(f"  [stderr] {line}")
+
+        # Parse results from output JSON
+        result_path = os.path.join(output_dir, "openevolve_result.json")
+        if os.path.isfile(result_path):
+            with open(result_path) as f:
+                result_data = json.load(f)
+
+            best_metrics = result_data.get("best_metrics", {})
+            baseline_metrics = result_data.get("baseline_metrics", {})
+            best_kernel = os.path.join(output_dir, "best_kernel.py")
+            commandment = os.path.join(output_dir, "COMMANDMENT.md")
+
+            response = {
+                "success": result_data.get("success", proc.returncode == 0),
+                "speedup": result_data.get("best_score", 1.0),
+                "best_score": result_data.get("best_score", 1.0),
+                "iterations_completed": result_data.get("iterations_completed", 0),
+                "baseline_latency_us": baseline_metrics.get("duration_us", 0),
+                "best_latency_us": best_metrics.get("duration_us", 0),
+                "output_dir": output_dir,
+                "best_kernel_path": best_kernel if os.path.isfile(best_kernel) else "",
+                "commandment_path": commandment if os.path.isfile(commandment) else "",
+                "error": None,
+            }
+            logger.info(f"Optimization complete: speedup={response['speedup']:.4f}x")
+            return response
+
+        elif proc.returncode == 0:
+            # Process succeeded but no result JSON -- check for best_kernel.py
+            best_kernel = os.path.join(output_dir, "best_kernel.py")
+            return {
+                "success": True,
+                "speedup": 1.0,
+                "best_score": 1.0,
+                "iterations_completed": 0,
+                "baseline_latency_us": 0,
+                "best_latency_us": 0,
+                "output_dir": output_dir,
+                "best_kernel_path": best_kernel if os.path.isfile(best_kernel) else "",
+                "commandment_path": "",
+                "error": "No result JSON found but process succeeded",
+            }
+        else:
+            error_msg = proc.stderr[-2000:] if proc.stderr else "Unknown error"
+            return {
+                "success": False,
+                "speedup": 1.0,
+                "error": f"Process exited with code {proc.returncode}: {error_msg}",
+            }
+
+    except subprocess.TimeoutExpired:
+        logger.error("OpenEvolve optimization timed out (2h limit)")
+        return {"success": False, "error": "Optimization timed out after 2 hours"}
+    except Exception as e:
+        logger.error(f"MCP tool execution failed: {e}", exc_info=True)
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool()
+def check_openevolve_status() -> dict:
+    """
+    Check if OpenEvolve is properly installed and configured.
+
+    Returns availability status, GEAK_OE_ROOT path, and run_openevolve.py location.
+    """
+    status = {
+        "geak_oe_root": GEAK_OE_ROOT,
+        "run_openevolve_script": RUN_OPENEVOLVE_SCRIPT,
+        "openevolve_available": False,
+        "kernel_profile_available": False,
+        "errors": [],
+    }
+
+    # Check run_openevolve.py
+    try:
+        script = _find_run_openevolve()
+        status["run_openevolve_script"] = script
+        status["openevolve_available"] = True
+    except FileNotFoundError as e:
+        status["errors"].append(str(e))
+
+    # Check OpenEvolve importable
+    try:
+        import openevolve  # noqa: F401
+        status["openevolve_importable"] = True
+    except ImportError:
+        status["openevolve_importable"] = False
+        status["errors"].append("Cannot import openevolve package")
+
+    # Check kernel-profile tool
+    try:
+        result = subprocess.run(
+            ["kernel-profile", "--help"],
+            capture_output=True, text=True, timeout=10
+        )
+        status["kernel_profile_available"] = result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        status["errors"].append("kernel-profile command not found")
+
+    return status
 
 
 def main():
     """Run MCP server."""
-    logger.info("Starting OpenEvolve MCP Server...")
+    logger.info("Starting OpenEvolve MCP Server (COMMANDMENT-based)...")
+    logger.info(f"  GEAK_OE_ROOT: {GEAK_OE_ROOT}")
+    logger.info(f"  run_openevolve.py: {RUN_OPENEVOLVE_SCRIPT}")
     mcp.run()
 
 


### PR DESCRIPTION
- Dockerfile: clone from optimizer-geak-openevolve branch (multi-file, GPU isolation)
- openevolve-mcp/server.py: rewritten to invoke run_openevolve.py as subprocess
  - Removed old SEPARATOR (#*146) format and rocm_evaluator.py references
  - Supports pre-built COMMANDMENT mode and auto-build mode
  - Added check_openevolve_status() tool for health checks
- entrypoint.sh: added OpenEvolve and run_openevolve.py health checks
- README.md: updated with new commands, architecture, and setup instructions

Verified end-to-end:
  - add_kernel via mini-SWE-agent: 1.58x speedup (18.32us -> 11.62us)
  - fused_qkv_rope via run.sh: 1.02x speedup (1 iteration)
  - fused_qkv_rope via run_openevolve.py direct: working
  - 8 GPU parallel evaluation with exclusive GPU assignment confirmed