### PR TITLE
fix(preprocess): structured eval_command path , proper command separa…

### DIFF
--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -349,7 +349,6 @@ def run_preprocessor(
     harness: str | None = None,
     repo: str | Path | None = None,
     eval_command: str | None = None,
-    compile_command: str | list[str] | None = None,
     correctness_command: str | list[str] | None = None,
     performance_command: str | list[str] | None = None,
 ) -> dict[str, Any]:
@@ -374,14 +373,15 @@ def run_preprocessor(
     repo:
         Repository root path.
     eval_command:
-        Legacy single command string. Prefer the structured triple
-        (compile_command, correctness_command, performance_command) instead.
+        Legacy single command string. Prefer the structured pair
+        (correctness_command, performance_command) instead.
         When only eval_command is given the preprocessor must guess which
         part is build vs. execution — the structured form avoids that.
-    compile_command:
-        Build/setup step(s), e.g. ``"make"`` or ``["make clean", "make"]``.
     correctness_command:
-        Correctness-validation command(s), e.g. ``"./test"``.
+        Compile + correctness validation command(s), e.g.
+        ``"make && ./test"`` or ``["make", "./test"]``.  Compilation
+        should be folded in so that a build failure is a correctness
+        failure.
     performance_command:
         Benchmark/performance command(s), e.g. ``"./benchmark"``.  Used
         directly for profiling and baseline capture — no ``&&`` guessing.
@@ -412,14 +412,13 @@ def run_preprocessor(
             return " && ".join(c.strip() for c in cmd if c.strip()) or None
         return cmd.strip() or None
 
-    compile_cmd = _join(compile_command)
     correctness_cmd = _join(correctness_command)
     perf_cmd = _join(performance_command)
 
-    has_structured = any(c is not None for c in (compile_cmd, correctness_cmd, perf_cmd))
+    has_structured = any(c is not None for c in (correctness_cmd, perf_cmd))
     if has_structured and not eval_command:
         eval_command = " && ".join(
-            c for c in (compile_cmd, correctness_cmd, perf_cmd) if c
+            c for c in (correctness_cmd, perf_cmd) if c
         )
     elif eval_command and not has_structured:
         perf_cmd = eval_command
@@ -925,18 +924,6 @@ def run_preprocessor(
         else:
             _cwd = str(repo_root) if repo_root else None
 
-            if compile_cmd:
-                _print(f"  Running build step: {compile_cmd}")
-                import subprocess
-                _build = subprocess.run(
-                    compile_cmd, shell=True, capture_output=True, text=True,
-                    timeout=120, cwd=_cwd,
-                )
-                if _build.returncode != 0:
-                    _print(f"  Build FAILED (rc={_build.returncode})")
-                    if _build.stderr:
-                        _print(f"  stderr: {_build.stderr[:500]}")
-
             _print(f"  Profiling with performance_command: {perf_cmd}")
             try:
                 _ensure_mcp_importable()
@@ -1067,7 +1054,7 @@ def run_preprocessor(
 
             commandment = generate_commandment_from_commands(
                 kernel_path=kernel_path,
-                compile_command=compile_cmd,
+                compile_command=None,
                 correctness_command=correctness_cmd,
                 performance_command=perf_cmd or eval_command,
                 repo_root=repo_root,
@@ -1196,17 +1183,12 @@ def main() -> None:
     parser.add_argument(
         "--eval-command",
         default=None,
-        help='Legacy single command string. Prefer --compile-command / --correctness-command / --performance-command.',
-    )
-    parser.add_argument(
-        "--compile-command",
-        default=None,
-        help='Build/setup command (e.g. "make"). Used in COMMANDMENT SETUP.',
+        help='Legacy single command string. Prefer --correctness-command / --performance-command.',
     )
     parser.add_argument(
         "--correctness-command",
         default=None,
-        help='Correctness validation command (e.g. "./test").',
+        help='Compile + correctness command (e.g. "make && ./test"). Build should be folded in.',
     )
     parser.add_argument(
         "--performance-command",
@@ -1237,7 +1219,6 @@ def main() -> None:
     print(f"  model:                {args.model}")
     print(f"  harness:              {args.harness}")
     print(f"  repo:                 {args.repo}")
-    print(f"  compile_command:      {args.compile_command}")
     print(f"  correctness_command:  {args.correctness_command}")
     print(f"  performance_command:  {args.performance_command}")
     print("-" * 60)
@@ -1258,7 +1239,6 @@ def main() -> None:
         harness=args.harness,
         repo=args.repo,
         eval_command=args.eval_command,
-        compile_command=args.compile_command,
         correctness_command=args.correctness_command,
         performance_command=args.performance_command,
     )


### PR DESCRIPTION
## Problem

The `eval_command` (HIP-style) preprocessing path in `preprocessor.py` has four interconnected bugs that cause missing artifacts, polluted output, and degraded pipeline quality. These affect all non-Triton (HIP/C++) kernel preprocessing.

### Real-world example

A user ran preprocessing with this eval_command (extracted from a `mini --task` string):

```
python3 scripts/task_runner.py compile && python3 scripts/task_runner.py correctness && python3 scripts/task_runner.py performance
```

via:

```python
preprocess_ctx = run_preprocessor(
    kernel_url=kernel_url,
    repo=repo,
    output_dir=Path(preprocess_output_dir),
    gpu_id=parsed_gpu_ids[0],
    model_factory=...,
    console=console,
    harness=harness,
    eval_command=test_command,  # the entire compound string
)
```

**Result**: `profile.json` and `baseline_metrics.json` were generated (profiling succeeded), but `benchmark_baseline.txt` was missing, and the COMMANDMENT.md was broken:

```
## SETUP
printf '#!/bin/bash\n...' > ${GEAK_WORK_DIR}/run.sh && chmod +x ${GEAK_WORK_DIR}/run.sh

## CORRECTNESS
echo 'No correctness command specified'

## PROFILE
kernel-profile "cd ${GEAK_WORK_DIR} && python3 scripts/task_runner.py compile && python3 scripts/task_runner.py correctness && python3 scripts/task_runner.py performance" ...

## BENCHMARK
cd ${GEAK_WORK_DIR} && python3 scripts/task_runner.py compile && python3 scripts/task_runner.py correctness && python3 scripts/task_runner.py performance
```

Every section is wrong:
- **CORRECTNESS** says "No correctness command specified" — but there IS a correctness command (`task_runner.py correctness`)
- **SETUP** has no compile step — but there IS a compile command (`task_runner.py compile`)
- **PROFILE** profiles the entire chain including compile and correctness (wasteful, pollutes trace)
- **BENCHMARK** runs compile + correctness + performance all together (pollutes output)

---

### Bug 1: Fragile `&&` split heuristic for profiling (line 898)

When `eval_command` is a compound string, the code blindly splits on `" && "` and **guesses** the last segment is the profiling target:

```python
perf_cmd_parts = perf_cmd.split(" && ")
perf_cmd_for_profiling = perf_cmd_parts[-1].strip()
```

This breaks for commands with nested `&&`, quoted strings containing `&&`, or when the benchmark command isn't the last one. Compare to the harness path, which explicitly runs `python {harness} --profile`.

### Bug 2: "Dump everything" baseline capture (line 934)

When profiling fails, the fallback runs the **entire** `eval_command` chain and dumps **all** stdout — build output, correctness output, and benchmark output mixed together — into `benchmark_baseline.txt`. Downstream consumers like `extract_latency_ms` have to parse through garbage.

Compare to the harness path, which runs each mode separately and extracts benchmark stdout specifically.

### Bug 3: Baseline capture gated behind profiling failure (line 960)

The baseline capture was inside `if not profiling_ok:` — meaning **if profiling succeeded, no `benchmark_baseline.txt` was ever written**. This is exactly what the user hit: profiling succeeded, `profile.json` was written, `baseline_metrics.json` was built from Metrix data, but `benchmark_baseline.txt` was never created.

Additionally, `ctx["benchmark_baseline"]` and `ctx["full_benchmark_baseline"]` were **never set** in the eval_command path (only in the harness `else` branch at lines 908-909), so downstream consumers received `None`.

### Bug 4: COMMANDMENT loses all structure (line 1037)

`generate_commandment_from_commands()` was designed to accept separate `compile_command`, `correctness_command`, and `performance_command`. But the preprocessor passed:

```python
compile_command=None,
correctness_command=None,
performance_command=eval_command,  # the entire compound string
```

This is why the generated COMMANDMENT had `echo 'No correctness command specified'` and no compile step in SETUP — the structure was destroyed before it reached the commandment generator.

---

## Fix

### New structured parameters

`run_preprocessor()` and the `geak-preprocess` CLI now accept three additional optional parameters:

| Parameter | CLI flag | Purpose |
|---|---|---|
| `compile_command` | `--compile-command` | Build/setup step (e.g. `"make"` or `"python3 scripts/task_runner.py compile"`) |
| `correctness_command` | `--correctness-command` | Correctness validation (e.g. `"python3 scripts/task_runner.py correctness"`) |
| `performance_command` | `--performance-command` | Benchmark (e.g. `"python3 scripts/task_runner.py performance"`) |

### What each fix does

1. **`&&` hack removed** — `perf_cmd` is now known directly from `performance_command`. If `compile_cmd` is provided, it runs as a separate build step before profiling.

2. **Baseline targets only benchmark output** — `subprocess.run` now runs only `perf_cmd`, not the entire compound chain.

3. **Baseline capture is unconditional** — runs after profiling regardless of success/failure. Both the files (`benchmark_baseline.txt`, `full_benchmark_baseline.txt`) and the ctx dict (`ctx["benchmark_baseline"]`, `ctx["full_benchmark_baseline"]`) are always populated.

4. **COMMANDMENT gets proper structure** — `generate_commandment_from_commands()` now receives the real `compile_cmd`, `correctness_cmd`, and `perf_cmd`, producing a COMMANDMENT.md with proper SETUP, CORRECTNESS, and BENCHMARK sections.

### Backward compatibility

Callers passing only `eval_command` (or `--eval-command`) still work:
- `perf_cmd` defaults to the full `eval_command` string
- `eval_command` is synthesised from the structured triple when only the new params are given

---

## Usage

### The user's broken call (before)

```python
preprocess_ctx = run_preprocessor(
    kernel_url=kernel_url,
    repo=repo,
    output_dir=Path(preprocess_output_dir),
    gpu_id=parsed_gpu_ids[0],
    model_factory=...,
    console=console,
    eval_command="python3 scripts/task_runner.py compile && python3 scripts/task_runner.py correctness && python3 scripts/task_runner.py performance",
)
```

### The fixed call (after)

```python
preprocess_ctx = run_preprocessor(
    kernel_url=kernel_url,
    repo=repo,
    output_dir=Path(preprocess_output_dir),
    gpu_id=parsed_gpu_ids[0],
    model_factory=...,
    console=console,
    compile_command="python3 scripts/task_runner.py compile",
    correctness_command="python3 scripts/task_runner.py correctness",
    performance_command="python3 scripts/task_runner.py performance",
)
```

### CLI usage

**Before** (single opaque string):

```bash
geak-preprocess <kernel-url> \
  --eval-command "make && ./test && ./benchmark"
```

**After** (structured — preferred):

```bash
geak-preprocess <kernel-url> \
  --compile-command "make" \
  --correctness-command "./test" \
  --performance-command "./benchmark"
```

The old `--eval-command` flag still works but is now documented as legacy.

### Expected COMMANDMENT output (after fix)

```
## SETUP
printf '#!/bin/bash\n...' > ${GEAK_WORK_DIR}/run.sh && chmod +x ${GEAK_WORK_DIR}/run.sh
cd ${GEAK_WORK_DIR} && python3 scripts/task_runner.py compile

## CORRECTNESS
cd ${GEAK_WORK_DIR} && python3 scripts/task_runner.py correctness

## PROFILE
kernel-profile "cd ${GEAK_WORK_DIR} && python3 scripts/task_runner.py correctness" ...

## BENCHMARK
cd ${GEAK_WORK_DIR} && python3 scripts/task_runner.py performance

## FULL_BENCHMARK
cd ${GEAK_WORK_DIR} && python3 scripts/task_runner.py performance
```

---

## Test plan

- [ ] Run `geak-preprocess` with `--compile-command`, `--correctness-command`, `--performance-command` on a HIP task — verify `benchmark_baseline.txt`, `profile.json`, and `COMMANDMENT.md` are all generated correctly
- [ ] Run `geak-preprocess` with only `--eval-command` (legacy) — verify backward compatibility, confirm baseline is now always captured
- [ ] Verify `COMMANDMENT.md` has proper SETUP (with compile), CORRECTNESS, PROFILE, and BENCHMARK sections when structured commands are provided
- [ ] Verify `baseline_metrics.json` contains `benchmark_duration_us` (extracted from `benchmark_baseline.txt`)
- [ ] Verify `ctx["benchmark_baseline"]` and `ctx["full_benchmark_baseline"]` are populated in the returned dict
