### PR TITLE
fix(preprocess): structured eval_command path — proper command separation, baseline capture, and COMMANDMENT generation

### DIFF
--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -349,6 +349,9 @@ def run_preprocessor(
     harness: str | None = None,
     repo: str | Path | None = None,
     eval_command: str | None = None,
+    compile_command: str | list[str] | None = None,
+    correctness_command: str | list[str] | None = None,
+    performance_command: str | list[str] | None = None,
 ) -> dict[str, Any]:
     """Run all preprocessing steps and return a context dict.
 
@@ -371,9 +374,17 @@ def run_preprocessor(
     repo:
         Repository root path.
     eval_command:
-        Single eval command string (e.g. "python test.py") that handles compile,
-        correctness, and performance testing. When provided, COMMANDMENT is generated
-        from this command instead of from a harness. Discovery and UnitTestAgent are skipped.
+        Legacy single command string. Prefer the structured triple
+        (compile_command, correctness_command, performance_command) instead.
+        When only eval_command is given the preprocessor must guess which
+        part is build vs. execution — the structured form avoids that.
+    compile_command:
+        Build/setup step(s), e.g. ``"make"`` or ``["make clean", "make"]``.
+    correctness_command:
+        Correctness-validation command(s), e.g. ``"./test"``.
+    performance_command:
+        Benchmark/performance command(s), e.g. ``"./benchmark"``.  Used
+        directly for profiling and baseline capture — no ``&&`` guessing.
 
     Returns
     -------
@@ -392,6 +403,26 @@ def run_preprocessor(
             print(msg, file=sys.stderr)
 
     ctx: dict[str, Any] = {}
+
+    # ── Normalise structured commands ────────────────────────────────
+    def _join(cmd: str | list[str] | None) -> str | None:
+        if cmd is None:
+            return None
+        if isinstance(cmd, list):
+            return " && ".join(c.strip() for c in cmd if c.strip()) or None
+        return cmd.strip() or None
+
+    compile_cmd = _join(compile_command)
+    correctness_cmd = _join(correctness_command)
+    perf_cmd = _join(performance_command)
+
+    has_structured = any(c is not None for c in (compile_cmd, correctness_cmd, perf_cmd))
+    if has_structured and not eval_command:
+        eval_command = " && ".join(
+            c for c in (compile_cmd, correctness_cmd, perf_cmd) if c
+        )
+    elif eval_command and not has_structured:
+        perf_cmd = eval_command
 
     # ── 1. resolve-kernel-url ────────────────────────────────────────
     _print(
@@ -889,23 +920,24 @@ def run_preprocessor(
 
     profiling: dict[str, Any] | None = None
     if eval_command:
-        # HIP-style: use performance_command directly for profiling
-        perf_cmd = eval_command
-        if perf_cmd:
-            if isinstance(perf_cmd, list):
-                perf_cmd = " && ".join(perf_cmd)
+        if not perf_cmd:
+            _print("  Skipping profiling (no performance_command in eval_command)")
+        else:
+            _cwd = str(repo_root) if repo_root else None
 
-            # If perf_cmd is "a && b && c" format, extract only the last command for profiling
-            # (the earlier parts are typically build/setup steps, not the actual execution)
-            if " && " in perf_cmd:
-                perf_cmd_parts = perf_cmd.split(" && ")
-                perf_cmd_for_profiling = perf_cmd_parts[-1].strip()
-                _print(f"  Original eval_command: {perf_cmd}")
-                _print(f"  Extracted last command for profiling: {perf_cmd_for_profiling}")
-            else:
-                perf_cmd_for_profiling = perf_cmd
+            if compile_cmd:
+                _print(f"  Running build step: {compile_cmd}")
+                import subprocess
+                _build = subprocess.run(
+                    compile_cmd, shell=True, capture_output=True, text=True,
+                    timeout=120, cwd=_cwd,
+                )
+                if _build.returncode != 0:
+                    _print(f"  Build FAILED (rc={_build.returncode})")
+                    if _build.stderr:
+                        _print(f"  stderr: {_build.stderr[:500]}")
 
-            _print(f"  Profiling with performance_command: {perf_cmd_for_profiling}")
+            _print(f"  Profiling with performance_command: {perf_cmd}")
             try:
                 _ensure_mcp_importable()
                 profiler_server = importlib.import_module("profiler_mcp.server")
@@ -913,45 +945,45 @@ def run_preprocessor(
 
                 _profile_fn = getattr(profile_kernel, "fn", profile_kernel)
                 profiling = _profile_fn(
-                    command=perf_cmd_for_profiling,
+                    command=perf_cmd,
                     backend="metrix",
                     num_replays=3,
                     quick=True,
                     gpu_devices=str(gpu_id),
-                    workdir=str(repo_root) if repo_root else None,
+                    workdir=_cwd,
                 )
             except Exception as exc:
                 _print(f"  [yellow]Profiling failed: {exc}[/yellow]" if console else f"  Profiling failed: {exc}")
                 logger.warning("Profiling failed: %s", exc, exc_info=True)
 
-            # Fallback: if profiling failed or returned unsuccessful, run performance_command directly
-            profiling_ok = profiling is not None and profiling.get("success", False)
-            if not profiling_ok:
-                _print("  Running performance_command directly as fallback for baseline...")
-                try:
-                    import subprocess
+            _print("  Capturing benchmark baseline from performance_command...")
+            try:
+                import subprocess
 
-                    result = subprocess.run(
-                        perf_cmd,
-                        shell=True,
-                        capture_output=True,
-                        text=True,
-                        timeout=300,
-                        cwd=str(repo_root) if repo_root else None,
-                    )
-                    if result.returncode == 0:
-                        (output_dir / "benchmark_baseline.txt").write_text(result.stdout)
-                        (output_dir / "full_benchmark_baseline.txt").write_text(result.stdout)
-                        _print(f"  Fallback baseline saved to benchmark_baseline.txt ({len(result.stdout)} bytes)")
-                    else:
-                        _print(f"  Fallback baseline capture: FAILED (returncode={result.returncode})")
-                        if result.stderr:
-                            _print(f"  stderr: {result.stderr[:500]}")
-                except Exception as fallback_exc:
-                    _print(f"  Fallback baseline capture failed: {fallback_exc}")
-                    logger.warning("Fallback baseline capture failed: %s", fallback_exc, exc_info=True)
-        else:
-            _print("  Skipping profiling (no performance_command in eval_command)")
+                result = subprocess.run(
+                    perf_cmd,
+                    shell=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=300,
+                    cwd=_cwd,
+                )
+                if result.returncode == 0:
+                    benchmark_baseline = result.stdout
+                    full_benchmark_baseline = result.stdout
+                    (output_dir / "benchmark_baseline.txt").write_text(result.stdout)
+                    (output_dir / "full_benchmark_baseline.txt").write_text(result.stdout)
+                    _print(f"  Baseline saved to benchmark_baseline.txt ({len(result.stdout)} bytes)")
+                else:
+                    _print(f"  Baseline capture: FAILED (returncode={result.returncode})")
+                    if result.stderr:
+                        _print(f"  stderr: {result.stderr[:500]}")
+            except Exception as baseline_exc:
+                _print(f"  Baseline capture failed: {baseline_exc}")
+                logger.warning("Baseline capture failed: %s", baseline_exc, exc_info=True)
+
+        ctx["benchmark_baseline"] = benchmark_baseline
+        ctx["full_benchmark_baseline"] = full_benchmark_baseline
     elif test_command:
         ctx["harness_path"] = extract_harness_path(test_command)
         (output_dir / "harness_path.txt").write_text(ctx["harness_path"])
@@ -1030,15 +1062,14 @@ def run_preprocessor(
 
     commandment: str | None = None
     if eval_command:
-        # Single eval command handles compile/correctness/performance
         try:
             from minisweagent.run.preprocess.commandment import generate_commandment_from_commands
 
             commandment = generate_commandment_from_commands(
                 kernel_path=kernel_path,
-                compile_command=None,
-                correctness_command=None,
-                performance_command=eval_command,
+                compile_command=compile_cmd,
+                correctness_command=correctness_cmd,
+                performance_command=perf_cmd or eval_command,
                 repo_root=repo_root,
             )
             ctx["test_command"] = eval_command
@@ -1165,7 +1196,22 @@ def main() -> None:
     parser.add_argument(
         "--eval-command",
         default=None,
-        help='Single command string (e.g. "python test.py") that handles compile, correctness, and performance testing. Skips harness creation.',
+        help='Legacy single command string. Prefer --compile-command / --correctness-command / --performance-command.',
+    )
+    parser.add_argument(
+        "--compile-command",
+        default=None,
+        help='Build/setup command (e.g. "make"). Used in COMMANDMENT SETUP.',
+    )
+    parser.add_argument(
+        "--correctness-command",
+        default=None,
+        help='Correctness validation command (e.g. "./test").',
+    )
+    parser.add_argument(
+        "--performance-command",
+        default=None,
+        help='Benchmark command (e.g. "./benchmark"). Used for profiling and baseline capture.',
     )
     args = parser.parse_args()
 
@@ -1191,6 +1237,9 @@ def main() -> None:
     print(f"  model:                {args.model}")
     print(f"  harness:              {args.harness}")
     print(f"  repo:                 {args.repo}")
+    print(f"  compile_command:      {args.compile_command}")
+    print(f"  correctness_command:  {args.correctness_command}")
+    print(f"  performance_command:  {args.performance_command}")
     print("-" * 60)
     print(f"  GEAK_MODEL:                 {os.environ.get('GEAK_MODEL', '<not set>')}")
     print(f"  GEAK_MODEL_ENSEMBLE:        {os.environ.get('GEAK_MODEL_ENSEMBLE', '<not set>')}")
@@ -1209,6 +1258,9 @@ def main() -> None:
         harness=args.harness,
         repo=args.repo,
         eval_command=args.eval_command,
+        compile_command=args.compile_command,
+        correctness_command=args.correctness_command,
+        performance_command=args.performance_command,
     )
 
     print(json.dumps(ctx, indent=2, default=str))


### PR DESCRIPTION
## Problem

The `eval_command` (HIP-style) preprocessing path in `preprocessor.py` has four interconnected bugs that cause missing artifacts, polluted output, and degraded pipeline quality. These affect all non-Triton (HIP/C++) kernel preprocessing.

### Bug 1: Fragile `&&` split heuristic for profiling (line 898)

When `eval_command` is a compound string like `"make && ./test && ./benchmark"`, the code blindly splits on `" && "` and **guesses** the last segment is the profiling target:

```python
perf_cmd_parts = perf_cmd.split(" && ")
perf_cmd_for_profiling = perf_cmd_parts[-1].strip()
```

This breaks for commands with nested `&&`, quoted strings containing `&&`, or when the benchmark command isn't the last one. Compare to the harness path, which explicitly runs `python {harness} --profile`.

### Bug 2: "Dump everything" baseline capture (line 934)

When profiling fails, the fallback runs the **entire** `eval_command` chain (`make && ./test && ./benchmark`) and dumps **all** stdout — build output, correctness output, and benchmark output mixed together — into `benchmark_baseline.txt`. Downstream consumers like `extract_latency_ms` have to parse through garbage.

Compare to the harness path, which runs each mode separately and extracts benchmark stdout specifically.

### Bug 3: Baseline capture gated behind profiling failure (line 960)

The baseline capture was inside `if not profiling_ok:` — meaning **if profiling succeeded, no `benchmark_baseline.txt` was ever written**. The harness path always gets this file (from `execute_harness_validation`), so the eval_command path silently produced incomplete output. Step 6 (baseline-metrics) tries to read `benchmark_baseline.txt` to compute `benchmark_duration_us` — and finds nothing.

Additionally, `ctx["benchmark_baseline"]` and `ctx["full_benchmark_baseline"]` were **never set** in the eval_command path (only in the harness `else` branch at lines 908-909), so downstream orchestrator consumers received `None`.

### Bug 4: COMMANDMENT loses all structure (line 1037)

`generate_commandment_from_commands()` was designed to accept separate `compile_command`, `correctness_command`, and `performance_command`. But the preprocessor passed:

```python
compile_command=None,
correctness_command=None,
performance_command=eval_command,  # the entire "make && ./test && ./benchmark" string
```

The config files **already have** this structure (`compile_command: make`, `correctness_command: ./test`, `performance_command: ./benchmark`), but it was destroyed before entering the preprocessor. The generated COMMANDMENT.md had no SETUP/compile section and no separate CORRECTNESS section.

---

## Fix

### New structured parameters

`run_preprocessor()` and the `geak-preprocess` CLI now accept three additional optional parameters:

| Parameter | CLI flag | Purpose |
|---|---|---|
| `compile_command` | `--compile-command` | Build/setup step (e.g. `"make"`) |
| `correctness_command` | `--correctness-command` | Correctness validation (e.g. `"./test"`) |
| `performance_command` | `--performance-command` | Benchmark (e.g. `"./benchmark"`) |

### What each fix does

1. **`&&` hack removed** — `perf_cmd` is now known directly from `performance_command`. If `compile_cmd` is provided, it runs as a separate build step before profiling.

2. **Baseline targets only benchmark output** — the fallback `subprocess.run` now runs only `perf_cmd`, not the entire compound chain.

3. **Baseline capture is unconditional** — runs after profiling regardless of success/failure. Both the files (`benchmark_baseline.txt`, `full_benchmark_baseline.txt`) and the ctx dict (`ctx["benchmark_baseline"]`, `ctx["full_benchmark_baseline"]`) are always populated.

4. **COMMANDMENT gets proper structure** — `generate_commandment_from_commands()` now receives the real `compile_cmd`, `correctness_cmd`, and `perf_cmd`, producing a COMMANDMENT.md with proper SETUP, CORRECTNESS, and BENCHMARK sections.

### Backward compatibility

Callers passing only `--eval-command` still work:
- `perf_cmd` defaults to the full `eval_command` string
- `eval_command` is synthesised from the structured triple when only the new params are given

---

## Usage

**Before** (single opaque string):

```bash
geak-preprocess <kernel-url> \
  --eval-command "make && ./test && ./benchmark"
```

**After** (structured — preferred):

```bash
geak-preprocess <kernel-url> \
  --compile-command "make" \
  --correctness-command "./test" \
  --performance-command "./benchmark"
```

**Python API**:

```python
ctx = run_preprocessor(
    kernel_url,
    output_dir,
    compile_command="make",
    correctness_command="./test",
    performance_command="./benchmark",
)
```

The old `--eval-command` flag still works but is now documented as legacy.

---

## Test plan

- [ ] Run `geak-preprocess` with `--compile-command`, `--correctness-command`, `--performance-command` on a HIP task — verify `benchmark_baseline.txt`, `profile.json`, and `COMMANDMENT.md` are all generated correctly
- [ ] Run `geak-preprocess` with only `--eval-command` (legacy) — verify backward compatibility
- [ ] Verify `COMMANDMENT.md` has proper SETUP, CORRECTNESS, and BENCHMARK sections when structured commands are provided
- [ ] Verify `baseline_metrics.json` contains `benchmark_duration_us` (extracted from `benchmark_baseline.txt`)
