### PR TITLE
Fix MCP usage in agent optimization loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GEAK is an AI-powered framework for automated GPU kernel optimization. It profil
 ### Prerequisites
 
 - Docker with AMD GPU access (`/dev/kfd`, `/dev/dri`)
-- `AMD_LLM_API_KEY` environment variable set
+- LLM API key: set `AMD_LLM_API_KEY` (AMD gateway) or `ANTHROPIC_API_KEY` (direct Anthropic API)
 
 ### Enter the container
 
@@ -131,12 +131,50 @@ Standalone MCP servers for specialized tasks:
 |--------|---------|
 | `automated-test-discovery` | Content-based test/benchmark discovery |
 | `kernel-profiler` | GPU profiling via Metrix and rocprof-compute |
-| `kernel-evolve` | LLM-guided kernel optimization |
+| `kernel-evolve` | LLM-guided kernel optimization (generate, mutate, crossover) |
 | `kernel-ercs` | Kernel evaluation, reflection, compatibility checks |
 | `openevolve-mcp` | OpenEvolve evolutionary optimizer |
 | `mcp-client` | JSON-RPC 2.0 client for MCP communication |
 
 Install individually: `pip install -e mcp_tools/<server-name>/`
+
+### MCP Model Configuration
+
+MCP tool servers that make LLM calls (kernel-evolve, kernel-ercs, automated-test-discovery)
+need a valid model name. The model is resolved in this order (highest priority first):
+
+1. **`GEAK_MCP_MODEL` env var** -- operator override, applies to all tools
+2. **YAML per-tool config** -- `mcp.tools.<server>.model` in `geak.yaml`
+3. **YAML global default** -- `mcp.default_model` in `geak.yaml`
+4. **Hardcoded fallback** -- `claude-sonnet-4.5` (AMD gateway alias)
+
+Example: to use `claude-sonnet-4-6` for all MCP tools when running outside the AMD gateway:
+
+```bash
+export GEAK_MCP_MODEL=claude-sonnet-4-6
+```
+
+Or configure per-tool in `geak.yaml`:
+
+```yaml
+mcp:
+  default_model: "claude-sonnet-4-6"
+  tools:
+    kernel-evolve:
+      model: "claude-haiku-4-5"    # cheaper model for generation
+    kernel-ercs:
+      model: "claude-sonnet-4-6"   # smarter model for evaluation
+```
+
+### MCP API Key Support
+
+Each MCP server that calls an LLM supports three backends (tried in order):
+
+1. **AMD LLM Gateway** -- if `AMD_LLM_API_KEY` or `LLM_GATEWAY_KEY` is set
+2. **Direct Anthropic API** -- if `ANTHROPIC_API_KEY` is set
+3. **litellm fallback** -- if the litellm package is installed
+
+API keys are automatically forwarded from the parent GEAK process to MCP subprocess environments.
 
 ## Architecture
 
@@ -176,13 +214,30 @@ mcp_tools/                   # Standalone MCP servers (profiler, kernel-evolve, 
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `AMD_LLM_API_KEY` | (required) | LLM API key |
+| `AMD_LLM_API_KEY` | (required*) | AMD LLM Gateway API key |
+| `ANTHROPIC_API_KEY` | (required*) | Direct Anthropic API key (alternative to AMD gateway) |
+| `GEAK_MODEL` | from `geak.yaml` | Override agent LLM model name |
+| `GEAK_MCP_MODEL` | `claude-sonnet-4.5` | Override LLM model for all MCP tool servers |
 | `GEAK_MAX_ROUNDS` | `5` | Max orchestration rounds |
 | `GEAK_BENCHMARK_EXTRA_ARGS` | `--iterations 50` | Extra args for benchmark commands (set by pipeline) |
 | `GEAK_ALLOWED_AGENTS` | (all) | Comma-separated agent type allowlist |
 | `GEAK_EXCLUDED_AGENTS` | (none) | Comma-separated agent type blocklist |
 
+\* At least one of `AMD_LLM_API_KEY` or `ANTHROPIC_API_KEY` must be set.
+
 See `INSTRUCTIONS.md` Section 6 for the full reference.
+
+## Branch: `fix/mcp-essential`
+
+Changes required for MCP tools to work outside the AMD LLM Gateway (e.g. with a direct Anthropic API key on LUMI or other non-gateway environments).
+
+| # | Commit | What changed | Why needed |
+|---|--------|--------------|------------|
+| 1 | `458f811` Add ANTHROPIC_API_KEY support to kernel-evolve MCP server | `call_llm()` gains a 3-tier backend: AMD gateway, direct Anthropic API, litellm | kernel-evolve tools (generate, mutate, crossover) fail when only `ANTHROPIC_API_KEY` is set |
+| 2 | `ec519d4` Add ANTHROPIC_API_KEY support to kernel-ercs MCP server | Same 3-tier fallback added to kernel-ercs | `evaluate_kernel_quality` and `reflect_on_kernel_result` fail without AMD gateway |
+| 3 | `c256eb3` Thread agent config through orchestrator pipeline to dispatch | `extra_agent_config` parameter threaded through `run_orchestrator` -> `run_task_batch` -> `ParallelAgent` | Custom YAML configs (system prompt, cost limit, etc.) were silently dropped -- agents always got the default prompt |
+| 4 | `23adeb2` Register mutate_kernel, crossover_kernels, get_optimization_strategies | Add 3 kernel-evolve tools to `ToolRuntime._tool_table` and `tools.json` | These tools existed on the MCP server but were invisible to the agent |
+| 5 | `d225845` Add GEAK_MCP_MODEL env var for flexible MCP model selection | Replace hardcoded `claude-sonnet-4.5` with configurable model via env var + YAML | The hardcoded model name is an AMD gateway alias that doesn't work with other LLM providers |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -227,18 +227,6 @@ mcp_tools/                   # Standalone MCP servers (profiler, kernel-evolve, 
 
 See `INSTRUCTIONS.md` Section 6 for the full reference.
 
-## Branch: `fix/mcp-essential`
-
-Changes required for MCP tools to work outside the AMD LLM Gateway (e.g. with a direct Anthropic API key on LUMI or other non-gateway environments).
-
-| # | Commit | What changed | Why needed |
-|---|--------|--------------|------------|
-| 1 | `458f811` Add ANTHROPIC_API_KEY support to kernel-evolve MCP server | `call_llm()` gains a 3-tier backend: AMD gateway, direct Anthropic API, litellm | kernel-evolve tools (generate, mutate, crossover) fail when only `ANTHROPIC_API_KEY` is set |
-| 2 | `ec519d4` Add ANTHROPIC_API_KEY support to kernel-ercs MCP server | Same 3-tier fallback added to kernel-ercs | `evaluate_kernel_quality` and `reflect_on_kernel_result` fail without AMD gateway |
-| 3 | `c256eb3` Thread agent config through orchestrator pipeline to dispatch | `extra_agent_config` parameter threaded through `run_orchestrator` -> `run_task_batch` -> `ParallelAgent` | Custom YAML configs (system prompt, cost limit, etc.) were silently dropped -- agents always got the default prompt |
-| 4 | `23adeb2` Register mutate_kernel, crossover_kernels, get_optimization_strategies | Add 3 kernel-evolve tools to `ToolRuntime._tool_table` and `tools.json` | These tools existed on the MCP server but were invisible to the agent |
-| 5 | `d225845` Add GEAK_MCP_MODEL env var for flexible MCP model selection | Replace hardcoded `claude-sonnet-4.5` with configurable model via env var + YAML | The hardcoded model name is an AMD gateway alias that doesn't work with other LLM providers |
-
 ## License
 
 MIT License - see LICENSE.md for details

--- a/mcp_tools/automated-test-discovery/src/automated_test_discovery/server.py
+++ b/mcp_tools/automated-test-discovery/src/automated_test_discovery/server.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
+_DEFAULT_MODEL = os.environ.get("GEAK_MCP_MODEL", "claude-sonnet-4.5")
+
 # Initialize MCP server
 mcp = FastMCP(
     name="automated-test-discovery",
@@ -387,7 +389,7 @@ def _llm_finalize_discovery(
 
     try:
         response = client.messages.create(
-            model="claude-sonnet-4.5",
+            model=_DEFAULT_MODEL,
             max_tokens=4000,
             messages=[{"role": "user", "content": prompt}],
             temperature=0.1,

--- a/mcp_tools/kernel-ercs/src/kernel_ercs/cli.py
+++ b/mcp_tools/kernel-ercs/src/kernel_ercs/cli.py
@@ -14,6 +14,7 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -42,7 +43,7 @@ def main():
     # evaluate command
     eval_parser = subparsers.add_parser("evaluate", help="Evaluate kernel quality")
     eval_parser.add_argument("kernel_file", help="Path to kernel file")
-    eval_parser.add_argument("--model", "-m", default="claude-sonnet-4.5", help="LLM model")
+    eval_parser.add_argument("--model", "-m", default=os.environ.get("GEAK_MCP_MODEL", "claude-sonnet-4.5"), help="LLM model")
 
     # reflect command
     ref_parser = subparsers.add_parser("reflect", help="Reflect on kernel test results")
@@ -54,7 +55,7 @@ def main():
     )
     ref_parser.add_argument("--history", help="Optimization history summary")
     ref_parser.add_argument("--tried", help="Comma-separated list of tried strategies")
-    ref_parser.add_argument("--model", "-m", default="claude-sonnet-4.5", help="LLM model")
+    ref_parser.add_argument("--model", "-m", default=os.environ.get("GEAK_MCP_MODEL", "claude-sonnet-4.5"), help="LLM model")
 
     # specs command
     subparsers.add_parser("specs", help="Get AMD MI350X GPU specifications")

--- a/mcp_tools/kernel-ercs/src/kernel_ercs/server.py
+++ b/mcp_tools/kernel-ercs/src/kernel_ercs/server.py
@@ -36,6 +36,8 @@ except ImportError:
     ANTHROPIC_AVAILABLE = False
 
 
+_DEFAULT_MODEL = os.environ.get("GEAK_MCP_MODEL", "claude-sonnet-4.5")
+
 # Create the MCP server
 mcp = FastMCP(
     name="kernel-ercs",
@@ -268,7 +270,7 @@ Only output valid JSON.
 
 
 @mcp.tool()
-def evaluate_kernel_quality(kernel_code: str, model: str = "claude-sonnet-4.5") -> dict[str, Any]:
+def evaluate_kernel_quality(kernel_code: str, model: str = _DEFAULT_MODEL) -> dict[str, Any]:
     """
     Evaluate Triton kernel quality using LLM analysis.
 
@@ -277,7 +279,7 @@ def evaluate_kernel_quality(kernel_code: str, model: str = "claude-sonnet-4.5") 
 
     Args:
         kernel_code: The Triton kernel code to evaluate
-        model: LLM model to use (default: claude-sonnet-4.5)
+        model: LLM model to use (default: GEAK_MCP_MODEL env var or claude-sonnet-4.5)
 
     Returns:
         dict with scores (0.0-1.0 each), total_score, reasoning, and suggestions
@@ -335,7 +337,7 @@ def reflect_on_kernel_result(
     correctness_status: str = "unknown",
     history: str = "",
     tried_strategies: str = "",
-    model: str = "claude-sonnet-4.5",
+    model: str = _DEFAULT_MODEL,
 ) -> dict[str, Any]:
     """
     Analyze kernel test results and get targeted improvement suggestions.

--- a/mcp_tools/kernel-ercs/src/kernel_ercs/server.py
+++ b/mcp_tools/kernel-ercs/src/kernel_ercs/server.py
@@ -99,11 +99,55 @@ def call_amd_gateway(messages: list, model: str, temperature: float = 0.1) -> st
     return response.content[0].text
 
 
+def _extract_system_and_messages(messages: list) -> tuple[str, list]:
+    """Separate system message from user/assistant messages for Anthropic API."""
+    system_content = ""
+    filtered_messages = []
+    for msg in messages:
+        if msg.get("role") == "system":
+            system_content = msg.get("content", "")
+        else:
+            filtered_messages.append(msg)
+    return system_content, filtered_messages
+
+
 def call_llm(messages: list, model: str, temperature: float = 0.1) -> str:
-    """Call LLM using appropriate backend."""
-    if is_amd_model(model) and ANTHROPIC_AVAILABLE:
+    """Call LLM using AMD gateway, direct Anthropic API, or litellm.
+
+    Backend selection order:
+      1. AMD LLM Gateway  – if AMD_LLM_API_KEY or LLM_GATEWAY_KEY is set
+      2. Direct Claude API – if ANTHROPIC_API_KEY is set
+      3. litellm fallback  – if litellm is installed
+    """
+    amd_api_key = os.environ.get("AMD_LLM_API_KEY") or os.environ.get("LLM_GATEWAY_KEY")
+    anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY")
+
+    # --- 1. AMD LLM Gateway ---------------------------------------------------
+    if ANTHROPIC_AVAILABLE and amd_api_key:
         return call_amd_gateway(messages, model, temperature)
-    elif LITELLM_AVAILABLE:
+
+    # --- 2. Direct Claude API (api.anthropic.com) ------------------------------
+    if ANTHROPIC_AVAILABLE and anthropic_api_key:
+        client = anthropic.Anthropic(
+            api_key=anthropic_api_key,
+            base_url="https://api.anthropic.com",
+        )
+
+        model_name = model.removeprefix("amd/")
+        system_content, filtered_messages = _extract_system_and_messages(messages)
+
+        response = client.messages.create(
+            model=model_name,
+            max_tokens=4096,
+            system=system_content if system_content else anthropic.NOT_GIVEN,
+            messages=filtered_messages,
+            temperature=temperature,
+        )
+
+        return response.content[0].text
+
+    # --- 3. litellm fallback ---------------------------------------------------
+    if LITELLM_AVAILABLE:
         api_key = os.environ.get("LLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
         response = completion(
             model=model,
@@ -112,8 +156,11 @@ def call_llm(messages: list, model: str, temperature: float = 0.1) -> str:
             temperature=temperature,
         )
         return response.choices[0].message.content
-    else:
-        raise RuntimeError("No LLM backend available. Install anthropic or litellm.")
+
+    raise RuntimeError(
+        "No LLM backend available. Set ANTHROPIC_API_KEY for direct Claude access, "
+        "AMD_LLM_API_KEY for AMD gateway, or install litellm."
+    )
 
 
 # Kernel Evaluation Prompt

--- a/mcp_tools/kernel-evolve/src/kernel_evolve/cli.py
+++ b/mcp_tools/kernel-evolve/src/kernel_evolve/cli.py
@@ -15,6 +15,7 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -50,7 +51,7 @@ def main():
         help="Bottleneck type",
     )
     gen_parser.add_argument("--strategy", "-s", help="Specific strategy to apply")
-    gen_parser.add_argument("--model", "-m", default="claude-sonnet-4.5", help="LLM model")
+    gen_parser.add_argument("--model", "-m", default=os.environ.get("GEAK_MCP_MODEL", "claude-sonnet-4.5"), help="LLM model")
 
     # mutate command
     mut_parser = subparsers.add_parser("mutate", help="Mutate existing kernel")
@@ -60,7 +61,7 @@ def main():
     )
     mut_parser.add_argument("--latency", "-l", type=float, default=0.0, help="Current latency (us)")
     mut_parser.add_argument("--speedup", "-s", type=float, default=1.0, help="Current speedup")
-    mut_parser.add_argument("--model", "-m", default="claude-sonnet-4.5", help="LLM model")
+    mut_parser.add_argument("--model", "-m", default=os.environ.get("GEAK_MCP_MODEL", "claude-sonnet-4.5"), help="LLM model")
 
     # crossover command
     cross_parser = subparsers.add_parser("crossover", help="Combine two kernels")
@@ -68,7 +69,7 @@ def main():
     cross_parser.add_argument("kernel2", help="Path to second kernel")
     cross_parser.add_argument("--speedup1", type=float, default=1.0, help="Speedup of kernel1")
     cross_parser.add_argument("--speedup2", type=float, default=1.0, help="Speedup of kernel2")
-    cross_parser.add_argument("--model", "-m", default="claude-sonnet-4.5", help="LLM model")
+    cross_parser.add_argument("--model", "-m", default=os.environ.get("GEAK_MCP_MODEL", "claude-sonnet-4.5"), help="LLM model")
 
     # strategies command
     strat_parser = subparsers.add_parser("strategies", help="Get strategies for bottleneck")

--- a/mcp_tools/kernel-evolve/src/kernel_evolve/server.py
+++ b/mcp_tools/kernel-evolve/src/kernel_evolve/server.py
@@ -35,6 +35,8 @@ except ImportError:
     LITELLM_AVAILABLE = False
 
 
+_DEFAULT_MODEL = os.environ.get("GEAK_MCP_MODEL", "claude-sonnet-4.5")
+
 # Create the MCP server
 mcp = FastMCP(
     name="kernel-evolve", instructions="Evolutionary GPU kernel optimization using LLM-guided mutation and crossover"
@@ -53,7 +55,7 @@ def _extract_system_and_messages(messages: list) -> tuple[str, list]:
     return system_content, filtered_messages
 
 
-def call_llm(messages: list, model: str = "claude-sonnet-4.5", temperature: float = 0.7) -> str:
+def call_llm(messages: list, model: str = _DEFAULT_MODEL, temperature: float = 0.7) -> str:
     """Call LLM using AMD gateway, direct Anthropic API, or litellm.
 
     Backend selection order:
@@ -258,7 +260,7 @@ def extract_code(response: str) -> str:
 
 @mcp.tool()
 def generate_optimization(
-    kernel_code: str, bottleneck: str = "balanced", strategy: str = None, model: str = "claude-sonnet-4.5"
+    kernel_code: str, bottleneck: str = "balanced", strategy: str = None, model: str = _DEFAULT_MODEL
 ) -> dict[str, Any]:
     """
     Generate an optimized kernel variant using LLM.
@@ -305,7 +307,7 @@ def mutate_kernel(
     mutation_type: str = "parameter",
     latency_us: float = 0.0,
     speedup: float = 1.0,
-    model: str = "claude-sonnet-4.5",
+    model: str = _DEFAULT_MODEL,
 ) -> dict[str, Any]:
     """
     Mutate an existing kernel optimization to explore variations.
@@ -358,7 +360,7 @@ def mutate_kernel(
 
 @mcp.tool()
 def crossover_kernels(
-    kernel1: str, kernel2: str, speedup1: float = 1.0, speedup2: float = 1.0, model: str = "claude-sonnet-4.5"
+    kernel1: str, kernel2: str, speedup1: float = 1.0, speedup2: float = 1.0, model: str = _DEFAULT_MODEL
 ) -> dict[str, Any]:
     """
     Combine two kernel optimizations to create a hybrid.

--- a/mcp_tools/kernel-evolve/src/kernel_evolve/server.py
+++ b/mcp_tools/kernel-evolve/src/kernel_evolve/server.py
@@ -41,11 +41,31 @@ mcp = FastMCP(
 )
 
 
-def call_llm(messages: list, model: str = "claude-sonnet-4.5", temperature: float = 0.7) -> str:
-    """Call LLM using AMD gateway or litellm."""
-    api_key = os.environ.get("AMD_LLM_API_KEY") or os.environ.get("LLM_GATEWAY_KEY")
+def _extract_system_and_messages(messages: list) -> tuple[str, list]:
+    """Separate system message from user/assistant messages for Anthropic API."""
+    system_content = ""
+    filtered_messages = []
+    for msg in messages:
+        if msg.get("role") == "system":
+            system_content = msg.get("content", "")
+        else:
+            filtered_messages.append(msg)
+    return system_content, filtered_messages
 
-    if ANTHROPIC_AVAILABLE and api_key:
+
+def call_llm(messages: list, model: str = "claude-sonnet-4.5", temperature: float = 0.7) -> str:
+    """Call LLM using AMD gateway, direct Anthropic API, or litellm.
+
+    Backend selection order:
+      1. AMD LLM Gateway  – if AMD_LLM_API_KEY or LLM_GATEWAY_KEY is set
+      2. Direct Claude API – if ANTHROPIC_API_KEY is set
+      3. litellm fallback  – if litellm is installed
+    """
+    amd_api_key = os.environ.get("AMD_LLM_API_KEY") or os.environ.get("LLM_GATEWAY_KEY")
+    anthropic_api_key = os.environ.get("ANTHROPIC_API_KEY")
+
+    # --- 1. AMD LLM Gateway ---------------------------------------------------
+    if ANTHROPIC_AVAILABLE and amd_api_key:
         try:
             user = os.getlogin()
         except OSError:
@@ -55,21 +75,14 @@ def call_llm(messages: list, model: str = "claude-sonnet-4.5", temperature: floa
             api_key="dummy",
             base_url="https://llm-api.amd.com/Anthropic",
             default_headers={
-                "Ocp-Apim-Subscription-Key": api_key,
+                "Ocp-Apim-Subscription-Key": amd_api_key,
                 "user": user,
                 "anthropic-version": "2023-10-16",
             },
         )
 
         model_name = model.removeprefix("amd/")
-
-        system_content = ""
-        filtered_messages = []
-        for msg in messages:
-            if msg.get("role") == "system":
-                system_content = msg.get("content", "")
-            else:
-                filtered_messages.append(msg)
+        system_content, filtered_messages = _extract_system_and_messages(messages)
 
         response = client.messages.create(
             model=model_name,
@@ -81,7 +94,38 @@ def call_llm(messages: list, model: str = "claude-sonnet-4.5", temperature: floa
 
         return response.content[0].text
 
-    elif LITELLM_AVAILABLE:
+    # --- 2. Direct Claude API (api.anthropic.com) ------------------------------
+    if ANTHROPIC_AVAILABLE and anthropic_api_key:
+        client = anthropic.Anthropic(
+            api_key=anthropic_api_key,
+            base_url="https://api.anthropic.com",
+        )
+
+        model_name = model.removeprefix("amd/")
+        system_content, filtered_messages = _extract_system_and_messages(messages)
+
+        try:
+            response = client.messages.create(
+                model=model_name,
+                max_tokens=16000,
+                system=system_content if system_content else anthropic.NOT_GIVEN,
+                messages=filtered_messages,
+                temperature=temperature,
+            )
+        except anthropic.APIStatusError as e:
+            raise ValueError(f"Anthropic API error: {e.status_code} - {e.message}") from e
+        except anthropic.APIConnectionError as e:
+            raise ValueError(f"API connection error: {e}") from e
+        except anthropic.AuthenticationError as e:
+            raise ValueError(f"Authentication error – check ANTHROPIC_API_KEY: {e}") from e
+
+        if not response or not hasattr(response, "content") or len(response.content) == 0:
+            raise ValueError("No response content returned from the Anthropic API.")
+
+        return response.content[0].text
+
+    # --- 3. litellm fallback ---------------------------------------------------
+    if LITELLM_AVAILABLE:
         api_key = os.environ.get("LLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
         response = completion(
             model=model,
@@ -91,8 +135,10 @@ def call_llm(messages: list, model: str = "claude-sonnet-4.5", temperature: floa
         )
         return response.choices[0].message.content
 
-    else:
-        raise RuntimeError("No LLM backend available. Install anthropic or litellm.")
+    raise RuntimeError(
+        "No LLM backend available. Set ANTHROPIC_API_KEY for direct Claude access, "
+        "AMD_LLM_API_KEY for AMD gateway, or install litellm."
+    )
 
 
 # Optimization strategies by bottleneck type

--- a/src/minisweagent/config/geak.yaml
+++ b/src/minisweagent/config/geak.yaml
@@ -41,3 +41,15 @@ tools:
   # reflect_on_kernel_result: kernel-ercs MCP
   # Native tools (always registered)
   # resolve_kernel_url, baseline_metrics, check_kernel_compatibility, sub_agent
+
+# MCP model configuration
+# Resolution order: GEAK_MCP_MODEL env var > per-tool > default_model > hardcoded fallback
+mcp:
+  # default_model: "claude-sonnet-4-6"
+  # tools:
+  #   kernel-evolve:
+  #     model: "claude-haiku-4-5"
+  #   kernel-ercs:
+  #     model: "claude-sonnet-4-6"
+  #   automated-test-discovery:
+  #     model: "claude-haiku-4-5"

--- a/src/minisweagent/run/dispatch.py
+++ b/src/minisweagent/run/dispatch.py
@@ -275,6 +275,7 @@ def run_task_batch(
     model_factory,
     *,
     console=None,
+    extra_agent_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run a batch of task files via ParallelAgent pool mode.
 
@@ -290,6 +291,10 @@ def run_task_batch(
         Callable returning a new model instance.
     console:
         Optional Rich console.
+    extra_agent_config:
+        Optional agent-level config (system_template, instance_template,
+        cost_limit, etc.) to merge into the agent config dict.  Sourced
+        from the merged YAML ``config["agent"]`` section.
 
     Returns
     -------
@@ -318,6 +323,7 @@ def run_task_batch(
     results_dir.mkdir(parents=True, exist_ok=True)
 
     agent_config: dict[str, Any] = {
+        **(extra_agent_config or {}),
         "save_patch": True,
     }
 

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -584,6 +584,7 @@ def main(
             max_rounds=max_rounds,
             heterogeneous=heterogeneous,
             console=console,
+            agent_config=config.get("agent"),
         )
 
         console.print("\n[bold green]Pipeline complete.[/bold green]")

--- a/src/minisweagent/run/orchestrator.py
+++ b/src/minisweagent/run/orchestrator.py
@@ -959,6 +959,7 @@ def _run_homogeneous_orchestrator(
     _print,
     console,
     model_factory=None,
+    agent_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run the orchestrator in homogeneous mode.
 
@@ -1040,6 +1041,7 @@ def _run_homogeneous_orchestrator(
                 output_dir=results_dir,
                 model_factory=model_factory,
                 console=console,
+                extra_agent_config=agent_config,
             )
         except Exception as exc:
             _print(f"  [yellow]Round {round_num} dispatch failed: {exc}[/yellow]")
@@ -1238,6 +1240,7 @@ def run_orchestrator(
     start_round: int = 1,
     heterogeneous: bool = False,
     console=None,
+    agent_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run the orchestrator agent loop.
 
@@ -1284,6 +1287,7 @@ def run_orchestrator(
         return _run_homogeneous_orchestrator(
             preprocess_ctx, gpu_ids, _out, max_rounds, start_round, _print, console,
             model_factory=model_factory,
+            agent_config=agent_config,
         )
 
     # Build DiscoveryResult from preprocessor's discovery dict

--- a/src/minisweagent/tools/mcp_bridge.py
+++ b/src/minisweagent/tools/mcp_bridge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import logging
+import os
 import sys
 import threading
 from pathlib import Path
@@ -179,10 +180,17 @@ class MCPToolBridge:
         module_name = server_name.replace("-", "_")
         src_dir = mcp_dir / "src"
 
+        env = {"PYTHONPATH": str(src_dir)}
+
+        for key in ("GEAK_MCP_MODEL", "ANTHROPIC_API_KEY", "AMD_LLM_API_KEY", "LLM_GATEWAY_KEY"):
+            val = os.environ.get(key)
+            if val:
+                env[key] = val
+
         return {
             "command": ["python3", "-m", f"{module_name}.server"],
             "cwd": str(mcp_dir),
-            "env": {"PYTHONPATH": str(src_dir)},
+            "env": env,
         }
 
 

--- a/src/minisweagent/tools/tools.json
+++ b/src/minisweagent/tools/tools.json
@@ -277,6 +277,84 @@
     }
   },
   {
+    "name": "mutate_kernel",
+    "type": "function",
+    "description": "Mutate an existing kernel optimization to explore variations. Makes intelligent changes based on mutation type (parameter tuning, algorithmic change, or hybrid). Use when you have a promising kernel and want to explore nearby variants.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "kernel_code": {
+          "type": "string",
+          "description": "The current kernel code to mutate"
+        },
+        "mutation_type": {
+          "type": "string",
+          "enum": ["parameter", "algorithm", "hybrid"],
+          "description": "Type of mutation: parameter (block sizes, warps), algorithm (different approach), hybrid (add technique)"
+        },
+        "latency_us": {
+          "type": "number",
+          "description": "Current latency in microseconds (for context)"
+        },
+        "speedup": {
+          "type": "number",
+          "description": "Current speedup vs baseline (for context)"
+        }
+      },
+      "required": [
+        "kernel_code"
+      ]
+    }
+  },
+  {
+    "name": "crossover_kernels",
+    "type": "function",
+    "description": "Combine two kernel optimizations to create a hybrid that takes the best aspects of both parents. Use when you have two promising variants with different strengths.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "kernel1": {
+          "type": "string",
+          "description": "First parent kernel code"
+        },
+        "kernel2": {
+          "type": "string",
+          "description": "Second parent kernel code"
+        },
+        "speedup1": {
+          "type": "number",
+          "description": "Speedup of first parent vs baseline"
+        },
+        "speedup2": {
+          "type": "number",
+          "description": "Speedup of second parent vs baseline"
+        }
+      },
+      "required": [
+        "kernel1",
+        "kernel2"
+      ]
+    }
+  },
+  {
+    "name": "get_optimization_strategies",
+    "type": "function",
+    "description": "Get recommended optimization strategies for a specific bottleneck type. Returns a prioritized list of strategies with descriptions. Fast lookup, no LLM call.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "bottleneck": {
+          "type": "string",
+          "enum": ["compute", "memory", "latency", "lds", "balanced"],
+          "description": "The bottleneck type to get strategies for"
+        }
+      },
+      "required": [
+        "bottleneck"
+      ]
+    }
+  },
+  {
     "name": "evaluate_kernel_quality",
     "type": "function",
     "description": "Evaluate a GPU kernel across AMD GPU optimization criteria. Returns scores and suggestions.",

--- a/src/minisweagent/tools/tools_runtime.py
+++ b/src/minisweagent/tools/tools_runtime.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -51,9 +52,11 @@ class ToolRuntime:
         on_strategy_change=None,
         patch_output_dir: str | None = None,
         tool_profile: str = "full",
+        mcp_config: dict | None = None,
     ):
         self._tool_profile = tool_profile
         self._mcp_bridges: list = []
+        self._mcp_config = mcp_config if mcp_config is not None else self._load_default_mcp_config()
         allowed = _TOOL_PROFILES.get(tool_profile)
 
         self._tool_table = {
@@ -99,6 +102,16 @@ class ToolRuntime:
         self.use_strategy_manager = use_strategy_manager
         self._codebase_context: str | None = None
 
+    @staticmethod
+    def _load_default_mcp_config() -> dict:
+        """Load the ``mcp`` section from the built-in geak.yaml config."""
+        try:
+            from minisweagent.config import load_config
+            cfg = load_config("geak")
+            return cfg.get("mcp", {}) or {}
+        except Exception:
+            return {}
+
     def _register_profiler_mcp(self):
         """Register only the profiler-mcp tool."""
         try:
@@ -108,6 +121,26 @@ class ToolRuntime:
         profiler = MCPToolBridge("profiler-mcp", timeout=600)
         self._mcp_bridges.append(profiler)
         self._tool_table["profile_kernel"] = profiler.tool("profile_kernel")
+
+    def _resolve_mcp_model(self, server_name: str) -> str | None:
+        """Resolve MCP model for a server from YAML config.
+
+        Resolution order (env var is handled at the bridge/server level):
+          1. GEAK_MCP_MODEL env var  (highest -- forwarded by MCPToolBridge)
+          2. mcp.tools.<server>.model (YAML per-tool)
+          3. mcp.default_model        (YAML global)
+          4. hardcoded fallback        (in server code)
+
+        Returns the YAML-derived model string (for steps 2-3), or None to let
+        the server use its own default (step 4).  Step 1 is already handled by
+        MCPToolBridge._default_config forwarding the env var.
+        """
+        if os.environ.get("GEAK_MCP_MODEL"):
+            return None  # env var takes priority; bridge already forwards it
+        per_tool = self._mcp_config.get("tools", {}).get(server_name, {}).get("model")
+        if per_tool:
+            return per_tool
+        return self._mcp_config.get("default_model")
 
     def _register_mcp_tools(self):
         """Register all MCP server tools via MCPToolBridge.
@@ -139,6 +172,12 @@ class ToolRuntime:
         openevolve = MCPToolBridge("openevolve-mcp", timeout=7200)
         self._mcp_bridges.append(openevolve)
         self._tool_table["openevolve"] = openevolve.tool("optimize_kernel")
+
+        # Apply YAML model overrides (only when GEAK_MCP_MODEL env var is not set)
+        for bridge in self._mcp_bridges:
+            model = self._resolve_mcp_model(bridge.server_name)
+            if model:
+                bridge.set_env({"GEAK_MCP_MODEL": model})
 
     def set_env(self, env: dict[str, str]) -> None:
         """Propagate environment overrides (e.g. HIP_VISIBLE_DEVICES) to tools."""

--- a/src/minisweagent/tools/tools_runtime.py
+++ b/src/minisweagent/tools/tools_runtime.py
@@ -127,6 +127,9 @@ class ToolRuntime:
         evolve = MCPToolBridge("kernel-evolve", timeout=300)
         self._mcp_bridges.append(evolve)
         self._tool_table["generate_optimization"] = evolve.tool("generate_optimization")
+        self._tool_table["mutate_kernel"] = evolve.tool("mutate_kernel")
+        self._tool_table["crossover_kernels"] = evolve.tool("crossover_kernels")
+        self._tool_table["get_optimization_strategies"] = evolve.tool("get_optimization_strategies")
 
         ercs = MCPToolBridge("kernel-ercs", timeout=300)
         self._mcp_bridges.append(ercs)


### PR DESCRIPTION
To make MCP available to and used by agent in optimization loop

- Bridge ANTHROPIC_API_KEY and related env vars through to kernel-evolve and kernel-ercs MCP servers
- Thread agent config (prompts, cost limits) through the orchestrator pipeline so the agent receives its configured prompt instead of the default
- Register mutate_kernel, crossover_kernels, and get_optimization_strategies as agent-callable MCP tools
- Add flexible MCP model selection with 4-level resolution: GEAK_MCP_MODEL env var > per-tool YAML (mcp.tools.<server>.model) > global YAML (mcp.default_model) > server hardcoded fallback (already existing)