### PR TITLE
Fix erroneus entrypoint.sh bash script declaration

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,5 @@
-# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved. Portions of this file consist of AI-generated content.
-
 #!/bin/bash
+# Copyright(C) [2026] Advanced Micro Devices, Inc. All rights reserved. Portions of this file consist of AI-generated content.
 # GEAK-agent container entrypoint
 # Sets up configuration and runs health checks
 


### PR DESCRIPTION
The script/run_docker.sh tool fails, because the entrypoint.sh has the copyright notice above the bash script declaration.