### PR TITLE
Unified --eval flag, COMMANDMENT from commands, anti-cheat guardrails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,11 +86,12 @@ Repository = "https://github.com/SWE-agent/mini-SWE-agent"
 "Bug Tracker" = "https://github.com/SWE-agent/mini-SWE-agent/issues"
 
 [project.scripts]
+# Legacy aliases (deprecated — use 'geak' instead)
 mini = "minisweagent.run.mini:app"
 mini-swe-agent = "minisweagent.run.mini:app"
 mini-extra = "minisweagent.run.mini_extra:main"
 mini-e= "minisweagent.run.mini_extra:main"
-# GEAK-specific entry points (ported from MSA branch)
+# Primary GEAK entry points
 geak = "minisweagent.run.mini:app"
 geak-preprocess = "minisweagent.run.preprocessor:main"
 geak-orchestrate = "minisweagent.run.orchestrator:main"

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -203,6 +203,79 @@ More information about the usage: [bold green]https://mini-swe-agent.com/latest/
 """
 
 
+def _resolve_eval_spec(eval_spec: str, workspace: Path | None = None) -> tuple[str, str]:
+    """Auto-detect whether eval_spec is a harness file path or a shell command.
+
+    Returns (eval_type, value) where eval_type is 'harness' or 'command'.
+
+    Detection logic:
+    - If the value is an existing file → harness
+    - If it ends with .py/.sh and has no shell operators → harness
+    - If it contains &&, ;, | or starts with python3/make/bash → command
+    - Otherwise → command (default)
+    """
+    # Check if file exists
+    if workspace:
+        candidate = workspace / eval_spec
+        if candidate.is_file():
+            return ("harness", str(candidate.resolve()))
+    p = Path(eval_spec)
+    if p.is_file():
+        return ("harness", str(p.resolve()))
+
+    # Pattern detection
+    has_shell_ops = any(op in eval_spec for op in ("&&", ";", "|", ">"))
+    first_word = eval_spec.split()[0] if eval_spec.split() else ""
+    starts_with_cmd = first_word in ("python3", "python", "make", "bash", "sh", "./")
+    looks_like_path = eval_spec.endswith((".py", ".sh")) and not has_shell_ops
+
+    if looks_like_path:
+        return ("harness", eval_spec)
+    if has_shell_ops or starts_with_cmd:
+        return ("command", eval_spec)
+    return ("command", eval_spec)
+
+
+def _extract_kernel_from_task(task_text: str) -> str | None:
+    """Extract kernel URL or path from natural language task prompt.
+
+    Checks:
+    1. YAML frontmatter (kernel_path, kernel_url)
+    2. GitHub URLs ending in .py/.hip/.cu/.cpp
+    3. Local file paths ending in .py/.hip/.cu/.cpp
+    """
+    import re as _re
+
+    if not task_text:
+        return None
+
+    # Check YAML frontmatter
+    if task_text.strip().startswith("---"):
+        parts = task_text.strip().split("---", 2)
+        if len(parts) >= 3:
+            try:
+                import yaml
+                frontmatter = yaml.safe_load(parts[1])
+                if isinstance(frontmatter, dict):
+                    for key in ("kernel_path", "kernel_url", "kernel"):
+                        if frontmatter.get(key):
+                            return frontmatter[key]
+            except Exception:
+                pass
+
+    # Check for GitHub URLs
+    urls = _re.findall(r'https://github\.com/\S+\.(?:py|hip|cu|cpp|cuh)', task_text)
+    if urls:
+        return urls[0]
+
+    # Check for local file paths
+    paths = _re.findall(r'(?:^|\s)([./]\S+\.(?:py|hip|cu|cpp|cuh))', task_text, _re.MULTILINE)
+    if paths:
+        return paths[0].strip()
+
+    return None
+
+
 # fmt: off
 @app.command(help=_HELP_TEXT)
 def main(
@@ -218,8 +291,12 @@ def main(
     # Strategy mode configuration
     enable_strategies: bool = typer.Option(True, "--enable-strategies/--no-enable-strategies", help="Enable optimization strategy management (optool command). Auto-selects appropriate template.", rich_help_panel="Advanced"),
     strategy_file: str = typer.Option(".optimization_strategies.md", "--strategy-file", help="Path to strategy file (relative to workspace)", rich_help_panel="Advanced"),
-    # Patch mode configuration (always enabled)
-    test_command: str | None = typer.Option(None, "--test_command", "--test-command", help="Test command to run for patch validation"),
+    # Evaluation mode: accepts a harness file path OR a shell command string.
+    # Auto-detected: if the value is an existing file or ends with .py/.sh → harness.
+    # If it contains && or ; or starts with python3/make → shell command.
+    eval_spec: str | None = typer.Option(None, "--eval", help="Evaluation harness file or test command. Auto-detected: file path → harness, shell command → test command.", rich_help_panel="Kernel"),
+    # Legacy aliases (deprecated — use --eval instead)
+    test_command: str | None = typer.Option(None, "--test_command", "--test-command", help="[Deprecated: use --eval] Test command to run for patch validation", hidden=True),
     create_test: bool = typer.Option(
         False,
         "--create-test",
@@ -251,8 +328,19 @@ def main(
     configure_if_first_time()
 
     configure_agent_filter_env(allowed_agents, excluded_agents)
-    if harness and not kernel_url:
-        raise typer.BadParameter("--harness requires --kernel-url")
+
+    # Merge --eval, --harness, --test-command into unified eval_spec
+    if eval_spec is None and harness:
+        eval_spec = harness  # legacy --harness → --eval
+    if eval_spec is None and test_command:
+        eval_spec = test_command  # legacy --test-command → --eval
+
+    # Extract kernel URL from task prompt if --kernel-url not given
+    if not kernel_url and task:
+        _extracted = _extract_kernel_from_task(task if not Path(task).is_file() else Path(task).read_text())
+        if _extracted:
+            kernel_url = _extracted
+            console.print(f"[bold cyan]Extracted kernel from task: {kernel_url}[/bold cyan]")
 
     # Deprecated --from-task: map to --task for backward compatibility
     _task_worktree: Path | None = None
@@ -556,8 +644,8 @@ def main(
 
     # ============ Full pipeline mode: geak <url> ============
     # When a kernel URL is provided (and we're not in a structured-task sub-agent mode),
-    # route through the preprocessor -> orchestrator pipeline instead of the
-    # legacy monolithic flow.
+    # route through the preprocessor -> orchestrator pipeline.
+    # This is the ONLY optimization path — always preprocess → orchestrate.
     if kernel_url and not _tf_meta:
         from minisweagent.run.orchestrator import run_orchestrator
         from minisweagent.run.preprocessor import run_preprocessor
@@ -567,6 +655,34 @@ def main(
         console.print(f"[dim]Kernel URL: {kernel_url}[/dim]")
         console.print(f"[dim]Output dir: {_pipeline_output}[/dim]")
 
+        # Resolve --eval: auto-detect harness vs command
+        _harness_arg: str | None = None
+        _eval_commands: dict | None = None
+        if eval_spec:
+            eval_type, eval_value = _resolve_eval_spec(eval_spec, workspace=repo)
+            if eval_type == "harness":
+                _harness_arg = eval_value
+                console.print(f"[dim]Eval mode: harness → {eval_value}[/dim]")
+            else:
+                # Shell command — parse into separate commands
+                # Split on && to identify compile/correctness/performance parts
+                parts = [p.strip() for p in eval_value.split("&&") if p.strip()]
+                _eval_commands = {}
+                if len(parts) >= 3:
+                    # Assume: compile && correctness && performance
+                    _eval_commands["compile_command"] = parts[0]
+                    _eval_commands["correctness_command"] = parts[1]
+                    _eval_commands["performance_command"] = parts[2]
+                elif len(parts) == 2:
+                    # Assume: correctness && performance
+                    _eval_commands["correctness_command"] = parts[0]
+                    _eval_commands["performance_command"] = parts[1]
+                else:
+                    # Single command — use for both
+                    _eval_commands["correctness_command"] = eval_value
+                    _eval_commands["performance_command"] = eval_value
+                console.print(f"[dim]Eval mode: command → {eval_value}[/dim]")
+
         preprocess_ctx = run_preprocessor(
             kernel_url,
             output_dir=_pipeline_output,
@@ -574,8 +690,9 @@ def main(
             model=model,
             model_factory=lambda: get_model(model_name_resolved, config.get("model", {})),
             console=console,
-            harness=harness,
+            harness=_harness_arg,
             repo=repo,
+            eval_commands=_eval_commands,
         )
 
         model_cfg = config.get("model", {})

--- a/src/minisweagent/run/preprocessor.py
+++ b/src/minisweagent/run/preprocessor.py
@@ -352,6 +352,7 @@ def run_preprocessor(
     console=None,
     harness: str | None = None,
     repo: str | Path | None = None,
+    eval_commands: dict[str, str | list[str]] | None = None,
 ) -> dict[str, Any]:
     """Run all preprocessing steps and return a context dict.
 
@@ -369,6 +370,14 @@ def run_preprocessor(
         Callable returning a new model instance (used if model is None).
     console:
         Optional Rich console for progress messages.
+    harness:
+        Exact harness file path (Triton-style with --correctness/--benchmark modes).
+    repo:
+        Repository root path.
+    eval_commands:
+        HIP-style commands dict with keys: compile_command, correctness_command,
+        performance_command. When provided, COMMANDMENT is generated from these
+        commands instead of from a harness. Discovery and UnitTestAgent are skipped.
 
     Returns
     -------
@@ -487,7 +496,26 @@ def run_preprocessor(
         "harness": harness,
     }
 
-    if harness:
+    if eval_commands:
+        # Skip harness creation entirely — COMMANDMENT will be generated from commands in Step 7
+        _print("  Skipping harness creation (eval_commands provided)")
+        selected_harness_source = "eval_commands"
+        testcase_selection["selected_source"] = "eval_commands"
+        # Build test_command from eval_commands for compatibility (deduplicated)
+        _cmds = []
+        _seen = set()
+        for key in ("compile_command", "correctness_command", "performance_command"):
+            val = eval_commands.get(key)
+            if val:
+                items = val if isinstance(val, list) else [val]
+                for cmd in items:
+                    if cmd not in _seen:
+                        _seen.add(cmd)
+                        _cmds.append(cmd)
+        if _cmds:
+            test_command = " && ".join(_cmds)
+
+    elif harness:
         deterministic_path, deterministic_meta = _resolve_deterministic_harness(
             harness,
             kernel_url=kernel_url,
@@ -877,7 +905,36 @@ def run_preprocessor(
     _print("[bold cyan]--- Step 7/7: Commandment ---[/bold cyan]" if console else "--- Step 7/7: Commandment ---")
 
     commandment: str | None = None
-    if test_command:
+    if eval_commands:
+        # HIP-style: generate COMMANDMENT from explicit compile/correctness/perf commands
+        try:
+            from minisweagent.tools.commandment import generate_commandment_from_commands
+
+            commandment = generate_commandment_from_commands(
+                kernel_path=kernel_path,
+                compile_command=eval_commands.get("compile_command"),
+                correctness_command=eval_commands.get("correctness_command"),
+                performance_command=eval_commands.get("performance_command"),
+                repo_root=repo_root,
+            )
+            # Build a test_command from the commands for save_and_test compatibility
+            cmds = []
+            for key in ("compile_command", "correctness_command", "performance_command"):
+                val = eval_commands.get(key)
+                if val:
+                    if isinstance(val, list):
+                        cmds.extend(val)
+                    else:
+                        cmds.append(val)
+            if cmds:
+                test_command = " && ".join(cmds)
+                ctx["test_command"] = test_command
+            _print("  COMMANDMENT.md generated (from eval commands)")
+        except Exception as exc:
+            _print(f"  [yellow]Commandment from commands failed: {exc}[/yellow]" if console else f"  Commandment from commands failed: {exc}")
+            logger.warning("Commandment from commands failed: %s", exc, exc_info=True)
+    elif test_command:
+        # Triton-style: generate COMMANDMENT from harness
         try:
             from minisweagent.tools.commandment import generate_commandment
             from minisweagent.tools.discovery_types import _infer_kernel_language
@@ -891,12 +948,12 @@ def run_preprocessor(
                 repo_root=repo_root,
                 kernel_language=_kl,
             )
-            _print("  COMMANDMENT.md generated")
+            _print("  COMMANDMENT.md generated (from harness)")
         except Exception as exc:
             _print(f"  [yellow]Commandment failed: {exc}[/yellow]" if console else f"  Commandment failed: {exc}")
             logger.warning("Commandment generation failed: %s", exc, exc_info=True)
     else:
-        _print("  Skipping commandment (no test command)")
+        _print("  Skipping commandment (no test command or eval commands)")
 
     ctx["commandment"] = commandment
     if commandment:

--- a/src/minisweagent/tools/commandment.py
+++ b/src/minisweagent/tools/commandment.py
@@ -336,6 +336,108 @@ def _auto_fix(content: str, errors: list[str]) -> str:
     return content
 
 
+def generate_commandment_from_commands(
+    kernel_path: str | Path,
+    compile_command: str | list[str] | None = None,
+    correctness_command: str | list[str] | None = None,
+    performance_command: str | list[str] | None = None,
+    repo_root: str | Path | None = None,
+    *,
+    warmup_runs: int = 2,
+    profile_replays: int = 5,
+) -> str:
+    """Generate a valid COMMANDMENT.md from explicit compile/correctness/performance commands.
+
+    This is the HIP/C++ equivalent of generate_commandment() which takes a harness.
+    Instead of a harness with --correctness/--profile/--benchmark modes, this function
+    builds COMMANDMENT sections from separate shell commands.
+
+    Args:
+        kernel_path: Path to the kernel file being optimized.
+        compile_command: Command(s) to compile the kernel (e.g. "make" or ["make clean", "make"]).
+        correctness_command: Command(s) to validate correctness.
+        performance_command: Command(s) to benchmark performance.
+        repo_root: Repository root for PYTHONPATH.
+        warmup_runs: Number of warm-up invocations before profiling.
+        profile_replays: Number of replay passes for kernel-profile.
+
+    Returns:
+        The content of a valid COMMANDMENT.md as a string.
+    """
+    kernel_path = Path(kernel_path).resolve()
+    if repo_root is not None:
+        repo_root = Path(repo_root).resolve()
+    else:
+        repo_root = kernel_path.parent
+
+    def _join_cmds(cmds):
+        if cmds is None:
+            return ""
+        if isinstance(cmds, str):
+            return cmds.strip()
+        return " && ".join(c.strip() for c in cmds if c.strip())
+
+    compile_cmd = _join_cmds(compile_command)
+    correctness_cmd = _join_cmds(correctness_command)
+    performance_cmd = _join_cmds(performance_command)
+
+    # SETUP: compile step (cd to workdir first)
+    setup_parts = []
+    setup_parts.append(
+        "printf '#!/bin/bash\\nexport PYTHONPATH=%s:%s:${PYTHONPATH}\\n"
+        "export HIP_VISIBLE_DEVICES=%s\\n"
+        'exec \"$@\"\\n\' '
+        '"${GEAK_WORK_DIR}" "${GEAK_REPO_ROOT}" "${GEAK_GPU_DEVICE}" '
+        "> ${GEAK_WORK_DIR}/run.sh && chmod +x ${GEAK_WORK_DIR}/run.sh"
+    )
+    if compile_cmd:
+        setup_parts.append(f"cd ${{GEAK_WORK_DIR}} && {compile_cmd}")
+    setup_section = "\n".join(setup_parts)
+
+    # CORRECTNESS
+    if correctness_cmd:
+        correctness_section = f"cd ${{GEAK_WORK_DIR}} && {correctness_cmd}"
+    else:
+        correctness_section = "echo 'No correctness command specified'"
+
+    # PROFILE: use correctness command for profiling if no separate profile command
+    profile_target = correctness_cmd or performance_cmd or "echo 'no profile target'"
+    warmup_block = _warmup_block(
+        f"cd ${{GEAK_WORK_DIR}} && {profile_target} > /dev/null 2>&1 || true",
+        warmup_runs,
+    )
+    profile_section = (
+        f"{warmup_block}\n"
+        f'kernel-profile "cd ${{GEAK_WORK_DIR}} && {profile_target}" '
+        f"--gpu-devices ${{GEAK_GPU_DEVICE}} --replays {profile_replays}"
+    )
+
+    # BENCHMARK and FULL_BENCHMARK
+    if performance_cmd:
+        benchmark_section = f"cd ${{GEAK_WORK_DIR}} && {performance_cmd}"
+    else:
+        benchmark_section = correctness_section  # fallback to correctness
+
+    content = f"""\
+## SETUP
+{setup_section}
+
+## CORRECTNESS
+{correctness_section}
+
+## PROFILE
+{profile_section}
+
+## BENCHMARK
+{benchmark_section}
+
+## FULL_BENCHMARK
+{benchmark_section}
+"""
+
+    return _validate_and_fix(content, harness_path=None)
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Simplifies the GEAK CLI by merging `--harness` and `--test-command` into a single `--eval` flag, adds HIP support to the full preprocessing pipeline, and implements anti-cheat guardrails.

### Before vs After

```
BEFORE:                                    AFTER:
  --harness test.py (Triton only)            --eval test.py        (auto-detect: harness)
  --test-command "make && test" (HIP)        --eval "make && test" (auto-detect: command)
  Path A: preprocessor→orchestrator          Always: preprocessor→orchestrator
  Path B: ParallelAgent (legacy)             (Path B kept for structured task files only)
```

### Changes

**Unified `--eval` flag** (`mini.py`)
- Auto-detects: file path → harness mode, shell command → command mode
- Legacy `--harness` and `--test-command` kept as hidden aliases
- Extracts kernel URL from task prompt text (GitHub URLs, local paths, YAML frontmatter)

**COMMANDMENT from commands** (`commandment.py`)
- New `generate_commandment_from_commands()` for HIP-style kernels
- Generates all 5 COMMANDMENT sections from compile/correctness/performance commands
- Enables HIP kernels to use the full preprocessor→orchestrator pipeline

**Anti-cheat guardrails** (`save_and_test.py`, `orchestrator.py`, `benchmark_parsing.py`)
- Layer 1: Restore protected eval files (harness, benchmarks/, scripts/) before each test
- Layer 2: Restore benchmark config variables in source files from baseline
- Layer 3: Config fingerprint validation — reject speedup if benchmark output configs differ from baseline
- HIP baseline vs cheated - Shapes changed by agent (256,1024)→(2,2)	DIFFER — caught reported 2.13x speedup, actually 1.07

**UnitTestAgent improvements** (`mini_unit_test_agent.yaml`)
- Read README.md first, pip install upfront, adapt existing benchmarks
- Require per-shape config+latency lines for fingerprinting
- Four modes (was three), INSTRUCTIONS.md optional

**Preprocessor** (`preprocessor.py`)
- Skip UnitTestAgent when `eval_commands` provided (HIP path)
- Build test_command with deduplication
- Branch: harness → `generate_commandment()`, commands → `generate_commandment_from_commands()`

## Test plan

- [x] Triton: `geak --kernel kernel.py --eval test_kernel_harness.py` → full pipeline, COMMANDMENT from harness
- [x] HIP: `geak --kernel silu.hip --eval "compile && correctness && performance"` → full pipeline, COMMANDMENT from commands, UnitTestAgent skipped
- [x] Config fingerprint: catches lean_atten_paged benchmark config cheat
- [x] Auto-detect: harness file vs shell command
- [x] Kernel extraction from task prompt (GitHub URL, local path, frontmatter)
- [ ] Full AKA Triton run (8 kernels)
- [ ] Full AKA HIP run (16 kernels)
