### PR TITLE
fix: resolve empty patch files for non-git kernel sources

### DIFF
--- a/src/minisweagent/agents/parallel_agent.py
+++ b/src/minisweagent/agents/parallel_agent.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import json
 import re
 import shutil
+import subprocess
 import sys
 import threading
 import traceback
@@ -238,7 +239,11 @@ class ParallelAgent(DefaultAgent):
 
     @staticmethod
     def _create_copy_workdir(repo_path: Path, workdir_path: Path) -> Path:
-        """Create an isolated work directory by copying `repo_path` (for non-git repos)."""
+        """Create an isolated work directory by copying `repo_path` (for non-git repos).
+
+        Initializes the copy as a git repo so that ``git diff`` in
+        ``save_and_test`` and ``git apply`` in evaluation both work.
+        """
         if workdir_path.exists():
             try:
                 shutil.rmtree(workdir_path)
@@ -249,6 +254,12 @@ class ParallelAgent(DefaultAgent):
             repo_path,
             workdir_path,
             ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"),
+        )
+        subprocess.run(["git", "init", "-q"], cwd=str(workdir_path), capture_output=True)
+        subprocess.run(["git", "add", "."], cwd=str(workdir_path), capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "baseline", "--allow-empty"],
+            cwd=str(workdir_path), capture_output=True,
         )
         return workdir_path
 
@@ -429,6 +440,10 @@ class ParallelAgent(DefaultAgent):
                 agent.base_repo_path = repo_path_resolved
             if hasattr(agent, "log_file"):
                 agent.log_file = log_file
+            # Rebuild save_and_test context now that base_repo_path is set
+            # (it was None during __init__)
+            if hasattr(agent, "_setup_save_and_test_context"):
+                agent._setup_save_and_test_context()
 
             with open(log_file, "w", encoding="utf-8") as f:
                 f.write(f"Agent {agent_id} Conversation Log\n")
@@ -571,6 +586,9 @@ class ParallelAgent(DefaultAgent):
                 agent.base_repo_path = repo_path_resolved
             if hasattr(agent, "log_file"):
                 agent.log_file = log_file
+            # Rebuild save_and_test context now that base_repo_path is set
+            if hasattr(agent, "_setup_save_and_test_context"):
+                agent._setup_save_and_test_context()
 
             with open(log_file, "w", encoding="utf-8") as f:
                 f.write(f"Agent {agent_id} ({label}) Conversation Log\n")
@@ -754,6 +772,9 @@ class ParallelAgent(DefaultAgent):
                     agent.base_repo_path = repo_path_resolved
                 if hasattr(agent, "log_file"):
                     agent.log_file = log_file
+                # Rebuild save_and_test context now that base_repo_path is set
+                if hasattr(agent, "_setup_save_and_test_context"):
+                    agent._setup_save_and_test_context()
 
                 with open(log_file, "w", encoding="utf-8") as f:
                     f.write(f"Task {task_id} ({label}) Conversation Log\n")

--- a/src/minisweagent/run/orchestrator.py
+++ b/src/minisweagent/run/orchestrator.py
@@ -577,6 +577,13 @@ def _setup_eval_worktree(repo_root: str, patch_file: str, output_dir: Path) -> P
         )
     else:
         shutil.copytree(str(repo), str(eval_dir), dirs_exist_ok=True)
+        # Init as git repo so git-apply works for patches from non-git workdirs
+        subprocess.run(["git", "init", "-q"], cwd=str(eval_dir), capture_output=True)
+        subprocess.run(["git", "add", "."], cwd=str(eval_dir), capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "baseline", "--allow-empty"],
+            cwd=str(eval_dir), capture_output=True,
+        )
 
     patch_path = Path(patch_file)
     if patch_path.exists() and patch_path.stat().st_size > 0:


### PR DESCRIPTION
- Fix empty patch files when optimizing kernels from non-git directories (e.g. local kernels)
- Root cause: `git diff` and `git apply` fail silently on plain directories copied with `shutil.copytree`
- Fix: initialize copied worktrees as git repos with a baseline commit so diff/apply work correctly; re-call `_setup_save_and_test_context()` after `base_repo_path` is set