### PR TITLE
Modular task pipeline: task files, --from-task, iterative refinement

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,6 +51,17 @@ else
     FAILED_CHECKS=$((FAILED_CHECKS + 1))
 fi
 
+# Check modular pipeline CLIs
+for tool in resolve-kernel-url test-discovery commandment validate-commandment \
+            baseline-metrics task-generator openevolve-worker select-patch; do
+    if command -v "$tool" > /dev/null 2>&1; then
+        echo "✅ ${tool}: OK"
+    else
+        echo "❌ ${tool}: Not found"
+        FAILED_CHECKS=$((FAILED_CHECKS + 1))
+    fi
+done
+
 # Check geak command
 if geak --help > /dev/null 2>&1; then
     echo "✅ geak (mini-swe-agent): OK"

--- a/mcp_tools/automated-test-discovery/src/automated_test_discovery/cli.py
+++ b/mcp_tools/automated-test-discovery/src/automated_test_discovery/cli.py
@@ -3,13 +3,20 @@
 Enables calling MCP tools via bash commands.
 
 Usage:
-    test-discovery discover <kernel_path> [--max-tests <n>] [--max-benchmarks <n>]
-    test-discovery <kernel_path>  # shorthand for discover
+    test-discovery <kernel_path> [--max-tests <n>] [--max-benchmarks <n>]
+    test-discovery --from-resolved resolved.json -o discovery.json
+
+Examples:
+    test-discovery /path/to/kernel.py
+    test-discovery /path/to/repo/
+    test-discovery /path/to/kernel.py --max-tests 10 --max-benchmarks 3
+    test-discovery --from-resolved resolved.json -o discovery.json
 """
 
 import argparse
 import json
 import sys
+from pathlib import Path
 
 from .server import discover
 
@@ -17,43 +24,54 @@ from .server import discover
 def main():
     parser = argparse.ArgumentParser(
         prog="test-discovery",
-        description="Automated test and benchmark discovery for GPU kernels"
+        description="Automated test and benchmark discovery for GPU kernels",
     )
-    
-    # Support both subcommand and direct usage
-    parser.add_argument("kernel_path", nargs="?", help="Path to kernel file")
-    parser.add_argument("--max-tests", "-t", type=int, default=5, help="Max tests to return")
-    parser.add_argument("--max-benchmarks", "-b", type=int, default=5, help="Max benchmarks to return")
-    
-    # Also support subcommand style
-    subparsers = parser.add_subparsers(dest="command")
-    disc_parser = subparsers.add_parser("discover", help="Discover tests and benchmarks")
-    disc_parser.add_argument("path", help="Path to kernel file")
-    disc_parser.add_argument("--max-tests", "-t", type=int, default=5, help="Max tests to return")
-    disc_parser.add_argument("--max-benchmarks", "-b", type=int, default=5, help="Max benchmarks to return")
+
+    parser.add_argument(
+        "kernel_path", nargs="?", default=None,
+        help="Path to a kernel file (.py/.cu/.hip) or a repository directory",
+    )
+    parser.add_argument(
+        "--from-resolved", default=None, metavar="FILE",
+        help="Read resolved.json from resolve-kernel-url and extract kernel path",
+    )
+    parser.add_argument(
+        "-o", "--output", default=None, metavar="FILE",
+        help="Write JSON output to file instead of stdout",
+    )
+    parser.add_argument(
+        "--max-tests", "-t", type=int, default=5, help="Max tests to return (default: 5)"
+    )
+    parser.add_argument(
+        "--max-benchmarks", "-b", type=int, default=5, help="Max benchmarks to return (default: 5)"
+    )
 
     args = parser.parse_args()
 
-    # Determine which path to use
-    if args.command == "discover":
-        kernel_path = args.path
-        max_tests = args.max_tests
-        max_benchmarks = args.max_benchmarks
-    elif args.kernel_path:
-        kernel_path = args.kernel_path
-        max_tests = args.max_tests
-        max_benchmarks = args.max_benchmarks
-    else:
-        parser.print_help()
-        sys.exit(1)
+    # Resolve kernel_path from --from-resolved or positional arg
+    kernel_path = args.kernel_path
+    if args.from_resolved:
+        resolved = json.loads(Path(args.from_resolved).read_text())
+        kernel_path = resolved.get("local_file_path") or kernel_path
+        if not kernel_path:
+            print("ERROR: --from-resolved JSON has no local_file_path", file=sys.stderr)
+            sys.exit(1)
+
+    if not kernel_path:
+        parser.error("kernel_path is required (positional or via --from-resolved)")
 
     result = discover(
         kernel_path=kernel_path,
-        max_tests=max_tests,
-        max_benchmarks=max_benchmarks
+        max_tests=args.max_tests,
+        max_benchmarks=args.max_benchmarks,
     )
 
-    print(json.dumps(result, indent=2))
+    output_text = json.dumps(result, indent=2)
+    if args.output:
+        Path(args.output).write_text(output_text + "\n")
+        print(f"Wrote {args.output}", file=sys.stderr)
+    else:
+        print(output_text)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,14 @@ mini-e= "minisweagent.run.mini_extra:main"
 # GEAK-specific entry points (ported from MSA branch)
 geak = "minisweagent.run.mini:app"
 kernel-profile = "minisweagent.kernel_profile:main"
+task-generator = "minisweagent.run.task_generator:main"
+# Modular pipeline steps
+commandment = "minisweagent.tools.commandment:main"
+validate-commandment = "minisweagent.tools.validate_commandment:main"
+baseline-metrics = "minisweagent.baseline_metrics:main"
+openevolve-worker = "minisweagent.agents.openevolve_worker:main"
+select-patch = "minisweagent.agents.select_patch_agent:main"
+resolve-kernel-url = "minisweagent.tools.resolve_kernel_url_impl:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,5 +1,34 @@
 #!/bin/bash
-# Simple script to build and run GEAK-agent Docker container
+# Build and run GEAK-agent Docker container.
+#
+# Usage:
+#   scripts/run-docker.sh                          # Interactive bash shell
+#   scripts/run-docker.sh --rebuild                # Rebuild image, then bash
+#   scripts/run-docker.sh -- test-discovery /path  # Run a command inside container
+#   scripts/run-docker.sh --rebuild -- geak --help # Rebuild, then run command
+#
+# Modular pipeline commands (chainable via intermediate files):
+#   resolve-kernel-url <url> --json -o resolved.json
+#   test-discovery --from-resolved resolved.json -o discovery.json
+#   kernel-profile --from-discovery discovery.json --json -o profile.json
+#   baseline-metrics build --from-profile profile.json --all -o baseline_metrics.json
+#   commandment --from-discovery discovery.json -o COMMANDMENT.md
+#   task-generator --from-discovery discovery.json --profiling profile.json \
+#       --commandment COMMANDMENT.md --baseline-metrics baseline_metrics.json \
+#       -o tasks/round_1/
+#
+# Iterative refinement (round 2+):
+#   task-generator ... --from-results results/round_1/ --round 2 -o tasks/round_2/
+#
+# Run individual tasks:
+#   openevolve-worker --from-task tasks/round_1/00_openevolve-inner.md --gpu 0
+#   geak --from-task tasks/round_1/10_triton-autotune.md --gpu-ids 2
+#
+# Other tools:
+#   validate-commandment <path>              Validate a COMMANDMENT.md
+#   openevolve-worker --kernel-path <p> ...  Run OpenEvolve optimizer (manual)
+#   select-patch --patch-dir <dir> ...       Select best patch from runs
+#   geak <github_url>                        Full optimization pipeline
 
 set -e
 
@@ -13,6 +42,7 @@ PARENT_DIR="${HOME}"
 HOST_CODE_DIR="${HOME}"
 
 REBUILD=false
+EXEC_CMD=()  # Command to run inside the container (empty = bash)
 
 #######################################
 # Parse options
@@ -23,18 +53,47 @@ while [[ $# -gt 0 ]]; do
             REBUILD=true
             shift
             ;;
+        --)
+            shift
+            EXEC_CMD=("$@")
+            break
+            ;;
         -h|--help)
-            echo "Usage: $0 [OPTIONS]"
+            echo "Usage: $0 [OPTIONS] [-- COMMAND [ARGS...]]"
             echo ""
             echo "Options:"
             echo "  --rebuild     Stop/remove container if present, then rebuild image (no cache)"
             echo "  -h, --help    Show this help"
             echo ""
+            echo "If COMMAND is provided after --, it runs inside the container instead of bash."
+            echo ""
+            echo "Pipeline commands (chainable via --from-* flags, run after --):"
+            echo "  resolve-kernel-url <url> --json -o resolved.json"
+            echo "  test-discovery --from-resolved resolved.json -o discovery.json"
+            echo "  kernel-profile --from-discovery discovery.json --json -o profile.json"
+            echo "  baseline-metrics build --from-profile profile.json --all -o baseline_metrics.json"
+            echo "  commandment --from-discovery discovery.json -o COMMANDMENT.md"
+            echo "  task-generator --from-discovery discovery.json --profiling profile.json \\"
+            echo "      --commandment COMMANDMENT.md --baseline-metrics baseline_metrics.json -o tasks/round_1/"
+            echo ""
+            echo "Iterative refinement (round 2+):"
+            echo "  task-generator ... --from-results results/round_1/ --round 2 -o tasks/round_2/"
+            echo ""
+            echo "Run individual tasks:"
+            echo "  openevolve-worker --from-task tasks/round_1/00_openevolve-inner.md --gpu 0"
+            echo "  geak --from-task tasks/round_1/10_triton-autotune.md --gpu-ids 2"
+            echo ""
+            echo "Other tools:"
+            echo "  validate-commandment <path>            Validate COMMANDMENT.md"
+            echo "  openevolve-worker --kernel-path <p> ...  Run OpenEvolve optimizer (manual)"
+            echo "  select-patch --patch-dir <dir> ...     Select best patch from runs"
+            echo "  geak <github_url>                      Full optimization pipeline"
+            echo ""
             echo "Requires: AMD_LLM_API_KEY environment variable"
             exit 0
             ;;
         *)
-            echo "Unknown option: $1"
+            echo "Unknown option: $1 (use -- before commands)"
             exit 1
             ;;
     esac
@@ -57,15 +116,25 @@ if [ "$REBUILD" = true ]; then
     echo ""
 fi
 
-# If container already exists (running or stopped), just use it — no pre-flight needed
+# Helper: exec into the container with the chosen command (or bash)
+_exec_into_container() {
+    if [[ ${#EXEC_CMD[@]} -gt 0 ]]; then
+        echo "Running: ${EXEC_CMD[*]}"
+        exec docker exec -it ${CONTAINER_NAME} "${EXEC_CMD[@]}"
+    else
+        exec docker exec -it ${CONTAINER_NAME} bash
+    fi
+}
+
+# If container already exists (running or stopped), just use it -- no pre-flight needed
 if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
-    echo "Container ${CONTAINER_NAME} is already running. Executing bash..."
-    exec docker exec -it ${CONTAINER_NAME} bash
+    echo "Container ${CONTAINER_NAME} is already running."
+    _exec_into_container
 fi
 if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     echo "Container ${CONTAINER_NAME} exists but is stopped. Restarting..."
     docker start ${CONTAINER_NAME}
-    exec docker exec -it ${CONTAINER_NAME} bash
+    _exec_into_container
 fi
 
 #######################################
@@ -142,4 +211,4 @@ docker run -d \
 
 # Now exec into the running container
 echo "Entering container ${CONTAINER_NAME}..."
-exec docker exec -it ${CONTAINER_NAME} bash
+_exec_into_container

--- a/src/minisweagent/agents/openevolve_worker.py
+++ b/src/minisweagent/agents/openevolve_worker.py
@@ -138,3 +138,131 @@ class OpenEvolveWorker(DefaultAgent):
             except Exception:
                 pass
         logger.info(message)
+
+
+# ---------------------------------------------------------------------------
+# Standalone CLI -- bypasses the agent runtime and calls optimizer.core
+# directly, reproducing the same behavior ParallelAgent would trigger.
+#
+# Usage:
+#   python -m minisweagent.agents.openevolve_worker \
+#       --kernel-path /path/to/kernel.py \
+#       --commandment COMMANDMENT.md \
+#       --baseline-metrics baseline_metrics.json \
+#       --iterations 10 --gpu 0
+# ---------------------------------------------------------------------------
+
+def main():
+    import argparse
+    import os
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Run OpenEvolve optimization on a kernel (standalone, no agent runtime)",
+    )
+    parser.add_argument("--kernel-path", default=None, help="Path to the kernel file to optimize")
+    parser.add_argument(
+        "--from-task", default=None, metavar="FILE",
+        help="Read a task .md file (YAML frontmatter) to populate kernel-path, commandment, etc.",
+    )
+    parser.add_argument("--commandment", default=None, help="Path to COMMANDMENT.md")
+    parser.add_argument("--baseline-metrics", default=None, help="Path to baseline_metrics.json")
+    parser.add_argument("--iterations", type=int, default=10, help="Max iterations (default: 10)")
+    parser.add_argument("--gpu", type=int, default=0, help="GPU device ID (default: 0)")
+    parser.add_argument("--output-dir", default=None, help="Output directory for results")
+
+    args = parser.parse_args()
+
+    # Populate from task file if provided (explicit flags override)
+    if args.from_task:
+        from minisweagent.run.task_file import read_task_file
+        meta, _body = read_task_file(Path(args.from_task))
+        if not args.kernel_path:
+            args.kernel_path = meta.get("kernel_path")
+        if not args.commandment:
+            args.commandment = meta.get("commandment")
+        if not args.baseline_metrics:
+            args.baseline_metrics = meta.get("baseline_metrics")
+
+    if not args.kernel_path:
+        parser.error("--kernel-path is required (or provide --from-task)")
+
+    kernel_path = Path(args.kernel_path).resolve()
+    if not kernel_path.is_file():
+        print(f"ERROR: kernel file not found: {args.kernel_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.commandment and not Path(args.commandment).is_file():
+        print(f"ERROR: commandment file not found: {args.commandment}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.baseline_metrics and not Path(args.baseline_metrics).is_file():
+        print(f"ERROR: baseline metrics file not found: {args.baseline_metrics}", file=sys.stderr)
+        sys.exit(1)
+
+    # Auto-worktree isolation when using --from-task with a git repo
+    worktree_path = None
+    original_repo = None
+    if args.from_task:
+        from minisweagent.run.task_file import read_task_file, create_worktree, is_git_repo, replace_paths
+        meta, _ = read_task_file(Path(args.from_task))
+        repo_root = meta.get("repo_root")
+        if repo_root:
+            repo_path = Path(repo_root).resolve()
+            if repo_path.is_dir() and is_git_repo(repo_path):
+                output_dir_base = Path(args.output_dir).resolve() if args.output_dir else kernel_path.parent / "optimization_output"
+                wt_dest = output_dir_base / "worktree"
+                print(f"[OpenEvolveWorker CLI] Creating isolated worktree at {wt_dest}...", file=sys.stderr)
+                worktree_path = create_worktree(repo_path, wt_dest)
+                original_repo = repo_path
+                # Rewrite kernel_path into worktree
+                kernel_path = Path(replace_paths(str(kernel_path), repo_path, worktree_path))
+                if args.commandment:
+                    args.commandment = replace_paths(args.commandment, repo_path, worktree_path)
+                if args.baseline_metrics:
+                    args.baseline_metrics = replace_paths(args.baseline_metrics, repo_path, worktree_path)
+
+    output_dir = args.output_dir or str(kernel_path.parent / "optimization_output")
+
+    os.environ["HIP_VISIBLE_DEVICES"] = str(args.gpu)
+
+    print(
+        f"[OpenEvolveWorker CLI] Starting optimization\n"
+        f"  kernel:           {kernel_path}\n"
+        f"  commandment:      {args.commandment or '(none)'}\n"
+        f"  baseline_metrics: {args.baseline_metrics or '(none)'}\n"
+        f"  iterations:       {args.iterations}\n"
+        f"  gpu:              {args.gpu}\n"
+        f"  output_dir:       {output_dir}"
+        + (f"\n  worktree:         {worktree_path}" if worktree_path else ""),
+        flush=True,
+    )
+
+    from minisweagent.optimizer.core import OptimizerType, optimize_kernel
+
+    try:
+        result = optimize_kernel(
+            kernel_code="",
+            kernel_path=str(kernel_path),
+            optimizer=OptimizerType.OPENEVOLVE,
+            max_iterations=args.iterations,
+            gpu=args.gpu,
+            output_dir=output_dir,
+            commandment_path=args.commandment,
+            baseline_metrics_path=args.baseline_metrics,
+        )
+    except Exception as e:
+        print(f"ERROR: OpenEvolve failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps({
+        "optimizer": result.optimizer_used,
+        "iterations": result.iterations,
+        "metrics": result.metrics,
+        "optimized_code_length": len(result.optimized_code),
+    }, indent=2))
+    print("[OpenEvolveWorker CLI] Done.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/minisweagent/agents/parallel_agent.py
+++ b/src/minisweagent/agents/parallel_agent.py
@@ -227,153 +227,20 @@ class ParallelAgent(DefaultAgent):
     @staticmethod
     def _ensure_safe_directory(repo_path: Path):
         """Ensure repository is in git's safe.directory list."""
-        repo_path_str = str(repo_path.resolve())
-        try:
-            result = subprocess.run(
-                ["git", "config", "--global", "--get-all", "safe.directory"],
-                capture_output=True,
-                text=True,
-            )
-            safe_dirs = result.stdout.strip().split("\n") if result.stdout.strip() else []
-            if repo_path_str not in safe_dirs:
-                subprocess.run(
-                    ["git", "config", "--global", "--add", "safe.directory", repo_path_str],
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-        except subprocess.CalledProcessError:
-            try:
-                subprocess.run(
-                    ["git", "config", "--global", "--add", "safe.directory", repo_path_str],
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            except subprocess.CalledProcessError:
-                pass
+        from minisweagent.run.task_file import _ensure_safe_directory
+        _ensure_safe_directory(repo_path)
 
     @staticmethod
     def _create_worktree(repo_path: Path, worktree_path: Path) -> Path:
         """Create a git worktree, cleaning up any existing one first."""
-        worktree_str = str(worktree_path.resolve())
-        
-        # Clean up any existing worktree
-        try:
-            result = subprocess.run(
-                ["git", "worktree", "list"],
-                cwd=repo_path,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            worktree_exists = any(worktree_str in line or str(worktree_path) in line for line in result.stdout.splitlines())
-            
-            if worktree_exists:
-                try:
-                    subprocess.run(
-                        ["git", "worktree", "remove", str(worktree_path), "--force"],
-                        cwd=repo_path,
-                        check=True,
-                        capture_output=True,
-                        text=True,
-                    )
-                except subprocess.CalledProcessError:
-                    subprocess.run(["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True)
-        except subprocess.CalledProcessError:
-            subprocess.run(["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True)
-        except Exception:
-            pass
-        
-        # Remove directory if it still exists
-        if worktree_path.exists():
-            try:
-                shutil.rmtree(worktree_path)
-            except Exception:
-                pass
-        
-        worktree_path.parent.mkdir(parents=True, exist_ok=True)
-        ParallelAgent._ensure_safe_directory(repo_path)
-        
-        # Create new worktree with detached HEAD to avoid branch name conflicts
-        try:
-            subprocess.run(
-                ["git", "worktree", "add", "--detach", str(worktree_path)],
-                cwd=repo_path,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as e:
-            error_msg = e.stderr if e.stderr else (e.stdout if e.stdout else str(e))
-            if "missing but already registered worktree" in error_msg.lower():
-                subprocess.run(["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True)
-                subprocess.run(
-                    ["git", "worktree", "add", "--detach", "-f", str(worktree_path)],
-                    cwd=repo_path,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            elif "dubious ownership" in error_msg.lower():
-                ParallelAgent._ensure_safe_directory(repo_path)
-                ParallelAgent._ensure_safe_directory(worktree_path)
-                subprocess.run(
-                    ["git", "worktree", "add", "--detach", str(worktree_path)],
-                    cwd=repo_path,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            elif "already used by worktree" in error_msg.lower():
-                # Branch name conflict - remove old worktree and retry
-                subprocess.run(["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True)
-                # Extract branch name from error message if possible, otherwise use worktree path
-                subprocess.run(
-                    ["git", "worktree", "remove", "--force", str(worktree_path)],
-                    cwd=repo_path,
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                )
-                subprocess.run(
-                    ["git", "worktree", "add", "--detach", str(worktree_path)],
-                    cwd=repo_path,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            else:
-                raise RuntimeError(f"Failed to create worktree: {error_msg}") from e
-        
-        # Ensure worktree path is also marked as safe
-        ParallelAgent._ensure_safe_directory(worktree_path)
-        
-        # Copy untracked files from repo to worktree (e.g., newly created test files)
-        ParallelAgent._copy_untracked_files(repo_path, worktree_path)
-        
-        return worktree_path
+        from minisweagent.run.task_file import create_worktree
+        return create_worktree(repo_path, worktree_path)
     
     @staticmethod
     def _copy_untracked_files(repo_path: Path, worktree_path: Path) -> None:
         """Copy untracked files from repo to worktree."""
-        try:
-            result = subprocess.run(
-                ["git", "ls-files", "--others", "--exclude-standard"],
-                cwd=repo_path,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            untracked_files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
-            for rel_path in untracked_files:
-                src = repo_path / rel_path
-                dst = worktree_path / rel_path
-                if src.is_file():
-                    dst.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(src, dst)
-        except subprocess.CalledProcessError:
-            pass  # If git command fails, skip copying untracked files
+        from minisweagent.run.task_file import _copy_untracked_files
+        _copy_untracked_files(repo_path, worktree_path)
 
     @staticmethod
     def _create_copy_workdir(repo_path: Path, workdir_path: Path) -> Path:

--- a/src/minisweagent/agents/select_patch_agent.py
+++ b/src/minisweagent/agents/select_patch_agent.py
@@ -105,3 +105,114 @@ class SelectPatchAgent(DefaultAgent):
         
         return None
 
+
+# ---------------------------------------------------------------------------
+# Standalone CLI -- replicates what ParallelAgent._select_best_from_parallel_runs()
+# does, so a user can run patch selection on an existing patches directory.
+#
+# Usage:
+#   python -m minisweagent.agents.select_patch_agent \
+#       --patch-dir ./patches/run7 \
+#       --metric "Compare per-kernel latency; lower is better"
+# ---------------------------------------------------------------------------
+
+def main():
+    import argparse
+    import json
+    import sys
+
+    import yaml
+
+    from minisweagent.config import get_config_path
+    from minisweagent.environments.local import LocalEnvironment, LocalEnvironmentConfig
+    from minisweagent.models import get_model
+
+    parser = argparse.ArgumentParser(
+        description="Select the best patch from parallel optimization runs (standalone)",
+    )
+    parser.add_argument(
+        "--patch-dir", required=True,
+        help="Base directory containing task_*/parallel_* subdirectories with patches",
+    )
+    parser.add_argument(
+        "--metric", default=None,
+        help="Metric description for the LLM (e.g. 'compare per-kernel latency; lower is better')",
+    )
+    parser.add_argument(
+        "--model", default=None,
+        help="Model name override (default: uses mini_select_patch.yaml config)",
+    )
+
+    args = parser.parse_args()
+
+    patch_dir = Path(args.patch_dir).resolve()
+    if not patch_dir.is_dir():
+        print(f"ERROR: patch directory not found: {args.patch_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Load config (same as ParallelAgent._select_best_from_parallel_runs)
+    config_path = get_config_path("mini_select_patch")
+    config = yaml.safe_load(config_path.read_text())
+    agent_config = config.get("agent", {})
+    model_config = config.get("model", {})
+
+    # Create model (CLI --model overrides config)
+    model = get_model(args.model, model_config)
+
+    # Create environment rooted at the patch directory
+    env_config = LocalEnvironmentConfig(cwd=str(patch_dir))
+    env = LocalEnvironment(**env_config.__dict__)
+
+    # Create and configure agent
+    agent = SelectPatchAgent(model, env, **agent_config)
+    log_file = patch_dir / "select_agent.log"
+    agent.log_file = log_file
+
+    # Count runs for the hint
+    task_dirs = sorted(patch_dir.glob("task_*"))
+    parallel_dirs = sorted(patch_dir.glob("parallel_*"))
+    num_parallel = len(task_dirs) + len(parallel_dirs)
+    if num_parallel == 0:
+        print("ERROR: no task_* or parallel_* directories found in patch-dir", file=sys.stderr)
+        sys.exit(1)
+
+    metric = args.metric or "Extract performance metrics and calculate the best speedup."
+
+    # Setup task and run
+    task = agent.setup_selection_task(patch_dir, num_parallel, metric)
+    if task is None:
+        print("ERROR: failed to setup selection task", file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        f"[SelectPatchAgent CLI] Starting patch selection\n"
+        f"  patch_dir:   {patch_dir}\n"
+        f"  runs found:  {num_parallel} ({len(task_dirs)} task_*, {len(parallel_dirs)} parallel_*)\n"
+        f"  metric:      {metric}\n"
+        f"  log:         {log_file}",
+        flush=True,
+    )
+
+    try:
+        exit_status, result = agent.run(task)
+        print(f"[SelectPatchAgent CLI] Finished with status: {exit_status}", flush=True)
+    except Exception as e:
+        print(f"ERROR: SelectPatchAgent failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Report result
+    best_patch_id = agent.extract_final_result()
+    if best_patch_id:
+        print(f"\nBest patch: {best_patch_id}")
+        best_results_file = patch_dir / "best_results.json"
+        if best_results_file.exists():
+            best_results = json.loads(best_results_file.read_text())
+            print(json.dumps(best_results, indent=2))
+    else:
+        print("WARNING: agent did not produce best_results.json", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/minisweagent/baseline_metrics.py
+++ b/src/minisweagent/baseline_metrics.py
@@ -269,12 +269,14 @@ def main():
 
     # --- list ---
     p_list = sub.add_parser("list", help="List all profiled kernels (for the agent to inspect)")
-    p_list.add_argument("input", help="MetrixTool JSON output (or '-' for stdin)")
+    p_list.add_argument("input", nargs="?", default=None, help="MetrixTool JSON output (or '-' for stdin)")
+    p_list.add_argument("--from-profile", default=None, metavar="FILE", help="Read profile JSON from kernel-profile output")
     p_list.add_argument("--gpu", type=int, default=0, help="GPU index (default: 0)")
 
     # --- build ---
     p_build = sub.add_parser("build", help="Build baseline_metrics.json from chosen kernels")
-    p_build.add_argument("input", help="MetrixTool JSON output (or '-' for stdin)")
+    p_build.add_argument("input", nargs="?", default=None, help="MetrixTool JSON output (or '-' for stdin)")
+    p_build.add_argument("--from-profile", default=None, metavar="FILE", help="Read profile JSON from kernel-profile output")
     p_build.add_argument("-o", "--output", default=None, help="Output path (default: stdout)")
     p_build.add_argument("--gpu", type=int, default=0, help="GPU index (default: 0)")
     sel = p_build.add_mutually_exclusive_group(required=True)
@@ -284,11 +286,16 @@ def main():
 
     args = parser.parse_args()
 
+    # Resolve input: --from-profile takes precedence, then positional, then stdin
+    input_source = args.from_profile or args.input
+    if not input_source:
+        parser.error("input is required (positional, --from-profile, or '-' for stdin)")
+
     # Load input
-    if args.input == "-":
+    if input_source == "-":
         data = json.load(sys.stdin)
     else:
-        data = json.loads(Path(args.input).read_text())
+        data = json.loads(Path(input_source).read_text())
 
     if args.command == "list":
         kernels = list_kernels(data, gpu_index=args.gpu)

--- a/src/minisweagent/kernel_profile.py
+++ b/src/minisweagent/kernel_profile.py
@@ -4,6 +4,7 @@ CLI for hardware-level kernel profiling. Naming aligned with kernel-evolve and k
 All kernels are profiled and reported; the agent chooses which to use. --auto-select is not used.
 """
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -19,9 +20,37 @@ Examples:
   %(prog)s 'python3 /path/to/kernel.py --profile'
   %(prog)s 'python3 kernel.py --profile' --gpu-devices 3
   %(prog)s 'python3 kernel.py --profile' --replays 5
-  %(prog)s 'python3 kernel.py --profile' --quick  # Fast profiling (3 metrics, 1 pass)
-  %(prog)s 'python3 kernel.py --profile' --gpu-devices 0,1,2  # Profile on multiple GPUs
+  %(prog)s 'python3 kernel.py --profile' --quick
+  %(prog)s 'python3 kernel.py --profile' --gpu-devices 0,1,2
+
+Pipeline chaining (read test command from discovery output):
+  %(prog)s --from-discovery discovery.json --json -o profile.json
+  %(prog)s --from-discovery discovery.json --quick --json -o profile.json
 """
+
+
+def _extract_command_from_discovery(discovery_path: str) -> str:
+    """Extract the profiling command from a discovery JSON file.
+
+    Prefers focused_test.focused_command, falls back to tests[0].command.
+    """
+    data = json.loads(Path(discovery_path).read_text())
+
+    focused = data.get("focused_test") or {}
+    cmd = focused.get("focused_command")
+    if cmd:
+        return cmd
+
+    tests = data.get("tests") or []
+    if tests:
+        cmd = tests[0].get("command")
+        if cmd:
+            return cmd
+
+    raise ValueError(
+        f"No profiling command found in {discovery_path}: "
+        "need focused_test.focused_command or tests[0].command"
+    )
 
 
 def main():
@@ -31,7 +60,20 @@ def main():
         epilog=EXAMPLES,
     )
     parser.add_argument(
-        "command", help='Command to profile (e.g., "python3 kernel.py --profile")'
+        "command", nargs="?", default=None,
+        help='Command to profile (e.g., "python3 kernel.py --profile")',
+    )
+    parser.add_argument(
+        "--from-discovery", default=None, metavar="FILE",
+        help="Read discovery.json and extract the test command for profiling",
+    )
+    parser.add_argument(
+        "--json", action="store_true", dest="output_json",
+        help="Output raw MetrixTool result as JSON (for piping to baseline-metrics)",
+    )
+    parser.add_argument(
+        "-o", "--output", default=None, metavar="FILE",
+        help="Write output to file instead of stdout (implies --json)",
     )
     parser.add_argument(
         "--gpu-devices",
@@ -57,6 +99,23 @@ def main():
 
     args = parser.parse_args()
 
+    # Resolve the command to profile
+    command = args.command
+    if args.from_discovery:
+        try:
+            discovery_cmd = _extract_command_from_discovery(args.from_discovery)
+        except (ValueError, FileNotFoundError, json.JSONDecodeError) as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
+        if not command:
+            command = discovery_cmd
+        print(f"[kernel-profile] Using command from discovery: {command}", file=sys.stderr)
+
+    if not command:
+        parser.error("command is required (positional or via --from-discovery)")
+
+    use_json = args.output_json or args.output is not None
+
     # All kernels are profiled and reported; agent chooses which to use.
     args.auto_select = False
 
@@ -67,21 +126,29 @@ def main():
 
     tool = MetrixTool(gpu_devices=gpu_devices)
     result = tool.profile(
-        command=args.command,
+        command=command,
         num_replays=args.replays,
         kernel_filter=None,
         auto_select=args.auto_select,
         quick=args.quick,
     )
 
-    # Display results (always a list, even for single GPU)
-    for gpu_result in result["results"]:
-        if len(result["results"]) > 1:
-            device_id = gpu_result.get("device_id", "?")
-            print(f"\n{'='*70}")
-            print(f"GPU {device_id}")
-            print(f"{'='*70}")
-        _display_single_gpu_result(gpu_result, args.auto_select)
+    if use_json:
+        output_text = json.dumps(result, indent=2)
+        if args.output:
+            Path(args.output).write_text(output_text + "\n")
+            print(f"Wrote {args.output}", file=sys.stderr)
+        else:
+            print(output_text)
+    else:
+        # Display human-readable results (always a list, even for single GPU)
+        for gpu_result in result["results"]:
+            if len(result["results"]) > 1:
+                device_id = gpu_result.get("device_id", "?")
+                print(f"\n{'='*70}")
+                print(f"GPU {device_id}")
+                print(f"{'='*70}")
+            _display_single_gpu_result(gpu_result, args.auto_select)
 
 
 def _display_single_gpu_result(result, auto_select):

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -133,6 +133,52 @@ def _run_discovery(kernel_path: str, kernel_name: str | None = None) -> str | tu
     return ""
 
 
+def _run_baseline_profile(test_command: str, gpu_id: int = 0, console=None) -> dict:
+    """Run kernel-profile on the test harness and return the raw profiling dict.
+
+    This is a lightweight wrapper that calls MetrixTool.profile() directly,
+    replicating what the ``kernel-profile`` CLI does but returning the dict
+    instead of printing to stdout.
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from metrix_mcp.core import MetrixTool
+
+    profile_cmd = _extract_harness_path(test_command) + " --profile"
+    if console:
+        console.print(f"[dim]Profiling: {profile_cmd} on GPU {gpu_id}[/dim]")
+
+    tool = MetrixTool(gpu_devices=str(gpu_id))
+    return tool.profile(command=f"python3 {profile_cmd}", num_replays=3, quick=True)
+
+
+def _extract_harness_path(test_command: str) -> str:
+    """Extract the harness script path from a test command string.
+
+    Handles patterns like:
+        'pytest /path/to/test.py -v'  -> '/path/to/test.py'
+        'python /path/to/harness.py --correctness' -> '/path/to/harness.py'
+        '/path/to/harness.py' -> '/path/to/harness.py'
+    """
+    import shlex
+    try:
+        tokens = shlex.split(test_command)
+    except ValueError:
+        tokens = test_command.split()
+
+    for token in tokens:
+        if token.endswith(".py") and "/" in token:
+            return token
+
+    # Fallback: return first token that looks like a path
+    for token in tokens:
+        if "/" in token:
+            return token
+
+    return test_command
+
+
 def _inject_resolved_kernel(kernel_url: str, workspace: str | None, task: str) -> tuple[str, str | None]:
     """Resolve kernel URL to local path/line/kernel name and append to task."""
     repo_root = Path(__file__).resolve().parent.parent.parent.parent
@@ -256,9 +302,42 @@ def main(
     docker_image: str | None = typer.Option(None, "--docker-image", help="Docker image to use when --runtime=docker.", rich_help_panel="Advanced"),
     workspace: Path | None = typer.Option(None, "--workspace", help="Workspace directory to mount in Docker.", rich_help_panel="Advanced"),
     kernel_url: str | None = typer.Option(None, "--kernel-url", help="Kernel as URL (e.g. https://github.com/.../file.py#L106). Resolved path/line/kernel name are injected into the task.", rich_help_panel="Kernel"),
+    from_task: Path | None = typer.Option(None, "--from-task", help="Path to a task .md file (YAML frontmatter). Populates --task, --repo, and other settings. Implies --yolo.", rich_help_panel="Task File"),
 ) -> Any:
     # fmt: on
     configure_if_first_time()
+
+    # --from-task: populate CLI parameters from the task file, unless explicitly set
+    _task_worktree: Path | None = None
+    if from_task:
+        from minisweagent.run.task_file import (
+            read_task_file as _read_tf,
+            create_worktree as _create_wt,
+            is_git_repo as _is_git,
+            replace_paths as _repl_paths,
+        )
+        _tf_meta, _tf_body = _read_tf(from_task)
+        console.print(f"[bold cyan]Loading task file: {from_task}[/bold cyan]")
+
+        if not task:
+            task = _tf_body
+
+        if not repo and _tf_meta.get("kernel_path"):
+            repo = Path(_tf_meta["kernel_path"]).resolve().parent
+        if not repo and _tf_meta.get("repo_root"):
+            repo = Path(_tf_meta["repo_root"]).resolve()
+
+        # Auto-worktree isolation
+        _tf_repo = Path(_tf_meta["repo_root"]).resolve() if _tf_meta.get("repo_root") else (repo.resolve() if repo else None)
+        if _tf_repo and _tf_repo.is_dir() and _is_git(_tf_repo):
+            _wt_dest = Path(from_task).resolve().parent.parent / "results" / (from_task.stem + "_wt")
+            console.print(f"[bold cyan]Creating isolated worktree at {_wt_dest}...[/bold cyan]")
+            _task_worktree = _create_wt(_tf_repo, _wt_dest)
+            # Rewrite repo to point at worktree
+            repo = _task_worktree
+
+        # Imply --yolo for task file runs
+        yolo = True
 
     # 0. Runtime environment check (ported from MSA branch)
     if runtime in ("auto", "docker"):
@@ -452,7 +531,51 @@ def main(
             discovery_context=discovery_context,
         )
         console.print(f"[bold green]Using UnitTestAgent test_command:[/bold green] {test_command}")
-    
+
+    # ============ Step 0c: Pre-agent baseline profiling + commandment generation ============
+    # These run once up front so the task generator has richer context.
+    # Results are stored in _pre_agent_* variables and passed to the task generator.
+    _pre_agent_profiling: dict | None = None
+    _pre_agent_baseline_metrics: dict | None = None
+    _pre_agent_commandment: str | None = None
+
+    if _resolved_kernel_path and test_command and (num_parallel and num_parallel > 1):
+        # -- Baseline profiling --
+        try:
+            console.print("[bold cyan]--- Pre-agent Baseline Profiling ---[/bold cyan]")
+            _pre_agent_profiling = _run_baseline_profile(
+                test_command, gpu_id=parsed_gpu_ids[0], console=console,
+            )
+        except Exception as e:
+            console.print(f"[yellow]Pre-agent profiling failed ({e}); tasks will use discovery only[/yellow]")
+
+        # -- Baseline metrics (from profiling) --
+        if _pre_agent_profiling:
+            try:
+                from minisweagent.baseline_metrics import build_baseline_metrics
+                _pre_agent_baseline_metrics = build_baseline_metrics(
+                    _pre_agent_profiling, include_all=True,
+                )
+                dur = _pre_agent_baseline_metrics.get("duration_us", "?")
+                bn = _pre_agent_baseline_metrics.get("bottleneck", "?")
+                console.print(f"[bold green]Baseline: {dur} us, bottleneck={bn}[/bold green]")
+            except Exception as e:
+                console.print(f"[yellow]Baseline metrics extraction failed ({e})[/yellow]")
+
+        # -- Commandment generation --
+        if _resolved_kernel_path:
+            try:
+                from minisweagent.tools.commandment import generate_commandment
+                _harness_path = _extract_harness_path(test_command)
+                _pre_agent_commandment = generate_commandment(
+                    kernel_path=_resolved_kernel_path,
+                    harness_path=_harness_path,
+                    repo_root=repo,
+                )
+                console.print("[bold green]COMMANDMENT.md generated (pre-agent)[/bold green]")
+            except Exception as e:
+                console.print(f"[yellow]Commandment generation failed ({e})[/yellow]")
+
     # ============ Step 1: Choose base agent class ============
     # Based on enable_strategies flag, select appropriate agent and template
     if enable_strategies:
@@ -512,25 +635,30 @@ def main(
         else:
             console.print("[bold yellow]Warning: No repo path specified for parallel execution[/bold yellow]")
 
-        # Generate dynamic optimization tasks from discovery results (if available)
+        # Generate dynamic optimization tasks (LLM-assisted if model available, else rule-based)
         discovery_result = getattr(_run_discovery, "_last_result", None)
         if discovery_result and discovery_result.kernels:
             try:
-                from minisweagent.run.task_planner import build_optimization_tasks
-                tasks = build_optimization_tasks(
+                from minisweagent.run.task_generator import generate_tasks
+                tasks = generate_tasks(
                     discovery_result=discovery_result,
                     base_task_context=task_content,
                     agent_class=base_agent_class,
+                    model=model if _pre_agent_profiling else None,
+                    profiling_result=_pre_agent_profiling,
+                    commandment_content=_pre_agent_commandment,
+                    baseline_metrics=_pre_agent_baseline_metrics,
                 )
                 if tasks:
                     agent_config["tasks"] = tasks
-                    console.print(f"[bold cyan]Task planner: {len(tasks)} optimization tasks generated (pool mode)[/bold cyan]")
+                    source = "LLM" if (_pre_agent_profiling and model) else "rule-based"
+                    console.print(f"[bold cyan]Task generator ({source}): {len(tasks)} optimization tasks (pool mode)[/bold cyan]")
                     for t in tasks[:6]:
                         console.print(f"  [dim]- [{t.priority:2d}] {t.label} ({t.kernel_language})[/dim]")
                     if len(tasks) > 6:
                         console.print(f"  [dim]  ... and {len(tasks) - 6} more[/dim]")
             except Exception as e:
-                console.print(f"[yellow]Task planner failed ({e}), falling back to homogeneous mode[/yellow]")
+                console.print(f"[yellow]Task generator failed ({e}), falling back to homogeneous mode[/yellow]")
     else:
         console.print("[bold cyan]Using Single Agent Mode[/bold cyan]")
         console.print(f"[dim]Using GPU: {parsed_gpu_ids[0]}[/dim]")

--- a/src/minisweagent/run/task_file.py
+++ b/src/minisweagent/run/task_file.py
@@ -1,0 +1,253 @@
+"""Task file utilities -- read/write Markdown task files with YAML frontmatter.
+
+Task files are the intermediate format between task-generator and downstream
+tools (openevolve-worker, geak). Each file has YAML frontmatter with metadata
+and a Markdown body with the full task prompt.
+
+Also provides git worktree helpers extracted from ParallelAgent so that
+CLI tools can create isolated work directories.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+# ============================================================================
+# Task file I/O
+# ============================================================================
+
+# Path keys in frontmatter that should be stored as relative and resolved on read
+_PATH_KEYS = ("kernel_path", "repo_root", "commandment", "baseline_metrics", "profiling")
+
+
+def write_task_file(
+    path: Path,
+    metadata: dict[str, Any],
+    body: str,
+    *,
+    relative_to: Path | None = None,
+) -> None:
+    """Write a task file with YAML frontmatter and Markdown body.
+
+    Args:
+        path: Output file path.
+        metadata: Dict of frontmatter fields. Path-valued keys in _PATH_KEYS
+                  are converted to relative paths if *relative_to* is set.
+        body: Markdown body (the full task prompt).
+        relative_to: If set, path-valued frontmatter fields are made relative
+                     to this directory.
+    """
+    fm = {}
+    for k, v in metadata.items():
+        if v is None:
+            continue
+        if relative_to and k in _PATH_KEYS and isinstance(v, (str, Path)):
+            abs_path = Path(v).resolve()
+            try:
+                fm[k] = os.path.relpath(abs_path, relative_to.resolve())
+            except ValueError:
+                fm[k] = str(abs_path)
+        else:
+            fm[k] = v
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---\n")
+        f.write(yaml.dump(fm, default_flow_style=False, sort_keys=False))
+        f.write("---\n\n")
+        f.write(body)
+        if not body.endswith("\n"):
+            f.write("\n")
+
+
+def read_task_file(path: Path) -> tuple[dict[str, Any], str]:
+    """Read a task file and return (metadata, body).
+
+    Path-valued fields in metadata are resolved to absolute paths relative
+    to the task file's directory.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+
+    # Split on --- delimiters
+    parts = re.split(r"^---\s*$", text, maxsplit=2, flags=re.MULTILINE)
+    if len(parts) < 3:
+        raise ValueError(f"Task file {path} does not have valid YAML frontmatter (need --- delimiters)")
+
+    fm_text = parts[1]
+    body = parts[2].lstrip("\n")
+
+    metadata = yaml.safe_load(fm_text) or {}
+    task_dir = Path(path).resolve().parent
+
+    # Resolve relative paths to absolute
+    for key in _PATH_KEYS:
+        if key in metadata and metadata[key]:
+            rel = metadata[key]
+            resolved = (task_dir / rel).resolve()
+            metadata[key] = str(resolved)
+
+    return metadata, body
+
+
+# ============================================================================
+# Git worktree helpers (extracted from ParallelAgent)
+# ============================================================================
+
+def _ensure_safe_directory(repo_path: Path) -> None:
+    """Ensure repository is in git's safe.directory list."""
+    repo_path_str = str(repo_path.resolve())
+    try:
+        result = subprocess.run(
+            ["git", "config", "--global", "--get-all", "safe.directory"],
+            capture_output=True, text=True,
+        )
+        safe_dirs = result.stdout.strip().split("\n") if result.stdout.strip() else []
+        if repo_path_str not in safe_dirs:
+            subprocess.run(
+                ["git", "config", "--global", "--add", "safe.directory", repo_path_str],
+                check=True, capture_output=True, text=True,
+            )
+    except subprocess.CalledProcessError:
+        try:
+            subprocess.run(
+                ["git", "config", "--global", "--add", "safe.directory", repo_path_str],
+                check=True, capture_output=True, text=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+
+
+def _copy_untracked_files(repo_path: Path, worktree_path: Path) -> None:
+    """Copy untracked files from repo to worktree."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            cwd=repo_path, check=True, capture_output=True, text=True,
+        )
+        for rel_path in (f.strip() for f in result.stdout.splitlines() if f.strip()):
+            src = repo_path / rel_path
+            dst = worktree_path / rel_path
+            if src.is_file():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+    except subprocess.CalledProcessError:
+        pass
+
+
+def create_worktree(repo_path: Path, worktree_path: Path) -> Path:
+    """Create a git worktree, cleaning up any existing one first.
+
+    Extracted from ParallelAgent._create_worktree() for reuse by CLI tools.
+
+    Args:
+        repo_path: Path to the git repository.
+        worktree_path: Desired path for the new worktree.
+
+    Returns:
+        The worktree path (same as input, for chaining).
+    """
+    worktree_str = str(worktree_path.resolve())
+
+    # Clean up any existing worktree at this path
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list"],
+            cwd=repo_path, check=True, capture_output=True, text=True,
+        )
+        worktree_exists = any(
+            worktree_str in line or str(worktree_path) in line
+            for line in result.stdout.splitlines()
+        )
+        if worktree_exists:
+            try:
+                subprocess.run(
+                    ["git", "worktree", "remove", str(worktree_path), "--force"],
+                    cwd=repo_path, check=True, capture_output=True, text=True,
+                )
+            except subprocess.CalledProcessError:
+                subprocess.run(
+                    ["git", "worktree", "prune"],
+                    cwd=repo_path, check=False, capture_output=True, text=True,
+                )
+    except subprocess.CalledProcessError:
+        subprocess.run(
+            ["git", "worktree", "prune"],
+            cwd=repo_path, check=False, capture_output=True, text=True,
+        )
+    except Exception:
+        pass
+
+    # Remove directory if it still exists
+    if worktree_path.exists():
+        try:
+            shutil.rmtree(worktree_path)
+        except Exception:
+            pass
+
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_safe_directory(repo_path)
+
+    # Create new worktree with detached HEAD
+    try:
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(worktree_path)],
+            cwd=repo_path, check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        error_msg = e.stderr or e.stdout or str(e)
+        if "missing but already registered worktree" in error_msg.lower():
+            subprocess.run(["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True)
+            subprocess.run(
+                ["git", "worktree", "add", "--detach", "-f", str(worktree_path)],
+                cwd=repo_path, check=True, capture_output=True, text=True,
+            )
+        elif "dubious ownership" in error_msg.lower():
+            _ensure_safe_directory(repo_path)
+            _ensure_safe_directory(worktree_path)
+            subprocess.run(
+                ["git", "worktree", "add", "--detach", str(worktree_path)],
+                cwd=repo_path, check=True, capture_output=True, text=True,
+            )
+        elif "already used by worktree" in error_msg.lower():
+            subprocess.run(["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True)
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(worktree_path)],
+                cwd=repo_path, check=False, capture_output=True, text=True,
+            )
+            subprocess.run(
+                ["git", "worktree", "add", "--detach", str(worktree_path)],
+                cwd=repo_path, check=True, capture_output=True, text=True,
+            )
+        else:
+            raise RuntimeError(f"Failed to create worktree: {error_msg}") from e
+
+    _ensure_safe_directory(worktree_path)
+    _copy_untracked_files(repo_path, worktree_path)
+    return worktree_path
+
+
+def replace_paths(text: str, repo_path: Path, worktree_path: Path) -> str:
+    """Replace repo paths with worktree paths in text."""
+    repo_str = str(repo_path.resolve())
+    wt_str = str(worktree_path.resolve())
+    return text.replace(repo_str, wt_str)
+
+
+def is_git_repo(path: Path) -> bool:
+    """Check if a path is inside a git repository."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=path, check=True, capture_output=True, text=True,
+        )
+        return result.stdout.strip() == "true"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False

--- a/src/minisweagent/run/task_generator.py
+++ b/src/minisweagent/run/task_generator.py
@@ -1,0 +1,651 @@
+"""LLM-assisted task generator -- produces optimization tasks using LLM reasoning.
+
+Given rich context (discovery results, profiling output, COMMANDMENT.md,
+baseline metrics), asks an LLM to generate a prioritized list of optimization
+tasks with appropriate sub-agent assignments.
+
+Falls back to the rule-based ``task_planner.build_optimization_tasks()`` when:
+- The LLM call fails (network error, rate limit, malformed output)
+- No model is available (``--no-llm-planning`` or missing API key)
+
+Priority scheme (lower = higher priority, runs first):
+  0  -- OpenEvolve on the inner kernel (highest impact, automated)
+  5  -- Kernel fusion / advanced tuning
+  10 -- Targeted optimization (autotune, memory, launch config)
+  15 -- Profile-guided (generic fallback)
+
+Usage (Python):
+    from minisweagent.run.task_generator import generate_tasks
+    tasks = generate_tasks(
+        discovery_result=result,
+        base_task_context=task_text,
+        agent_class=StrategyAgent,
+        model=model,
+        profiling_result=profiling,
+        commandment_content=commandment,
+        baseline_metrics=metrics,
+    )
+
+Usage (CLI):
+    python -m minisweagent.run.task_generator \\
+        --kernel-path /path/to/kernel.py \\
+        --profiling profiler_output.json \\
+        --commandment COMMANDMENT.md \\
+        --baseline-metrics baseline_metrics.json
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import textwrap
+from pathlib import Path
+from typing import Any
+
+from minisweagent.agents.agent_spec import AgentTask
+from minisweagent.run.task_planner import (
+    _GPU_AND_PROFILER_RULES,
+    build_optimization_tasks,
+)
+from minisweagent.tools.discovery import DiscoveryResult
+
+logger = logging.getLogger(__name__)
+
+_MAX_LLM_RETRIES = 1
+
+# ============================================================================
+# System prompt for the LLM task generator
+# ============================================================================
+
+_SYSTEM_PROMPT = textwrap.dedent("""\
+You are an expert GPU kernel optimization planner. Given information about a
+kernel (its type, structure, profiling bottlenecks, and available tests), you
+generate a prioritized list of optimization tasks.
+
+## Available sub-agent types
+
+1. **strategy_agent** (default) -- An LLM-guided agent that reads code,
+   profiles, reasons about bottlenecks, and edits the kernel directly.
+   Best for targeted optimizations: autotune config, memory access patterns,
+   launch configuration, kernel fusion.
+
+2. **openevolve** -- An evolutionary optimizer that mutates the kernel and
+   evaluates candidates automatically (no LLM reasoning during optimization).
+   Best for inner kernels where small code changes can yield large speedups.
+   Requires a COMMANDMENT.md and baseline_metrics.json.
+
+## Task priority scheme (lower number = higher priority = runs first)
+
+- 0: OpenEvolve on inner kernel (highest impact, automated)
+- 5: Kernel fusion, advanced language-specific tuning
+- 10: Targeted optimizations (autotune, memory, launch config)
+- 15: Profile-guided generic optimization (fallback)
+
+## Output format
+
+Return a JSON array of task objects. Each task has:
+- "label": short kebab-case identifier (e.g. "openevolve-inner", "triton-autotune")
+- "priority": integer 0-15
+- "agent_type": "strategy_agent" or "openevolve"
+- "kernel_language": "python", "cpp", or "asm"
+- "task_prompt": detailed instructions for the sub-agent (include file paths,
+  specific optimization focus, what to measure). This is the FULL prompt the
+  agent will see.
+
+## Rules for task_prompt content
+
+{gpu_rules}
+
+Return ONLY the JSON array. No markdown fences, no explanation.
+""").format(gpu_rules=_GPU_AND_PROFILER_RULES.strip())
+
+
+# ============================================================================
+# Public API
+# ============================================================================
+
+def generate_tasks(
+    discovery_result: DiscoveryResult,
+    base_task_context: str,
+    agent_class: type,
+    *,
+    model: Any | None = None,
+    profiling_result: dict | None = None,
+    commandment_content: str | None = None,
+    baseline_metrics: dict | None = None,
+) -> list[AgentTask]:
+    """Generate optimization tasks, using LLM if available.
+
+    Args:
+        discovery_result: Output of DiscoveryPipeline.run().
+        base_task_context: Common context prepended to each task prompt.
+        agent_class: Default agent class for tasks (typically StrategyAgent).
+        model: LLM model instance (if None, falls back to rule-based planner).
+        profiling_result: Output from kernel-profile (dict with "results" key).
+        commandment_content: Content of the generated COMMANDMENT.md.
+        baseline_metrics: Content of baseline_metrics.json (parsed dict).
+
+    Returns:
+        List of AgentTask sorted by priority.
+    """
+    if not discovery_result.kernels:
+        return []
+
+    if model is None:
+        logger.info("No model provided; falling back to rule-based task planner")
+        return build_optimization_tasks(discovery_result, base_task_context, agent_class)
+
+    try:
+        tasks = _generate_with_llm(
+            discovery_result=discovery_result,
+            base_task_context=base_task_context,
+            agent_class=agent_class,
+            model=model,
+            profiling_result=profiling_result,
+            commandment_content=commandment_content,
+            baseline_metrics=baseline_metrics,
+        )
+        if tasks:
+            return tasks
+        logger.warning("LLM returned empty task list; falling back to rule-based planner")
+    except Exception as e:
+        logger.warning("LLM task generation failed (%s); falling back to rule-based planner", e)
+
+    return build_optimization_tasks(discovery_result, base_task_context, agent_class)
+
+
+# ============================================================================
+# LLM interaction
+# ============================================================================
+
+def _generate_with_llm(
+    discovery_result: DiscoveryResult,
+    base_task_context: str,
+    agent_class: type,
+    model: Any,
+    profiling_result: dict | None,
+    commandment_content: str | None,
+    baseline_metrics: dict | None,
+) -> list[AgentTask]:
+    """Call the LLM and parse the response into AgentTask objects."""
+    user_prompt = _build_user_prompt(
+        discovery_result=discovery_result,
+        base_task_context=base_task_context,
+        profiling_result=profiling_result,
+        commandment_content=commandment_content,
+        baseline_metrics=baseline_metrics,
+    )
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": user_prompt},
+    ]
+
+    for attempt in range(_MAX_LLM_RETRIES + 1):
+        response = model.query(messages)
+        content = response.get("content", "").strip()
+
+        try:
+            tasks = _parse_llm_response(content, agent_class, base_task_context)
+            return tasks
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+            if attempt < _MAX_LLM_RETRIES:
+                logger.info("LLM output parse failed (attempt %d): %s; retrying", attempt + 1, e)
+                messages.append({"role": "assistant", "content": content})
+                messages.append({
+                    "role": "user",
+                    "content": (
+                        f"Your response was not valid JSON: {e}\n"
+                        "Please return ONLY a JSON array of task objects with keys: "
+                        "label, priority, agent_type, kernel_language, task_prompt. "
+                        "No markdown fences, no explanation."
+                    ),
+                })
+            else:
+                raise
+
+    return []  # unreachable but satisfies type checker
+
+
+def _build_user_prompt(
+    discovery_result: DiscoveryResult,
+    base_task_context: str,
+    profiling_result: dict | None,
+    commandment_content: str | None,
+    baseline_metrics: dict | None,
+) -> str:
+    """Assemble all available context into a structured prompt."""
+    sections: list[str] = []
+
+    # -- Kernel info --
+    kernel = discovery_result.kernels[0]
+    sections.append(textwrap.dedent(f"""\
+    ## Kernel Information
+    - File: {kernel.file_path}
+    - Name: {kernel.kernel_name}
+    - Type: {kernel.kernel_type}
+    - Language: {kernel.kernel_language}
+    - Inner kernel: {kernel.inner_kernel_path or 'N/A'}
+    - Inner kernel language: {kernel.inner_kernel_language or 'N/A'}
+    - Has autotune: {kernel.has_autotune}
+    - Function names: {', '.join(kernel.function_names) if kernel.function_names else 'N/A'}
+    """))
+
+    # -- Fusion opportunities --
+    if kernel.fusion_opportunities:
+        sections.append("## Fusion Opportunities")
+        for opp in kernel.fusion_opportunities:
+            sections.append(f"- {opp}")
+        sections.append("")
+
+    # -- Dependency graph --
+    dep_graph = discovery_result.dependency_graphs.get(kernel.kernel_name)
+    if dep_graph:
+        sections.append(f"## Dependency Graph\n{dep_graph.summary()}\n")
+
+    # -- Discovered tests --
+    if discovery_result.tests:
+        sections.append("## Discovered Tests")
+        for t in discovery_result.tests[:5]:
+            sections.append(f"- {t.file_path} (confidence: {t.confidence:.2f}, command: {t.command})")
+        sections.append("")
+
+    # -- Discovered benchmarks --
+    if discovery_result.benchmarks:
+        sections.append("## Discovered Benchmarks")
+        for b in discovery_result.benchmarks[:3]:
+            sections.append(f"- {b.file_path} (confidence: {b.confidence:.2f})")
+        sections.append("")
+
+    # -- Profiling result --
+    if profiling_result:
+        sections.append("## Profiling Results (baseline)")
+        results = profiling_result.get("results", [])
+        if results:
+            gpu_result = results[0]
+            kernels = gpu_result.get("kernels", [])
+            for k in kernels[:10]:
+                dur = k.get("duration_us", k.get("metrics", {}).get("duration_us", "?"))
+                bn = k.get("bottleneck", "?")
+                sections.append(f"- {k.get('name', '?')}: {dur} us, bottleneck={bn}")
+            observations = gpu_result.get("observations", [])
+            if observations:
+                sections.append("Observations:")
+                for obs in observations[:5]:
+                    sections.append(f"  - {obs}")
+        sections.append("")
+
+    # -- Baseline metrics --
+    if baseline_metrics:
+        sections.append("## Baseline Metrics")
+        sections.append(f"- Duration: {baseline_metrics.get('duration_us', '?')} us")
+        sections.append(f"- Kernel: {baseline_metrics.get('kernel_name', '?')}")
+        sections.append(f"- Bottleneck: {baseline_metrics.get('bottleneck', '?')}")
+        metrics = baseline_metrics.get("metrics", {})
+        for k, v in list(metrics.items())[:10]:
+            sections.append(f"- {k}: {v}")
+        sections.append("")
+
+    # -- COMMANDMENT.md --
+    if commandment_content:
+        sections.append(f"## COMMANDMENT.md (evaluation contract)\n```\n{commandment_content}\n```\n")
+
+    # -- Base task context (truncated) --
+    ctx_preview = base_task_context[:2000]
+    if len(base_task_context) > 2000:
+        ctx_preview += "\n... (truncated)"
+    sections.append(f"## Base Task Context\n{ctx_preview}\n")
+
+    # -- Instructions --
+    sections.append(textwrap.dedent("""\
+    ## Your Task
+    Based on all the information above, generate a prioritized list of
+    optimization tasks as a JSON array. Each task should target a specific
+    optimization opportunity. Include the full base task context in each
+    task_prompt so the sub-agent has all the information it needs.
+
+    Consider:
+    - If an inner kernel exists, OpenEvolve on it is usually the highest-impact task (priority 0).
+    - Profiling bottlenecks should inform what targeted optimizations to suggest.
+    - Fusion opportunities from the dependency graph are high-value tasks.
+    - Include at least one profile-guided fallback task (priority 15).
+    - Each task_prompt MUST include absolute file paths and specific instructions.
+    """))
+
+    return "\n".join(sections)
+
+
+def _parse_llm_response(
+    content: str,
+    agent_class: type,
+    base_task_context: str,
+) -> list[AgentTask]:
+    """Parse JSON response into AgentTask objects."""
+    # Strip markdown code fences if the LLM wrapped the JSON
+    content = content.strip()
+    if content.startswith("```"):
+        lines = content.splitlines()
+        # Remove first and last fence lines
+        if lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        content = "\n".join(lines)
+
+    raw_tasks = json.loads(content)
+    if not isinstance(raw_tasks, list):
+        raise TypeError(f"Expected JSON array, got {type(raw_tasks).__name__}")
+
+    tasks: list[AgentTask] = []
+    for item in raw_tasks:
+        if not isinstance(item, dict):
+            continue
+
+        label = str(item.get("label", "unknown"))
+        priority = int(item.get("priority", 10))
+        priority = max(0, min(15, priority))  # clamp to valid range
+        kernel_language = str(item.get("kernel_language", "python"))
+        task_prompt = str(item.get("task_prompt", ""))
+
+        if not task_prompt:
+            continue
+
+        tasks.append(AgentTask(
+            agent_class=agent_class,
+            task=task_prompt,
+            label=label,
+            priority=priority,
+            kernel_language=kernel_language,
+        ))
+
+    if not tasks:
+        raise ValueError("LLM response contained no valid tasks")
+
+    return sorted(tasks, key=lambda t: t.priority)
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+def _scan_previous_results(results_dir: Path) -> str:
+    """Scan a previous round's results directory and build a summary.
+
+    Reads task_*/patch_*_test.txt and task_*/*.log to understand what
+    each task achieved. Returns a Markdown summary for the LLM prompt.
+    """
+    import re as _re
+
+    sections: list[str] = []
+    task_dirs = sorted(results_dir.glob("task_*"))
+    if not task_dirs:
+        return ""
+
+    for td in task_dirs:
+        label = td.name
+        patches = sorted(td.glob("patch_*.patch"))
+        test_outputs = sorted(td.glob("patch_*_test.txt"))
+        log_files = sorted(td.glob("*.log"))
+
+        section = [f"### {label}"]
+        section.append(f"- Patches produced: {len(patches)}")
+
+        # Extract key metrics from test outputs
+        for tf in test_outputs[:3]:
+            try:
+                content = tf.read_text(errors="replace")[-2000:]
+                # Look for common metric patterns
+                speedups = _re.findall(r"speedup[:\s]+([0-9.]+)x?", content, _re.IGNORECASE)
+                durations = _re.findall(r"duration[:\s]+([0-9.]+)\s*(?:us|µs|ms)", content, _re.IGNORECASE)
+                if speedups:
+                    section.append(f"- {tf.name}: speedup = {speedups[-1]}")
+                elif durations:
+                    section.append(f"- {tf.name}: duration = {durations[-1]}")
+                else:
+                    # Last 3 non-empty lines as fallback
+                    lines = [l.strip() for l in content.splitlines() if l.strip()]
+                    tail = lines[-3:] if len(lines) >= 3 else lines
+                    section.append(f"- {tf.name} (tail): {' | '.join(tail)}")
+            except Exception:
+                section.append(f"- {tf.name}: (unreadable)")
+
+        # Check for errors in logs
+        for lf in log_files[:1]:
+            try:
+                content = lf.read_text(errors="replace")[-1000:]
+                if "ERROR" in content or "Traceback" in content:
+                    section.append(f"- Log ({lf.name}): contains errors")
+                else:
+                    section.append(f"- Log ({lf.name}): completed")
+            except Exception:
+                pass
+
+        sections.append("\n".join(section))
+
+    return "## Previous Round Results\n\n" + "\n\n".join(sections) + "\n"
+
+
+def main():
+    """Generate optimization tasks from the command line."""
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Generate optimization tasks using LLM reasoning (or rule-based fallback)",
+    )
+    parser.add_argument("--kernel-path", default=None, help="Path to the kernel file")
+    parser.add_argument(
+        "--from-discovery", default=None, metavar="FILE",
+        help="Read discovery.json and extract kernel-path and repo-root",
+    )
+    parser.add_argument("--profiling", default=None, help="Path to kernel-profile JSON output")
+    parser.add_argument("--commandment", default=None, help="Path to COMMANDMENT.md")
+    parser.add_argument("--baseline-metrics", default=None, help="Path to baseline_metrics.json")
+    parser.add_argument("--model", default=None, help="Model name (default: from config/env)")
+    parser.add_argument("--no-llm", action="store_true", help="Skip LLM, use rule-based planner only")
+    parser.add_argument("--repo-root", default=None, help="Repository root (for discovery)")
+    parser.add_argument(
+        "-o", "--output", default=None, metavar="DIR",
+        help="Write task files to this directory (one .md per task) instead of JSON to stdout",
+    )
+    parser.add_argument(
+        "--from-results", default=None, metavar="DIR",
+        help="Previous round results directory (for iterative refinement)",
+    )
+    parser.add_argument(
+        "--round", type=int, default=1,
+        help="Round number for task file frontmatter (default: 1)",
+    )
+
+    args = parser.parse_args()
+
+    # Populate from discovery JSON if provided (explicit flags override)
+    disc_json = None
+    if args.from_discovery:
+        disc_json = json.loads(Path(args.from_discovery).read_text())
+        if not args.kernel_path:
+            args.kernel_path = (disc_json.get("kernel") or {}).get("file")
+        if not args.repo_root:
+            args.repo_root = disc_json.get("workspace")
+
+    if not args.kernel_path:
+        parser.error("--kernel-path is required (or provide --from-discovery)")
+
+    kernel_path = Path(args.kernel_path).resolve()
+    if not kernel_path.exists():
+        print(f"ERROR: kernel path not found: {args.kernel_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Build DiscoveryResult -- from pre-computed JSON if available, else run pipeline
+    from minisweagent.tools.discovery import (
+        BenchmarkInfo,
+        DiscoveryResult,
+        KernelInfo,
+        TestInfo,
+    )
+
+    if disc_json:
+        # Reconstruct DiscoveryResult from the test-discovery JSON output
+        print(f"[task-generator] Loading discovery from {args.from_discovery}...", file=sys.stderr)
+        kernel_info = disc_json.get("kernel") or {}
+        kernels = []
+        if kernel_info.get("file"):
+            kernels.append(KernelInfo(
+                file_path=Path(kernel_info["file"]),
+                kernel_name=kernel_info.get("name", kernel_path.stem),
+                kernel_type=kernel_info.get("type", "unknown"),
+                kernel_language="python" if kernel_path.suffix == ".py" else "cpp",
+                function_names=kernel_info.get("functions", []),
+            ))
+        tests = [
+            TestInfo(
+                file_path=Path(t["file"]),
+                test_type=t.get("type", "script"),
+                command=t.get("command", ""),
+                confidence=t.get("confidence", 0.5),
+            )
+            for t in (disc_json.get("tests") or [])
+        ]
+        benchmarks = [
+            BenchmarkInfo(
+                file_path=Path(b["file"]),
+                bench_type=b.get("type", "script"),
+                command=b.get("command", ""),
+                confidence=b.get("confidence", 0.5),
+            )
+            for b in (disc_json.get("benchmarks") or [])
+        ]
+        workspace = Path(disc_json.get("workspace", kernel_path.parent))
+        discovery_result = DiscoveryResult(
+            kernels=kernels,
+            tests=tests,
+            benchmarks=benchmarks,
+            workspace_path=workspace,
+        )
+    else:
+        print(f"[task-generator] Running discovery on {kernel_path}...", file=sys.stderr)
+        try:
+            from minisweagent.tools.discovery import DiscoveryPipeline
+            repo_root = Path(args.repo_root).resolve() if args.repo_root else None
+            workspace = repo_root or kernel_path.parent
+            pipeline = DiscoveryPipeline(workspace_path=workspace)
+            discovery_result = pipeline.run(kernel_path=kernel_path)
+        except Exception as e:
+            print(f"ERROR: discovery failed: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if not discovery_result.kernels:
+        print("ERROR: no kernels found by discovery", file=sys.stderr)
+        sys.exit(1)
+
+    # Load optional inputs
+    profiling_result = None
+    if args.profiling:
+        profiling_result = json.loads(Path(args.profiling).read_text())
+
+    commandment_content = None
+    if args.commandment:
+        commandment_content = Path(args.commandment).read_text()
+
+    baseline_metrics = None
+    if args.baseline_metrics:
+        baseline_metrics = json.loads(Path(args.baseline_metrics).read_text())
+
+    # Scan previous results for iterative refinement
+    previous_results_summary = ""
+    if args.from_results:
+        results_dir = Path(args.from_results).resolve()
+        if results_dir.is_dir():
+            previous_results_summary = _scan_previous_results(results_dir)
+            if previous_results_summary:
+                print(f"[task-generator] Loaded results from {results_dir}", file=sys.stderr)
+            else:
+                print(f"[task-generator] No task results found in {results_dir}", file=sys.stderr)
+
+    # Create model (unless --no-llm)
+    model = None
+    if not args.no_llm:
+        try:
+            from minisweagent.models import get_model
+            model = get_model(args.model)
+            print(f"[task-generator] Using model: {model.config.model_name}", file=sys.stderr)
+        except Exception as e:
+            print(f"[task-generator] Could not create model ({e}); using rule-based fallback", file=sys.stderr)
+
+    # Placeholder agent class for CLI output
+    from minisweagent.agents.strategy_interactive import StrategyInteractiveAgent
+    agent_class = StrategyInteractiveAgent
+
+    base_task_context = f"Optimize the kernel at {kernel_path} for maximum performance."
+    if previous_results_summary:
+        base_task_context += f"\n\n{previous_results_summary}"
+
+    # Generate tasks
+    tasks = generate_tasks(
+        discovery_result=discovery_result,
+        base_task_context=base_task_context,
+        agent_class=agent_class,
+        model=model,
+        profiling_result=profiling_result,
+        commandment_content=commandment_content,
+        baseline_metrics=baseline_metrics,
+    )
+
+    # Print summary to stderr
+    print(f"\n[task-generator] Generated {len(tasks)} task(s):\n", file=sys.stderr)
+    for i, t in enumerate(tasks):
+        print(f"  [{t.priority:2d}] {t.label} ({t.kernel_language})", file=sys.stderr)
+
+    # Output: directory of task files or JSON to stdout
+    if args.output:
+        from minisweagent.run.task_file import write_task_file
+
+        out_dir = Path(args.output)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        manifest = []
+        for i, t in enumerate(tasks):
+            filename = f"{t.priority:02d}_{t.label}.md"
+            task_path = out_dir / filename
+
+            metadata = {
+                "label": t.label,
+                "priority": t.priority,
+                "agent_type": "openevolve" if "openevolve" in t.label else "strategy_agent",
+                "kernel_language": t.kernel_language,
+                "kernel_path": str(kernel_path),
+                "repo_root": args.repo_root,
+                "commandment": args.commandment,
+                "baseline_metrics": args.baseline_metrics,
+                "profiling": args.profiling,
+                "round": args.round,
+            }
+
+            body = f"# {t.label}\n\n{t.task}\n"
+            write_task_file(task_path, metadata, body, relative_to=out_dir)
+
+            manifest.append({
+                "index": i,
+                "label": t.label,
+                "priority": t.priority,
+                "kernel_language": t.kernel_language,
+                "file": str(task_path),
+            })
+
+        print(f"\n[task-generator] Wrote {len(tasks)} task file(s) to {out_dir}/", file=sys.stderr)
+        print(json.dumps(manifest, indent=2))
+    else:
+        output = []
+        for i, t in enumerate(tasks):
+            output.append({
+                "index": i,
+                "label": t.label,
+                "priority": t.priority,
+                "kernel_language": t.kernel_language,
+                "task_prompt_preview": t.task[:300] + ("..." if len(t.task) > 300 else ""),
+            })
+        print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/minisweagent/tools/commandment.py
+++ b/src/minisweagent/tools/commandment.py
@@ -1,0 +1,349 @@
+"""Generate and validate COMMANDMENT.md files for OpenEvolve.
+
+A COMMANDMENT.md is the evaluation contract between the agent and OpenEvolve.
+It has exactly three sections:
+  ## SETUP        -- prepare the evaluation environment
+  ## CORRECTNESS  -- verify the optimized kernel is correct
+  ## PROFILE      -- benchmark the optimized kernel
+
+This module generates a valid COMMANDMENT.md deterministically from:
+  - kernel_path: the kernel file to optimize
+  - harness_path: the test harness (must support --correctness and --profile)
+  - repo_root: the repository root (for PYTHONPATH)
+  - inner_kernel: whether the kernel is an inner kernel imported by a wrapper
+
+Generation includes a built-in validation loop: after generating, the content
+is validated using ``validate_commandment()``.  If validation fails, known
+fixable issues are auto-corrected and re-validated, up to ``max_retries``
+times.  The generator returns only fully-valid content.
+
+Usage (Python):
+    from minisweagent.tools.commandment import generate_commandment
+    content = generate_commandment(
+        kernel_path="/path/to/kernel.py",
+        harness_path="/path/to/test_harness.py",
+        repo_root="/path/to/repo",
+    )
+
+Usage (CLI):
+    python -m minisweagent.tools.commandment \\
+        --kernel-path /path/to/kernel.py \\
+        --harness /path/to/test_harness.py \\
+        --repo-root /path/to/repo \\
+        --output COMMANDMENT.md
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Import validate_commandment directly from the sibling module to avoid
+# pulling in the full minisweagent.tools package (whose __init__.py imports
+# heavy dependencies like typer via strategy_manager).
+import importlib.util as _ilu
+
+_vc_path = Path(__file__).with_name("validate_commandment.py")
+_vc_spec = _ilu.spec_from_file_location("validate_commandment", _vc_path)
+_vc_mod = _ilu.module_from_spec(_vc_spec)
+_vc_spec.loader.exec_module(_vc_mod)
+validate_commandment = _vc_mod.validate_commandment
+format_validation_message = _vc_mod.format_validation_message
+
+_MAX_FIX_RETRIES = 3
+
+
+def generate_commandment(
+    kernel_path: str | Path,
+    harness_path: str | Path,
+    repo_root: str | Path | None = None,
+    *,
+    inner_kernel: bool = False,
+    inner_kernel_relpath: str | None = None,
+    warmup_runs: int = 2,
+    profile_replays: int = 5,
+) -> str:
+    """Generate a valid COMMANDMENT.md and return its content.
+
+    Args:
+        kernel_path: Absolute path to the kernel file being optimized.
+        harness_path: Absolute path to the test harness script.  Must accept
+            ``--correctness`` and ``--profile`` flags.
+        repo_root: Repository root for PYTHONPATH.  If *None*, uses the
+            parent of *kernel_path*.
+        inner_kernel: If *True*, the kernel is an inner file imported by a
+            wrapper.  The SETUP section will create package directory
+            structure inside ``${GEAK_WORK_DIR}`` and shadow the original.
+        inner_kernel_relpath: Relative path from *repo_root* to the inner
+            kernel file (e.g. ``aiter/ops/triton/_triton_kernels/rope/rope.py``).
+            Required when *inner_kernel* is True.
+        warmup_runs: Number of warm-up invocations before profiling.
+        profile_replays: Number of replay passes for ``kernel-profile``.
+
+    Returns:
+        The content of a valid COMMANDMENT.md as a string.
+
+    Raises:
+        ValueError: If validation still fails after auto-fix retries.
+    """
+    kernel_path = Path(kernel_path).resolve()
+    harness_path = Path(harness_path).resolve()
+
+    if repo_root is not None:
+        repo_root = Path(repo_root).resolve()
+    else:
+        repo_root = kernel_path.parent
+
+    if inner_kernel and not inner_kernel_relpath:
+        try:
+            inner_kernel_relpath = str(kernel_path.relative_to(repo_root))
+        except ValueError:
+            inner_kernel_relpath = kernel_path.name
+
+    if inner_kernel:
+        content = _generate_inner_kernel(
+            kernel_path=kernel_path,
+            harness_path=harness_path,
+            repo_root=repo_root,
+            inner_kernel_relpath=inner_kernel_relpath,
+            warmup_runs=warmup_runs,
+            profile_replays=profile_replays,
+        )
+    else:
+        content = _generate_simple(
+            kernel_path=kernel_path,
+            harness_path=harness_path,
+            repo_root=repo_root,
+            warmup_runs=warmup_runs,
+            profile_replays=profile_replays,
+        )
+
+    content = _validate_and_fix(content)
+    return content
+
+
+def _generate_simple(
+    kernel_path: Path,
+    harness_path: Path,
+    repo_root: Path,
+    warmup_runs: int,
+    profile_replays: int,
+) -> str:
+    """Generate COMMANDMENT for a simple (non-inner) kernel."""
+    warmup_lines = "\n".join(
+        [f"${{GEAK_WORK_DIR}}/run.sh {harness_path} --profile > /dev/null 2>&1 || true"]
+        * warmup_runs
+    )
+
+    return f"""\
+## SETUP
+printf '#!/bin/bash\\nexport PYTHONPATH=%s:{repo_root}:${{PYTHONPATH}}\\nexport HIP_VISIBLE_DEVICES=%s\\nexec python3 "$@"\\n' "${{GEAK_WORK_DIR}}" "${{GEAK_GPU_DEVICE}}" > ${{GEAK_WORK_DIR}}/run.sh && chmod +x ${{GEAK_WORK_DIR}}/run.sh
+
+## CORRECTNESS
+${{GEAK_WORK_DIR}}/run.sh {harness_path} --correctness
+
+## PROFILE
+{warmup_lines}
+kernel-profile "${{GEAK_WORK_DIR}}/run.sh {harness_path} --profile" --gpu-devices ${{GEAK_GPU_DEVICE}} --replays {profile_replays}
+"""
+
+
+def _generate_inner_kernel(
+    kernel_path: Path,
+    harness_path: Path,
+    repo_root: Path,
+    inner_kernel_relpath: str,
+    warmup_runs: int,
+    profile_replays: int,
+) -> str:
+    """Generate COMMANDMENT for an inner kernel (imported by a wrapper).
+
+    The SETUP section creates the package directory structure inside
+    ``${GEAK_WORK_DIR}`` so the mutated candidate shadows the original.
+    """
+    rel_path = Path(inner_kernel_relpath)
+    rel_dir = rel_path.parent
+    basename = rel_path.name
+
+    # Build mkdir for the package directory
+    mkdir_path = f"${{GEAK_WORK_DIR}}/{rel_dir}"
+
+    # Build touch commands for __init__.py at each package level
+    init_paths = []
+    current = rel_dir
+    while str(current) not in (".", ""):
+        init_paths.append(f"${{GEAK_WORK_DIR}}/{current}/__init__.py")
+        current = current.parent
+    init_touch = " ".join(init_paths) if init_paths else ""
+
+    # Copy candidate to the correct import path
+    copy_cmd = f"cp ${{GEAK_WORK_DIR}}/{kernel_path.name} ${{GEAK_WORK_DIR}}/{rel_dir}/{basename}"
+
+    warmup_lines = "\n".join(
+        [f"${{GEAK_WORK_DIR}}/run_harness.sh --profile > /dev/null 2>&1 || true"]
+        * warmup_runs
+    )
+
+    setup_lines = [
+        f"mkdir -p {mkdir_path}",
+        copy_cmd,
+    ]
+    if init_touch:
+        setup_lines.append(f"touch {init_touch}")
+
+    setup_lines.append(
+        f"printf '#!/bin/bash\\nexport PYTHONPATH=%s:{repo_root}:${{PYTHONPATH}}\\n"
+        f"export HIP_VISIBLE_DEVICES=%s\\nexec python3 {harness_path} \"$@\"\\n' "
+        f"\"${{GEAK_WORK_DIR}}\" \"${{GEAK_GPU_DEVICE}}\" > ${{GEAK_WORK_DIR}}/run_harness.sh "
+        f"&& chmod +x ${{GEAK_WORK_DIR}}/run_harness.sh"
+    )
+
+    setup_block = "\n".join(setup_lines)
+
+    return f"""\
+## SETUP
+{setup_block}
+
+## CORRECTNESS
+${{GEAK_WORK_DIR}}/run_harness.sh --correctness
+
+## PROFILE
+{warmup_lines}
+kernel-profile "${{GEAK_WORK_DIR}}/run_harness.sh --profile" --gpu-devices ${{GEAK_GPU_DEVICE}} --replays {profile_replays}
+"""
+
+
+def _validate_and_fix(content: str) -> str:
+    """Validate content and attempt to auto-fix known issues.
+
+    Raises ValueError if the content cannot be made valid after retries.
+    """
+    for attempt in range(_MAX_FIX_RETRIES + 1):
+        result = validate_commandment(content)
+        if result["valid"]:
+            return content
+
+        if attempt == _MAX_FIX_RETRIES:
+            break
+
+        content = _auto_fix(content, result["errors"])
+
+    msg = format_validation_message(validate_commandment(content))
+    raise ValueError(f"COMMANDMENT.md generation failed validation after {_MAX_FIX_RETRIES} retries:\n{msg}")
+
+
+def _auto_fix(content: str, errors: list[str]) -> str:
+    """Attempt to fix known validation errors in-place."""
+    for error in errors:
+        # Fix: unknown section headers -> remove them
+        m = re.search(r"Unknown section\(s\): (.*?)\.", error)
+        if m:
+            unknown_names = re.findall(r"## (\w+)", m.group(1))
+            for name in unknown_names:
+                content = re.sub(rf"^## {re.escape(name)}\b.*$", "", content, flags=re.MULTILINE)
+
+        # Fix: shell built-in as command prefix -> wrap in bash -c
+        m = re.search(r"Command starts with shell built-in '(\w+)': '(.*?)'", error)
+        if m:
+            original_cmd = m.group(2)
+            fixed_cmd = f'bash -c "{original_cmd}"'
+            content = content.replace(original_cmd, fixed_cmd)
+
+        # Fix: inline env var prefix -> wrap in bash -c
+        m = re.search(r"Command uses inline env var prefix '(\w+=\S+)' .* '(.*?)'", error)
+        if m:
+            original_cmd = m.group(2)
+            fixed_cmd = f'bash -c "{original_cmd}"'
+            content = content.replace(original_cmd, fixed_cmd)
+
+    return content
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _extract_harness_from_command(command: str) -> str | None:
+    """Extract the .py script path from a test command like 'python /path/to/test.py -v'."""
+    import shlex
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    for token in tokens:
+        if token.endswith(".py"):
+            return token
+    return None
+
+
+def main():
+    import argparse
+    import json
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Generate a valid COMMANDMENT.md for OpenEvolve",
+    )
+    parser.add_argument("--kernel-path", default=None, help="Path to the kernel file")
+    parser.add_argument("--harness", default=None, help="Path to the test harness script")
+    parser.add_argument("--repo-root", default=None, help="Repository root for PYTHONPATH (default: kernel parent dir)")
+    parser.add_argument(
+        "--from-discovery", default=None, metavar="FILE",
+        help="Read discovery.json and extract kernel-path, harness, and repo-root",
+    )
+    parser.add_argument("--inner-kernel", action="store_true", help="Kernel is an inner file imported by a wrapper")
+    parser.add_argument("--inner-kernel-relpath", default=None, help="Relative path from repo-root to inner kernel")
+    parser.add_argument("--warmup-runs", type=int, default=2, help="Warm-up runs before profiling (default: 2)")
+    parser.add_argument("--profile-replays", type=int, default=5, help="Profiling replay count (default: 5)")
+    parser.add_argument("-o", "--output", default=None, help="Output file path (default: stdout)")
+
+    args = parser.parse_args()
+
+    # Populate from discovery JSON if provided (explicit flags override)
+    if args.from_discovery:
+        disc = json.loads(Path(args.from_discovery).read_text())
+        if not args.kernel_path:
+            args.kernel_path = (disc.get("kernel") or {}).get("file")
+        if not args.repo_root:
+            args.repo_root = disc.get("workspace")
+        if not args.harness:
+            focused = disc.get("focused_test") or {}
+            args.harness = focused.get("focused_test_file")
+            if not args.harness:
+                tests = disc.get("tests") or []
+                if tests:
+                    args.harness = _extract_harness_from_command(tests[0].get("command", ""))
+
+    if not args.kernel_path:
+        parser.error("--kernel-path is required (or provide --from-discovery)")
+    if not args.harness:
+        parser.error("--harness is required (or provide --from-discovery)")
+
+    try:
+        content = generate_commandment(
+            kernel_path=args.kernel_path,
+            harness_path=args.harness,
+            repo_root=args.repo_root,
+            inner_kernel=args.inner_kernel,
+            inner_kernel_relpath=args.inner_kernel_relpath,
+            warmup_runs=args.warmup_runs,
+            profile_replays=args.profile_replays,
+        )
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.write_text(content)
+        print(f"Wrote {out_path}", file=sys.stderr)
+
+        # Print validation summary to stderr
+        result = validate_commandment(content)
+        print(format_validation_message(result), file=sys.stderr)
+    else:
+        print(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/minisweagent/tools/resolve_kernel_url_impl.py
+++ b/src/minisweagent/tools/resolve_kernel_url_impl.py
@@ -214,3 +214,62 @@ def cleanup_resolved_path(local_repo_path: str | None) -> None:
             shutil.rmtree(path, ignore_errors=True)
         except OSError:
             pass
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+def main():
+    """Resolve a GitHub kernel URL to a local file path."""
+    import argparse
+    import json
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Clone a GitHub repo and resolve a kernel URL to a local path",
+    )
+    parser.add_argument("url", help="GitHub file URL (blob link)")
+    parser.add_argument(
+        "--json", action="store_true", dest="output_json",
+        help="Output result as JSON (for piping to test-discovery --from-resolved)",
+    )
+    parser.add_argument(
+        "-o", "--output", default=None,
+        help="Write output to file instead of stdout (implies --json)",
+    )
+    args = parser.parse_args()
+
+    use_json = args.output_json or args.output is not None
+
+    print(f"Resolving: {args.url}", file=sys.stderr)
+    result = resolve_kernel_url(args.url)
+
+    if result.get("error"):
+        print(f"ERROR: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
+    if use_json:
+        output_text = json.dumps(result, indent=2)
+        if args.output:
+            Path(args.output).write_text(output_text + "\n")
+            print(f"Wrote {args.output}", file=sys.stderr)
+        else:
+            print(output_text)
+    else:
+        local_path = result["local_file_path"]
+        line = result.get("line_number")
+        repo_root = result.get("local_repo_path")
+
+        print(f"Local path:  {local_path}")
+        if repo_root:
+            print(f"Repo root:   {repo_root}")
+        if line:
+            print(f"Line number: {line}")
+            name = get_kernel_name_at_line(local_path, line)
+            if name:
+                print(f"Kernel name: {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/minisweagent/tools/validate_commandment.py
+++ b/src/minisweagent/tools/validate_commandment.py
@@ -162,3 +162,41 @@ def format_validation_message(result: dict) -> str:
             parts.append(f"  WARNING: {warn}")
 
     return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    """Validate one or more COMMANDMENT.md files from the command line."""
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python -m minisweagent.tools.validate_commandment <file> [<file> ...]", file=sys.stderr)
+        sys.exit(2)
+
+    any_invalid = False
+    for path_str in sys.argv[1:]:
+        from pathlib import Path
+
+        path = Path(path_str)
+        if not path.is_file():
+            print(f"ERROR: {path_str}: file not found", file=sys.stderr)
+            any_invalid = True
+            continue
+
+        content = path.read_text()
+        result = validate_commandment(content)
+        message = format_validation_message(result)
+        print(f"--- {path_str} ---")
+        print(message)
+
+        if not result["valid"]:
+            any_invalid = True
+
+    sys.exit(1 if any_invalid else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run/test_task_generator.py
+++ b/tests/run/test_task_generator.py
@@ -1,0 +1,180 @@
+"""Tests for the LLM-assisted task generator with rule-based fallback."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from minisweagent.agents.agent_spec import AgentTask
+from minisweagent.run.task_generator import generate_tasks, _parse_llm_response
+from minisweagent.tools.discovery import DiscoveryResult, KernelInfo
+
+
+class FakeAgentClass:
+    """Stand-in for an agent class in tests."""
+    pass
+
+
+def _make_discovery(
+    kernel_type: str = "triton",
+    inner_kernel_path: Path | None = None,
+) -> DiscoveryResult:
+    kernel = KernelInfo(
+        file_path=Path("/workspace/kernel.py"),
+        kernel_name="test_kernel",
+        kernel_type=kernel_type,
+        kernel_language="python",
+        function_names=["kernel_fwd"],
+        has_jit_decorator=True,
+        inner_kernel_path=inner_kernel_path,
+    )
+    return DiscoveryResult(kernels=[kernel])
+
+
+# ---- Fallback: model=None -> rule-based ----
+
+def test_no_model_falls_back_to_rule_based():
+    dr = _make_discovery("triton", inner_kernel_path=Path("/ws/inner.py"))
+    tasks = generate_tasks(
+        discovery_result=dr,
+        base_task_context="ctx",
+        agent_class=FakeAgentClass,
+        model=None,
+    )
+    labels = [t.label for t in tasks]
+    assert "openevolve-inner" in labels
+    assert "triton-autotune" in labels
+    assert "profile-guided" in labels
+
+
+# ---- Fallback: LLM raises exception -> rule-based ----
+
+def test_llm_exception_falls_back():
+    mock_model = MagicMock()
+    mock_model.query.side_effect = RuntimeError("API error")
+    dr = _make_discovery("triton")
+    tasks = generate_tasks(
+        discovery_result=dr,
+        base_task_context="ctx",
+        agent_class=FakeAgentClass,
+        model=mock_model,
+    )
+    labels = [t.label for t in tasks]
+    assert "profile-guided" in labels
+
+
+# ---- Fallback: LLM returns garbage -> rule-based ----
+
+def test_llm_garbage_falls_back():
+    mock_model = MagicMock()
+    mock_model.query.return_value = {"content": "This is not JSON at all"}
+    dr = _make_discovery("hip")
+    tasks = generate_tasks(
+        discovery_result=dr,
+        base_task_context="ctx",
+        agent_class=FakeAgentClass,
+        model=mock_model,
+    )
+    labels = [t.label for t in tasks]
+    assert "hip-launch-config" in labels
+
+
+# ---- Fallback: LLM returns empty array -> rule-based ----
+
+def test_llm_empty_array_falls_back():
+    mock_model = MagicMock()
+    mock_model.query.return_value = {"content": "[]"}
+    dr = _make_discovery("triton")
+    tasks = generate_tasks(
+        discovery_result=dr,
+        base_task_context="ctx",
+        agent_class=FakeAgentClass,
+        model=mock_model,
+    )
+    labels = [t.label for t in tasks]
+    assert "profile-guided" in labels
+
+
+# ---- Success: LLM returns valid JSON ----
+
+def test_llm_valid_response_produces_tasks():
+    mock_model = MagicMock()
+    mock_model.query.return_value = {"content": """[
+        {
+            "label": "evolve-inner",
+            "priority": 0,
+            "agent_type": "openevolve",
+            "kernel_language": "python",
+            "task_prompt": "Run OpenEvolve on /ws/inner.py"
+        },
+        {
+            "label": "mem-opt",
+            "priority": 10,
+            "agent_type": "strategy_agent",
+            "kernel_language": "python",
+            "task_prompt": "Optimize memory patterns"
+        }
+    ]"""}
+    dr = _make_discovery("triton")
+    tasks = generate_tasks(
+        discovery_result=dr,
+        base_task_context="ctx",
+        agent_class=FakeAgentClass,
+        model=mock_model,
+    )
+    assert len(tasks) == 2
+    assert tasks[0].label == "evolve-inner"
+    assert tasks[0].priority == 0
+    assert tasks[1].label == "mem-opt"
+
+
+# ---- LLM wraps JSON in code fences -> still parsed ----
+
+def test_llm_code_fenced_json_parsed():
+    mock_model = MagicMock()
+    mock_model.query.return_value = {"content": """```json
+[{"label": "opt-1", "priority": 5, "agent_type": "strategy_agent", "kernel_language": "python", "task_prompt": "Do something"}]
+```"""}
+    dr = _make_discovery("triton")
+    tasks = generate_tasks(
+        discovery_result=dr,
+        base_task_context="ctx",
+        agent_class=FakeAgentClass,
+        model=mock_model,
+    )
+    assert len(tasks) == 1
+    assert tasks[0].label == "opt-1"
+
+
+# ---- _parse_llm_response edge cases ----
+
+def test_parse_rejects_non_array():
+    with pytest.raises(TypeError, match="Expected JSON array"):
+        _parse_llm_response('{"not": "array"}', FakeAgentClass, "ctx")
+
+
+def test_parse_rejects_empty_task_prompt():
+    # Tasks with empty task_prompt are skipped; if all are empty -> ValueError
+    with pytest.raises(ValueError, match="no valid tasks"):
+        _parse_llm_response(
+            '[{"label": "x", "priority": 5, "task_prompt": ""}]',
+            FakeAgentClass,
+            "ctx",
+        )
+
+
+def test_parse_clamps_priority():
+    tasks = _parse_llm_response(
+        '[{"label": "x", "priority": 99, "task_prompt": "Do it"}]',
+        FakeAgentClass,
+        "ctx",
+    )
+    assert tasks[0].priority == 15  # clamped to max
+
+
+# ---- No kernels -> empty ----
+
+def test_no_kernels_returns_empty():
+    dr = DiscoveryResult()
+    tasks = generate_tasks(dr, "ctx", FakeAgentClass, model=MagicMock())
+    assert tasks == []


### PR DESCRIPTION
Make every optimization pipeline step independently callable from the CLI with chainable --from-* flags and -o output options:

New modules:
- task_file.py: shared YAML-frontmatter task file I/O + git worktree helpers (extracted from ParallelAgent to eliminate duplication)
- task_generator.py: LLM-assisted task generation with -o DIR for Markdown task files, --from-results for iterative round-over-round refinement
- commandment.py: programmatic COMMANDMENT.md generation with built-in validation loop

CLI enhancements:
- openevolve-worker --from-task: reads task .md, auto-creates worktree
- geak --from-task: reads task .md, populates --task/--repo, auto-worktree
- All pipeline CLIs support --from-discovery/--from-resolved/--from-profile for seamless chaining via intermediate JSON files
- resolve-kernel-url --json/-o, test-discovery --from-resolved/-o, kernel-profile --from-discovery/--json/-o, baseline-metrics --from-profile

Infrastructure:
- pyproject.toml: new entry points for all modular CLI tools
- entrypoint.sh: health checks for new tools
- scripts/run-docker.sh: updated docs with full pipeline, iterative refinement, and --from-task examples
- tests/run/test_task_generator.py: unit tests for LLM fallback logic