### PR TITLE
Fix MCP subprocess PYTHONPATH in containerized environments

### DIFF
--- a/src/minisweagent/tools/mcp_bridge.py
+++ b/src/minisweagent/tools/mcp_bridge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import logging
+import os
 import sys
 import threading
 from pathlib import Path
@@ -179,10 +180,16 @@ class MCPToolBridge:
         module_name = server_name.replace("-", "_")
         src_dir = mcp_dir / "src"
 
+        # Include parent process site-packages so subprocesses can find
+        # transitive deps (e.g. cachetools for fastmcp) even when
+        # --system-site-packages doesn't propagate (Singularity/Apptainer).
+        site_pkgs = [p for p in sys.path if "site-packages" in p]
+        pythonpath = os.pathsep.join([str(src_dir)] + site_pkgs)
+
         return {
             "command": ["python3", "-m", f"{module_name}.server"],
             "cwd": str(mcp_dir),
-            "env": {"PYTHONPATH": str(src_dir)},
+            "env": {"PYTHONPATH": pythonpath},
         }
 
 


### PR DESCRIPTION
 Include parent process site-packages in MCP subprocess PYTHONPATH.
 Fixes ImportError for transitive dependencies (e.g. cachetools) when running inside Singularity/Apptainer with --system-site-packages venvs.

This has been tested and confirmed to work with venv in Singularity containers on LUMI cluster + in docker on a Vultr cluster. Previous version only works on the latter.
