### PR TITLE
Reapply "Cherry-pick critical bug fixes from agent-filtering-and-cli-…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ where = ["src"]
 include = ["minisweagent*"]
 
 [tool.setuptools.package-data]
-minisweagent = ["config/**/*"]
+minisweagent = ["config/**/*", "tools/tools.json"]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/src/minisweagent/agents/parallel_agent.py
+++ b/src/minisweagent/agents/parallel_agent.py
@@ -252,6 +252,76 @@ class ParallelAgent(DefaultAgent):
         return workdir_path
 
     @staticmethod
+    def _bootstrap_git_repo(repo_path: Path, console=None) -> bool:
+        """Bootstrap a minimal git repository for non-git directories.
+
+        Creates .git, adds .gitignore to exclude build artifacts, and creates
+        an initial commit. This allows unified git diff-based patch generation.
+
+        Returns True if successful, False otherwise.
+        """
+        import subprocess
+
+        try:
+            subprocess.run(
+                ["git", "init", "-b", "geak-bootstrap"],
+                cwd=repo_path, check=True, capture_output=True, text=True, timeout=30,
+            )
+
+            gitignore_path = repo_path / ".gitignore"
+            gitignore_content = "\n".join([
+                "# GEAK auto-generated gitignore for build artifacts",
+                "build/",
+                "*/build/",
+                ".rocprofv3/",
+                "__pycache__/",
+                "*.pyc",
+                "*.o",
+                "*.so",
+                "*.a",
+                "*.log",
+                "*.dat",
+                "optimization_logs/",
+                "*/_logs/",
+                "CMakeCache.txt",
+                "CMakeFiles/",
+                ".pytest_cache/",
+                "*.egg-info/",
+                ".geak_resolved/",
+                "traj.json",
+            ])
+            if gitignore_path.exists():
+                existing = gitignore_path.read_text()
+                if "# GEAK auto-generated" not in existing:
+                    gitignore_path.write_text(existing + "\n" + gitignore_content)
+            else:
+                gitignore_path.write_text(gitignore_content)
+
+            subprocess.run(
+                ["git", "add", "-A"],
+                cwd=repo_path, check=True, capture_output=True, text=True, timeout=120,
+            )
+            subprocess.run(
+                ["git", "-c", "user.name=geak-bootstrap", "-c", "user.email=geak@local",
+                 "commit", "-m", "GEAK bootstrap commit", "--allow-empty"],
+                cwd=repo_path, check=True, capture_output=True, text=True, timeout=60,
+            )
+
+            if console:
+                console.print("[bold green]Git repo bootstrapped successfully[/bold green]")
+            return True
+
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr or e.stdout or str(e)
+            if console:
+                console.print(f"[bold red]Failed to bootstrap git repo: {error_msg}[/bold red]")
+            return False
+        except Exception as e:
+            if console:
+                console.print(f"[bold red]Failed to bootstrap git repo: {e}[/bold red]")
+            return False
+
+    @staticmethod
     def _replace_paths(text: str, repo_path: Path, worktree_path: Path) -> str:
         """Replace repository paths with worktree path in text.
 
@@ -368,6 +438,7 @@ class ParallelAgent(DefaultAgent):
                 worktree_path = cls._create_worktree(repo_path, worktree_base / f"agent_{agent_id}")
             else:
                 worktree_path = cls._create_copy_workdir(repo_path, worktree_base / f"agent_{agent_id}")
+                cls._bootstrap_git_repo(worktree_path, console)
             worktree_path_str = str(worktree_path.resolve())
 
             if console:
@@ -512,6 +583,7 @@ class ParallelAgent(DefaultAgent):
                 worktree_path = cls._create_worktree(repo_path, worktree_base / f"agent_{agent_id}")
             else:
                 worktree_path = cls._create_copy_workdir(repo_path, worktree_base / f"agent_{agent_id}")
+                cls._bootstrap_git_repo(worktree_path, console)
             worktree_path_str = str(worktree_path.resolve())
 
             label = spec.label or spec.agent_class.__name__
@@ -666,6 +738,11 @@ class ParallelAgent(DefaultAgent):
 
         # Sort tasks by priority (lower = runs first)
         sorted_tasks = sorted(enumerate(tasks), key=lambda t: t[1].priority)
+        _label_counts: dict[str, int] = {}
+        for _, t in sorted_tasks:
+            _lbl = t.label or ""
+            _label_counts[_lbl] = _label_counts.get(_lbl, 0) + 1
+        _has_dup_labels = any(c > 1 for c in _label_counts.values())
 
         def execute_task(task_id: int, task) -> tuple[int, Any, Any, Any]:
             """Execute a single task on dynamically-assigned GPU(s)."""
@@ -698,10 +775,14 @@ class ParallelAgent(DefaultAgent):
                         cls._create_worktree(repo_path, wt_path)
                 else:
                     cls._create_copy_workdir(repo_path, wt_path)
+                    cls._bootstrap_git_repo(wt_path, console)
                 wt_path_str = str(wt_path.resolve())
 
                 # Each task gets its own patch dir named by label (persists across worktree resets)
-                dir_name = task.label if task.label else f"task_{task_id}"
+                if _has_dup_labels:
+                    dir_name = f"{task.label}_{task_id}" if task.label else f"task_{task_id}"
+                else:
+                    dir_name = task.label if task.label else f"task_{task_id}"
                 task_patch_dir = (base_patch_dir / dir_name).resolve()
                 task_patch_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/minisweagent/config/geak.yaml
+++ b/src/minisweagent/config/geak.yaml
@@ -14,7 +14,7 @@ model:
   model_class: amd_llm
   # claude-opus-4.5, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
   model_name: claude-opus-4.5
-  api_key: ""
+  api_key: null
   model_kwargs:
     temperature: 0.0
     max_tokens: 16000

--- a/src/minisweagent/kernel_profile.py
+++ b/src/minisweagent/kernel_profile.py
@@ -28,7 +28,7 @@ for _sub in ("mcp_tools/profiler-mcp/src", "mcp_tools/metrix-mcp/src"):
 EXAMPLES = """
 Examples (metrix backend, default):
   %(prog)s 'python3 /path/to/kernel.py --profile'
-  %(prog)s 'python3 kernel.py --profile' --gpu-devices 3
+  %(prog)s 'python3 kernel.py --profile' --gpu-devices 0
   %(prog)s 'python3 kernel.py --profile' --replays 5
   %(prog)s 'python3 kernel.py --profile' --quick
 
@@ -330,8 +330,8 @@ def main():
     )
     parser.add_argument(
         "--gpu-devices",
-        default="3",
-        help='GPU device ID(s): single ("3") or comma-separated ("0,1,2") (default: 3)',
+        default="0",
+        help='GPU device ID(s): single ("0") or comma-separated ("0,1,2") (default: 0)',
     )
 
     # Metrix-specific options

--- a/src/minisweagent/models/__init__.py
+++ b/src/minisweagent/models/__init__.py
@@ -73,6 +73,8 @@ def get_model_name(input_model_name: str | None = None, config: dict | None = No
         return input_model_name
     if from_config := config.get("model_name"):
         return from_config
+    if from_env := os.getenv("GEAK_MODEL"):
+        return from_env
     if from_env := os.getenv("MSWEA_MODEL_NAME"):
         return from_env
     raise ValueError("No default model set. Please run `mini-extra config setup` to set one.")

--- a/src/minisweagent/run/orchestrator.py
+++ b/src/minisweagent/run/orchestrator.py
@@ -1449,7 +1449,7 @@ def _run_homogeneous_orchestrator(
         metadata: dict[str, Any] = {
             "label": "kernel_optimization",
             "priority": 10,
-            "agent_type": "strategy_agent",
+            "agent_type": "swe_agent",
             "kernel_path": preprocess_ctx.get("kernel_path"),
             "repo_root": preprocess_ctx.get("repo_root"),
             "test_command": preprocess_ctx.get("test_command"),

--- a/src/minisweagent/tools/mcp_bridge.py
+++ b/src/minisweagent/tools/mcp_bridge.py
@@ -74,8 +74,8 @@ class MCPToolBridge:
             raw = self._run_async(self._async_call(tool_name, arguments or {}))
             return self._format_result(raw)
         except Exception as e:
-            logger.error(f"MCPToolBridge({self.server_name}).{tool_name} failed: {e}")
-            return {"output": f"MCP tool error: {e}", "returncode": 1}
+            logger.exception(f"MCPToolBridge({self.server_name}).{tool_name} failed: {e!r}")
+            return {"output": f"MCP tool error: {e!r}", "returncode": 1}
 
     # ------------------------------------------------------------------
     # Internal

--- a/src/minisweagent/tools/save_and_test.py
+++ b/src/minisweagent/tools/save_and_test.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -477,6 +478,13 @@ class SaveAndTestTool:
         """Get current changes as patch content."""
         ctx = self.context
         cwd = ctx.cwd
+
+        if ctx.test_command:
+            cd_match = re.match(r'^cd\s+([^\s&]+)\s*&&', ctx.test_command)
+            if cd_match:
+                task_dir = cd_match.group(1)
+                if Path(task_dir).is_dir():
+                    cwd = task_dir
 
         if self._is_git_repo(Path(cwd)):
             excludes = [


### PR DESCRIPTION
Port the following fixes from the AF branch into dev-working:

Fix 1 (https://github.com/AMD-AGI/GEAK/commit/dc5240910b159f1dedbce9af4ad851b58c9f5e35): MCP bridge error reporting — use repr and logger.exception for full traceback visibility
Fix 3 (https://github.com/AMD-AGI/GEAK/commit/480e5882df447956b4c8a4251afbb2c788dbd994): Extract task dir from test_command cd prefix in save_and_test
Fix 4b (https://github.com/AMD-AGI/GEAK/commit/23864adce6cb9bd474546e3cb1dbe8c09c8489a1): Bootstrap git repo for non-git workspaces so parallel agents can generate unified diffs via git instead of fragile diff -ruN
Fix 5 (https://github.com/AMD-AGI/GEAK/commit/8e434782d29b3d6e3d844a765ee6dd2a0331ff4a): Disambiguate duplicate task labels in _run_pool to prevent homogeneous-mode patch directory collisions
Fix 7a (https://github.com/AMD-AGI/GEAK/commit/85b905f865c81ebdc536a170fc64510099888946): Default --gpu-devices to 0 instead of 3 in kernel_profile
Fix 7b (https://github.com/AMD-AGI/GEAK/commit/85b905f865c81ebdc536a170fc64510099888946): Add GEAK_MODEL env var to model name resolution chain
Fix 7c (https://github.com/AMD-AGI/GEAK/commit/85b905f865c81ebdc536a170fc64510099888946): Use api_key: null instead of "" in geak.yaml
Partly made-with: Cursor
