### PR TITLE
Add notebook-backed working state and deterministic rerun hardening

### DIFF
--- a/src/minisweagent/agents/unit_test_agent.py
+++ b/src/minisweagent/agents/unit_test_agent.py
@@ -197,6 +197,8 @@ def run_unit_test_agent(
     repo: Path,
     kernel_name: str,
     log_dir: Path | None = None,
+    preferred_harness_path: Path | None = None,
+    kernel_path: Path | None = None,
     discovery_context: str = "",
 ) -> str:
     """Run UnitTestAgent in ``repo`` and return the extracted test command string.
@@ -219,6 +221,27 @@ def run_unit_test_agent(
         f"IMPORTANT: Read INSTRUCTIONS.md in the repository for test harness requirements\n"
         f"and COMMANDMENT format rules before creating the harness."
     )
+    if preferred_harness_path is not None:
+        task += (
+            f"\n\nWrite the harness to this exact path: {preferred_harness_path}"
+            "\nDo NOT place the final harness next to the kernel source file."
+            "\nReturn TEST_COMMAND using this exact harness path."
+        )
+    if kernel_path is not None:
+        kernel_dir = kernel_path.resolve().parent
+        try:
+            rel_kernel_dir = kernel_dir.relative_to(repo.resolve())
+        except ValueError:
+            rel_kernel_dir = None
+        task += (
+            f"\n\nTarget kernel file: {kernel_path.resolve()}"
+            "\nThe harness must remain runnable even when it is outside the kernel directory."
+            "\nDo NOT rely on __file__ being in the same directory as kernel.py."
+            "\nResolve imports by preferring GEAK_WORK_DIR when available, then "
+            "GEAK_REPO_ROOT plus the kernel's repo-relative directory, then the original kernel directory."
+        )
+        if rel_kernel_dir is not None:
+            task += f"\nKernel repo-relative directory: {rel_kernel_dir.as_posix()}"
     if discovery_context:
         task += f"\n\n{discovery_context}"
 

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -642,6 +642,7 @@ def main(
             repo=repo,
             kernel_name=kernel_name or "unknown",
             log_dir=patch_output,
+            kernel_path=Path(_resolved_kernel_path) if _resolved_kernel_path else None,
             discovery_context=discovery_context,
             gpu_id=parsed_gpu_ids[0] if parsed_gpu_ids else 0,
         )

--- a/src/minisweagent/run/pipeline_helpers.py
+++ b/src/minisweagent/run/pipeline_helpers.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import sys
 from pathlib import Path
 from typing import Any
@@ -159,6 +160,136 @@ def extract_harness_path(test_command: str) -> str:
     return tokens[-1] if tokens else test_command
 
 
+def _preferred_harness_path(log_dir: Path, kernel_path: Path | None) -> Path:
+    if kernel_path is not None:
+        stem = kernel_path.stem or "kernel"
+        return log_dir / f"test_{stem}_harness.py"
+    return log_dir / "geak_test_harness.py"
+
+
+def _materialized_harness_bootstrap(
+    *,
+    repo_root: Path,
+    kernel_path: Path | None,
+) -> str:
+    kernel_dir = kernel_path.resolve().parent if kernel_path is not None else None
+    rel_kernel_dir: Path | None = None
+    if kernel_dir is not None:
+        try:
+            rel_kernel_dir = kernel_dir.relative_to(repo_root.resolve())
+        except ValueError:
+            rel_kernel_dir = None
+
+    rel_kernel_dir_text = str(rel_kernel_dir).replace("\\", "/") if rel_kernel_dir is not None else ""
+    original_kernel_dir = str(kernel_dir) if kernel_dir is not None else ""
+    return (
+        "# GEAK materialized harness bootstrap\n"
+        "def _resolve_geak_kernel_dir():\n"
+        "    candidates = []\n"
+        "    work_dir = os.environ.get(\"GEAK_WORK_DIR\", \"\").strip()\n"
+        "    if work_dir:\n"
+        "        candidates.append(work_dir)\n"
+        "    repo_root = os.environ.get(\"GEAK_REPO_ROOT\", \"\").strip()\n"
+        f"    rel_kernel_dir = {rel_kernel_dir_text!r}\n"
+        "    if repo_root and rel_kernel_dir:\n"
+        "        candidates.append(os.path.join(repo_root, rel_kernel_dir))\n"
+        f"    original_kernel_dir = {original_kernel_dir!r}\n"
+        "    if original_kernel_dir:\n"
+        "        candidates.append(original_kernel_dir)\n"
+        "    for candidate in candidates:\n"
+        "        if candidate and os.path.isfile(os.path.join(candidate, \"kernel.py\")):\n"
+        "            return candidate\n"
+        "    return original_kernel_dir or os.getcwd()\n"
+        "\n"
+        "_KERNEL_DIR = _resolve_geak_kernel_dir()\n"
+        "if _KERNEL_DIR not in sys.path:\n"
+        "    sys.path.insert(0, _KERNEL_DIR)\n"
+    )
+
+
+def _rewrite_materialized_harness_source(
+    source_text: str,
+    *,
+    repo_root: Path,
+    kernel_path: Path | None,
+) -> str:
+    bootstrap = _materialized_harness_bootstrap(
+        repo_root=repo_root,
+        kernel_path=kernel_path,
+    )
+    legacy_patterns = [
+        re.compile(
+            r"(?ms)^# Ensure the kernel directory is importable\n"
+            r"_KERNEL_DIR = os\.path\.dirname\(os\.path\.abspath\(__file__\)\)\n"
+            r"if _KERNEL_DIR not in sys\.path:\n"
+            r"\s+sys\.path\.insert\(0, _KERNEL_DIR\)\n"
+        ),
+        re.compile(
+            r"(?ms)^_KERNEL_DIR = os\.path\.dirname\(os\.path\.abspath\(__file__\)\)\n"
+            r"if _KERNEL_DIR not in sys\.path:\n"
+            r"\s+sys\.path\.insert\(0, _KERNEL_DIR\)\n"
+        ),
+    ]
+    for pattern in legacy_patterns:
+        if pattern.search(source_text):
+            return pattern.sub(bootstrap, source_text, count=1)
+
+    import_block = re.compile(
+        r"(?ms)\A((?:from __future__ import annotations\n)?(?:import .+\n|from .+ import .+\n)+)"
+    )
+    match = import_block.match(source_text)
+    if match:
+        return source_text[: match.end()] + "\n" + bootstrap + source_text[match.end():]
+    return bootstrap + "\n" + source_text
+
+
+def _materialize_validated_harness(
+    *,
+    test_command: str,
+    harness_path: str,
+    repo_root: Path,
+    log_dir: Path | None,
+    kernel_path: Path | None,
+    gpu_id: int,
+) -> tuple[str, str, list[dict[str, Any]]] | None:
+    if log_dir is None:
+        return None
+
+    source_harness = Path(harness_path).resolve()
+    target_dir = log_dir.resolve()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_harness = _preferred_harness_path(target_dir, kernel_path)
+    if source_harness == target_harness:
+        return None
+
+    rewritten_text = _rewrite_materialized_harness_source(
+        source_harness.read_text(),
+        repo_root=repo_root,
+        kernel_path=kernel_path,
+    )
+    target_harness.write_text(rewritten_text)
+    shutil.copymode(source_harness, target_harness)
+
+    materialized_command = test_command.replace(str(source_harness), str(target_harness))
+    valid, static_errors = validate_harness(str(target_harness))
+    if not valid:
+        raise RuntimeError(
+            "Materialized harness static validation failed: " + "; ".join(static_errors)
+        )
+
+    exec_ok, exec_errors, harness_results = execute_harness_validation(
+        str(target_harness),
+        repo_root=str(repo_root),
+        gpu_id=gpu_id,
+    )
+    if not exec_ok:
+        raise RuntimeError(
+            "Materialized harness runtime validation failed: "
+            + "; ".join(e.splitlines()[0] for e in exec_errors)
+        )
+    return materialized_command, str(target_harness), harness_results
+
+
 # ── harness validation ───────────────────────────────────────────────
 
 
@@ -289,6 +420,7 @@ def create_validated_harness(
     repo: Path,
     kernel_name: str,
     log_dir: Path | None,
+    kernel_path: Path | None,
     discovery_context: str,
     max_retries: int = MAX_HARNESS_RETRIES,
     gpu_id: int = 0,
@@ -334,6 +466,8 @@ def create_validated_harness(
             repo=repo,
             kernel_name=kernel_name,
             log_dir=log_dir,
+            preferred_harness_path=_preferred_harness_path(log_dir, kernel_path) if log_dir else None,
+            kernel_path=kernel_path,
             discovery_context=ctx,
         )
         logger.info("UnitTestAgent test_command (attempt %d): %s", attempt, test_command)
@@ -364,6 +498,31 @@ def create_validated_harness(
             harness, repo_root=repo_root, gpu_id=gpu_id,
         )
         if exec_ok:
+            try:
+                materialized = _materialize_validated_harness(
+                    test_command=test_command,
+                    harness_path=harness,
+                    repo_root=repo,
+                    log_dir=log_dir,
+                    kernel_path=kernel_path,
+                    gpu_id=gpu_id,
+                )
+            except Exception as exc:
+                harness_errors = [str(exc)]
+                logger.warning(
+                    "Harness materialization failed (attempt %d/%d): %s",
+                    attempt,
+                    max_attempts,
+                    harness_errors,
+                )
+                if attempt == max_attempts:
+                    raise RuntimeError(
+                        f"Harness materialization failed after {max_attempts} attempts: {exc}"
+                    )
+                continue
+            if materialized is not None:
+                test_command, harness, harness_results = materialized
+                logger.info("Materialized harness to %s", harness)
             logger.info("Harness runtime validation: ALL MODES PASSED")
             return test_command, harness_results
 

--- a/src/minisweagent/run/preprocessor.py
+++ b/src/minisweagent/run/preprocessor.py
@@ -38,6 +38,7 @@ def _ensure_mcp_importable() -> None:
 
 from minisweagent.run.pipeline_helpers import (
     DEFAULT_EVAL_BENCHMARK_ITERATIONS,
+    _materialize_validated_harness,
     create_validated_harness,
     execute_harness_validation,
     extract_harness_path,
@@ -200,6 +201,29 @@ def _build_harness_candidates(
     for _rank, _index, cmd, harness_path, source in sorted(ranked_discovery, key=lambda item: (item[0], item[1])):
         candidates.append((cmd, harness_path, source))
     return candidates
+
+
+def _materialize_preprocessor_harness(
+    *,
+    test_command: str,
+    harness_path: str,
+    repo_root: str | Path,
+    output_dir: Path,
+    kernel_path: str | Path,
+    gpu_id: int,
+    harness_results: list[dict[str, Any]],
+) -> tuple[str, str, list[dict[str, Any]]]:
+    materialized = _materialize_validated_harness(
+        test_command=test_command,
+        harness_path=harness_path,
+        repo_root=Path(repo_root),
+        log_dir=output_dir,
+        kernel_path=Path(kernel_path),
+        gpu_id=gpu_id,
+    )
+    if materialized is not None:
+        return materialized
+    return test_command, harness_path, harness_results
 
 
 def run_preprocessor(
@@ -401,6 +425,15 @@ def run_preprocessor(
                             gpu_id=gpu_id,
                         )
                         if ok_runtime:
+                            candidate_cmd, candidate_harness, candidate_results = _materialize_preprocessor_harness(
+                                test_command=candidate_cmd,
+                                harness_path=candidate_harness,
+                                repo_root=repo_root,
+                                output_dir=output_dir,
+                                kernel_path=kernel_path,
+                                gpu_id=gpu_id,
+                                harness_results=candidate_results,
+                            )
                             test_command = candidate_cmd
                             harness_results = candidate_results
                             ctx["harness_path"] = candidate_harness
@@ -435,6 +468,15 @@ def run_preprocessor(
                 if not ok_runtime:
                     continue
 
+                candidate_cmd, candidate_harness, candidate_results = _materialize_preprocessor_harness(
+                    test_command=candidate_cmd,
+                    harness_path=candidate_harness,
+                    repo_root=repo_root,
+                    output_dir=output_dir,
+                    kernel_path=kernel_path,
+                    gpu_id=gpu_id,
+                    harness_results=candidate_results,
+                )
                 test_command = candidate_cmd
                 harness_results = candidate_results
                 ctx["harness_path"] = candidate_harness
@@ -508,6 +550,7 @@ def run_preprocessor(
                 repo=Path(repo_root),
                 kernel_name=kernel_name,
                 log_dir=output_dir,
+                kernel_path=Path(kernel_path),
                 discovery_context=discovery_context,
                 gpu_id=gpu_id,
             )

--- a/tests/run/test_pipeline_helpers.py
+++ b/tests/run/test_pipeline_helpers.py
@@ -1,6 +1,14 @@
 """Tests for workload-aware prompt guidance in pipeline helpers."""
 
-from minisweagent.run.pipeline_helpers import _bottleneck_guidance
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from minisweagent.run.pipeline_helpers import (
+    _bottleneck_guidance,
+    create_validated_harness,
+)
 
 
 def test_bottleneck_guidance_adds_search_specific_hip_hints() -> None:
@@ -25,3 +33,92 @@ def test_bottleneck_guidance_adds_search_specific_hip_hints() -> None:
     assert "Workload Guidance (HIP search / pointer-chasing)" in text
     assert "branchless search logic" in text
     assert "Deprioritize generic vectorization" in text
+
+
+def _demo_harness_results() -> list[dict[str, object]]:
+    return [
+        {"mode": "correctness", "success": True, "returncode": 0, "duration_s": 0.1, "stdout": "ALL PASS\n"},
+        {"mode": "profile", "success": True, "returncode": 0, "duration_s": 0.1, "stdout": "PROFILE OK\n"},
+        {"mode": "benchmark", "success": True, "returncode": 0, "duration_s": 0.1, "stdout": "GEAK_RESULT_LATENCY_MS=1.0\n"},
+        {"mode": "full-benchmark", "success": True, "returncode": 0, "duration_s": 0.1, "stdout": "GEAK_RESULT_LATENCY_MS=1.0\n"},
+    ]
+
+
+def test_create_validated_harness_materializes_harness_into_log_dir(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    task_dir = repo_root / "tasks" / "demo"
+    task_dir.mkdir(parents=True)
+    kernel_path = task_dir / "kernel.py"
+    kernel_path.write_text("def kernel():\n    return 1\n")
+
+    source_harness = task_dir / "test_demo_harness.py"
+    source_harness.write_text(
+        "\n".join(
+            [
+                "import argparse",
+                "import os",
+                "import sys",
+                "",
+                "# Ensure the kernel directory is importable",
+                "_KERNEL_DIR = os.path.dirname(os.path.abspath(__file__))",
+                "if _KERNEL_DIR not in sys.path:",
+                "    sys.path.insert(0, _KERNEL_DIR)",
+                "",
+                "from kernel import kernel",
+                "",
+                "def main():",
+                "    parser = argparse.ArgumentParser()",
+                "    parser.add_argument('--correctness', action='store_true')",
+                "    parser.add_argument('--profile', action='store_true')",
+                "    parser.add_argument('--benchmark', action='store_true')",
+                "    parser.add_argument('--full-benchmark', action='store_true')",
+                "    parser.add_argument('--iterations', type=int, default=1)",
+                "    parser.parse_args()",
+                "",
+                "if __name__ == '__main__':",
+                "    main()",
+            ]
+        )
+        + "\n"
+    )
+
+    output_dir = tmp_path / "output"
+    seen_harnesses: list[str] = []
+
+    def _fake_execute(harness_path: str, **kwargs):
+        seen_harnesses.append(harness_path)
+        return True, [], _demo_harness_results()
+
+    with (
+        patch(
+            "minisweagent.agents.unit_test_agent.run_unit_test_agent",
+            return_value=f"python {source_harness} --correctness && python {source_harness} --benchmark",
+        ),
+        patch(
+            "minisweagent.run.pipeline_helpers.execute_harness_validation",
+            side_effect=_fake_execute,
+        ),
+    ):
+        test_command, harness_results = create_validated_harness(
+            model=object(),
+            repo=repo_root,
+            kernel_name="kernel",
+            log_dir=output_dir,
+            kernel_path=kernel_path,
+            discovery_context="",
+            gpu_id=0,
+        )
+
+    materialized_harness = output_dir / "test_kernel_harness.py"
+    assert harness_results == _demo_harness_results()
+    assert materialized_harness.is_file()
+    assert str(materialized_harness) in test_command
+    assert str(source_harness) not in test_command
+    assert str(source_harness) in seen_harnesses[0]
+    assert str(materialized_harness) in seen_harnesses[-1]
+
+    text = materialized_harness.read_text()
+    assert "GEAK materialized harness bootstrap" in text
+    assert "GEAK_WORK_DIR" in text
+    assert "GEAK_REPO_ROOT" in text
+    assert "os.path.dirname(os.path.abspath(__file__))" not in text

--- a/tests/run/test_preprocessor_deterministic.py
+++ b/tests/run/test_preprocessor_deterministic.py
@@ -70,6 +70,7 @@ def test_run_preprocessor_uses_explicit_deterministic_harness(tmp_path, monkeypa
     _write_demo_harness(harness_path)
 
     output_dir = tmp_path / "output"
+    output_dir.mkdir()
 
     fake_pkg = types.ModuleType("automated_test_discovery")
     fake_server = types.ModuleType("automated_test_discovery.server")
@@ -153,6 +154,7 @@ def test_run_preprocessor_accepts_local_deterministic_harness_path(tmp_path, mon
     _write_demo_harness(harness_path)
 
     output_dir = tmp_path / "output"
+    output_dir.mkdir()
 
     fake_pkg = types.ModuleType("automated_test_discovery")
     fake_server = types.ModuleType("automated_test_discovery.server")
@@ -163,6 +165,8 @@ def test_run_preprocessor_accepts_local_deterministic_harness_path(tmp_path, mon
     fake_server.discover = _discover
     monkeypatch.setitem(sys.modules, "automated_test_discovery", fake_pkg)
     monkeypatch.setitem(sys.modules, "automated_test_discovery.server", fake_server)
+    materialized_harness = output_dir / "test_kernel_harness.py"
+    materialized_harness.write_text("# materialized harness\n")
 
     with (
         patch("minisweagent.run.preprocessor._ensure_mcp_importable", return_value=None),
@@ -240,6 +244,8 @@ def test_run_preprocessor_prefers_focused_harness_when_top_test_is_irrelevant(tm
     fake_server.discover = _discover
     monkeypatch.setitem(sys.modules, "automated_test_discovery", fake_pkg)
     monkeypatch.setitem(sys.modules, "automated_test_discovery.server", fake_server)
+    materialized_harness = output_dir / "test_kernel_harness.py"
+    materialized_harness.write_text("# materialized harness\n")
 
     with (
         patch("minisweagent.run.preprocessor._ensure_mcp_importable", return_value=None),
@@ -260,6 +266,14 @@ def test_run_preprocessor_prefers_focused_harness_when_top_test_is_irrelevant(tm
         patch(
             "minisweagent.run.preprocessor.execute_harness_validation",
             side_effect=lambda harness_path, **kwargs: (True, [], _demo_harness_results()),
+        ),
+        patch(
+            "minisweagent.run.preprocessor._materialize_preprocessor_harness",
+            side_effect=lambda **kwargs: (
+                kwargs["test_command"],
+                kwargs["harness_path"],
+                kwargs["harness_results"],
+            ),
         ),
         patch("minisweagent.run.preprocessor.create_validated_harness", side_effect=AssertionError("UnitTestAgent should be skipped")),
         patch("minisweagent.run.preprocessor.run_baseline_profile", return_value=None),
@@ -317,6 +331,8 @@ def test_run_preprocessor_skips_generic_cached_harness_when_top_test_is_irreleva
     fake_server.discover = _discover
     monkeypatch.setitem(sys.modules, "automated_test_discovery", fake_pkg)
     monkeypatch.setitem(sys.modules, "automated_test_discovery.server", fake_server)
+    materialized_harness = output_dir / "test_kernel_harness.py"
+    materialized_harness.write_text("# materialized harness\n")
 
     with (
         patch("minisweagent.run.preprocessor._ensure_mcp_importable", return_value=None),
@@ -345,6 +361,14 @@ def test_run_preprocessor_skips_generic_cached_harness_when_top_test_is_irreleva
         patch(
             "minisweagent.run.preprocessor.execute_harness_validation",
             side_effect=lambda harness_path, **kwargs: (True, [], _demo_harness_results()),
+        ),
+        patch(
+            "minisweagent.run.preprocessor._materialize_preprocessor_harness",
+            side_effect=lambda **kwargs: (
+                kwargs["test_command"],
+                kwargs["harness_path"],
+                kwargs["harness_results"],
+            ),
         ),
         patch("minisweagent.run.preprocessor.create_validated_harness", side_effect=AssertionError("UnitTestAgent should be skipped")),
         patch("minisweagent.run.preprocessor.run_baseline_profile", return_value=None),
@@ -378,6 +402,7 @@ def test_run_preprocessor_uses_unit_test_agent_when_irrelevant_top_test_has_no_v
     _write_demo_harness(repo_harness)
 
     output_dir = tmp_path / "output"
+    output_dir.mkdir()
     focused_harness = output_dir / "test_demo_focused.py"
     focused_harness.parent.mkdir(parents=True, exist_ok=True)
     focused_harness.write_text("print('not a four-mode harness')\n")
@@ -445,3 +470,77 @@ def test_run_preprocessor_uses_unit_test_agent_when_irrelevant_top_test_has_no_v
     assert create_harness.called
     assert ctx["harness_path"] == str(generated_harness.resolve())
     assert ctx["testcase_selection"]["selected_source"] == "unit_test_agent"
+
+
+def test_run_preprocessor_materializes_discovery_harness_into_output_dir(tmp_path, monkeypatch) -> None:
+    repo_root = tmp_path / "repo"
+    task_dir = repo_root / "tasks" / "demo"
+    task_dir.mkdir(parents=True)
+    kernel_path = task_dir / "kernel.py"
+    harness_path = task_dir / "test_demo_harness.py"
+    kernel_path.write_text("def kernel():\n    return 1\n")
+    _write_demo_harness(harness_path)
+
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    materialized_harness = output_dir / "test_kernel_harness.py"
+    materialized_harness.write_text("# materialized harness\n")
+
+    fake_pkg = types.ModuleType("automated_test_discovery")
+    fake_server = types.ModuleType("automated_test_discovery.server")
+
+    def _discover(*, kernel_path: str, output_dir: str):
+        return {
+            "tests": [
+                {
+                    "file": str(harness_path),
+                    "command": f"python {harness_path}",
+                }
+            ],
+            "kernel": {"type": "python"},
+        }
+
+    fake_server.discover = _discover
+    monkeypatch.setitem(sys.modules, "automated_test_discovery", fake_pkg)
+    monkeypatch.setitem(sys.modules, "automated_test_discovery.server", fake_server)
+
+    with (
+        patch("minisweagent.run.preprocessor._ensure_mcp_importable", return_value=None),
+        patch(
+            "minisweagent.tools.resolve_kernel_url_impl.resolve_kernel_url",
+            return_value={
+                "error": None,
+                "local_repo_path": str(repo_root),
+                "local_file_path": str(kernel_path),
+            },
+        ),
+        patch(
+            "minisweagent.run.codebase_context.generate_codebase_context",
+            side_effect=lambda repo_root, kernel_path, output_dir: output_dir / "CODEBASE_CONTEXT.md",
+        ),
+        patch("minisweagent.run.preprocessor.get_testcase_cache_dir", return_value=None),
+        patch(
+            "minisweagent.run.preprocessor.execute_harness_validation",
+            side_effect=lambda harness_path, **kwargs: (True, [], _demo_harness_results()),
+        ),
+        patch(
+            "minisweagent.run.preprocessor._materialize_preprocessor_harness",
+            return_value=(
+                f"python {materialized_harness}",
+                str(materialized_harness.resolve()),
+                _demo_harness_results(),
+            ),
+        ),
+        patch("minisweagent.run.preprocessor.run_baseline_profile", return_value=None),
+        patch("minisweagent.tools.commandment.generate_commandment", return_value="COMMANDMENT"),
+    ):
+        (output_dir / "CODEBASE_CONTEXT.md").write_text("context\n")
+        ctx = run_preprocessor(
+            str(kernel_path),
+            output_dir=output_dir,
+            gpu_id=0,
+        )
+
+    assert ctx["harness_path"] == str(materialized_harness.resolve())
+    assert ctx["testcase_selection"]["selected_source"] == "discovery_test"
+    assert materialized_harness.is_file()


### PR DESCRIPTION
## Summary
- add notebook-backed working memory plumbing and orchestration support so agents can persist and reuse structured working state across runs
- harden deterministic reruns by propagating dirty tracked files into round worktrees, supporting local deterministic harness paths, and improving testcase caching / kernel resolution flows
- tighten save-and-test and sub-agent execution behavior, and add broad regression coverage for the new notebook, preprocessor, testcase cache, rerun, and tool-path logic

## Test plan
- [ ] Run targeted pytest coverage for working notebook, testcase cache, deterministic preprocessor, save-and-test, resolve-kernel-url, and sub-agent budget normalization
- [ ] Run a deterministic topk preprocess / rerun using a local harness path to verify the local-path fallback end to end
- [ ] Verify dirty tracked edits in the source tree are visible inside per-round worktrees during a clean rerun