### PR TITLE
docs: add end-to-end examples; update default model to claude-opus-4.6

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ How GEAK loads **YAML** for **`geak`**, where builtin files live, and how **`--c
 | Key | Purpose |
 |-----|---------|
 | **`model_class`** | Backend short name for **`get_model_class`** (here **`amd_llm`** — AMD LLM gateway). |
-| **`model_name`** | Gateway model id (e.g. **`claude-opus-4.5`**, **`claude-sonnet-4.5`**, **`gpt-5`**, **`gpt-5.1`**, **`gpt-5-codex`**). Routed inside **`AmdLlmModel`** to Claude / OpenAI / Gemini clients by name pattern. |
+| **`model_name`** | Gateway model id (e.g. **`claude-opus-4.6`**, **`claude-sonnet-4.5`**, **`gpt-5`**, **`gpt-5.1`**, **`gpt-5-codex`**). Routed inside **`AmdLlmModel`** to Claude / OpenAI / Gemini clients by name pattern. |
 | **`api_key`** | Empty string **`""`** means “read **`AMD_LLM_API_KEY`** or **`LLM_GATEWAY_KEY`** from the environment”; a non-empty value is sent to the gateway instead. |
 | **`model_kwargs`** | Passed through to the vendor implementation: **`temperature`**, **`max_tokens`**, plus gateway-specific blocks. **`reasoning.effort`** and **`text.verbosity`** apply to **GPT**-style models on the gateway (see inline comments in the YAML). |
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -34,7 +34,7 @@ YAML **`model.model_class`** selects the backend. If it is **missing or empty**,
 | `model_class` (YAML) | Backend |
 |----------------------|---------|
 | **`litellm`**  | **`LitellmModel`** — any `provider/model` string supported by [LiteLLM](https://docs.litellm.ai/) |
-| **`amd_llm`** | **`AmdLlmModel`** — AMD LLM gateway; **`model_name`** examples: `claude-opus-4.5`, `claude-sonnet-4.5`, `gpt-5`, `gpt-5-codex`, Gemini-style names with `gemini` |
+| **`amd_llm`** | **`AmdLlmModel`** — AMD LLM gateway; **`model_name`** examples: `claude-opus-4.6`, `claude-sonnet-4.5`, `gpt-5`, `gpt-5-codex`, Gemini-style names with `gemini` |
 | **`anthropic_model`** | Direct Anthropic SDK |
 
 Optional global override: **`MSWEA_MODEL_API_KEY`** is copied into **`model_kwargs.api_key`** when set.
@@ -86,7 +86,7 @@ Other LiteLLM providers (**Azure**, **Vertex**, …): set the **`MSWEA_MODEL_NAM
 ```yaml
 model:
   model_class: amd_llm
-  model_name: claude-opus-4.5
+  model_name: claude-opus-4.6
   api_key: ""
 ```
 
@@ -131,6 +131,57 @@ geak --num-parallel 4 \
   --gpu-ids 0,1,2,3 
 ```
 
+
+### End-to-end examples
+
+The four invocations below show every combination of **natural-language (NL) task description** versus **explicit CLI flags**, and **with / without a pre-built test harness**. All target the same kernel (`topk.py` in [aiter](https://github.com/ROCm/aiter)) on 8 GPUs.
+
+**Task 1 — Without NL, without harness**
+
+GEAK discovers the kernel structure, generates its own harness, and runs optimization — all from CLI flags.
+
+```bash
+geak --kernel-url 'https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py' \
+  --gpu-ids '0,1,2,3,4,5,6,7' --heterogeneous --yolo \
+  --task 'Optimize the topk kernel.' --exit-immediately \
+  -o '/workspace/GEAK_ARTIFACTS/topk_wo_task_wo_harness' \
+  2>&1 | tee '/workspace/GEAK_ARTIFACTS/topk_wo_task_wo_harness.log'
+```
+
+**Task 2 — Without NL, with harness**
+
+Same CLI-flag style, but a pre-existing test harness is supplied via `--test-command`.
+
+```bash
+geak --kernel-url 'https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py' \
+  --test-command 'python3 /workspace/GEAK_ARTIFACTS/test_topk_harness.py --correctness && python3 /workspace/GEAK_ARTIFACTS/test_topk_harness.py --full-benchmark' \
+  --gpu-ids '0,1,2,3,4,5,6,7' --heterogeneous --yolo \
+  --task 'Optimize the topk kernel.' --exit-immediately \
+  -o '/workspace/GEAK_ARTIFACTS/topk_wo_task_w_harness' \
+  2>&1 | tee '/workspace/GEAK_ARTIFACTS/topk_wo_task_w_harness.log'
+```
+
+**Task 3 — With NL, without harness**
+
+Everything is expressed in a single natural-language `-t` string; GEAK parses the kernel URL, GPU count, and mode from the text.
+
+```bash
+geak -t 'Optimize the topk kernel at https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py. Use GPUs 0-7 and heterogeneous mode.' \
+  --yolo --exit-immediately \
+  -o '/workspace/GEAK_ARTIFACTS/topk_w_task_wo_harness' \
+  2>&1 | tee '/workspace/GEAK_ARTIFACTS/topk_w_task_wo_harness.log'
+```
+
+**Task 4 — With NL, with harness**
+
+Natural-language task that also references an external test harness URL.
+
+```bash
+geak -t 'Optimize the topk kernel at https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py, using the harness at https://github.com/AMD-AGI/AIG-Eval/blob/sdubagun/fix-kernel-harness-parity/tasks/geak_eval/topk/test_topk_harness.py. Use GPUs 0-7 and heterogeneous mode.' \
+  --yolo --exit-immediately \
+  -o '/workspace/GEAK_ARTIFACTS/topk_w_task_w_harness' \
+  2>&1 | tee '/workspace/GEAK_ARTIFACTS/topk_w_task_w_harness.log'
+```
 
 ### CLI reference
 

--- a/docs/subagent_guide.md
+++ b/docs/subagent_guide.md
@@ -18,7 +18,7 @@ from minisweagent.utils.subagent import create_rag_filter_subagent
 
 # Create sub-agent
 subagent = create_rag_filter_subagent(
-    model_name="claude-opus-4.5",
+    model_name="claude-opus-4.6",
     api_key="your-api-key",
     enabled=True,
 )
@@ -43,7 +43,7 @@ from minisweagent.mcp_integration.mcp_environment import MCPEnabledEnvironment
 # Create environment with sub-agent enabled
 env = MCPEnabledEnvironment(
     enable_rag_subagent=True,
-    rag_subagent_model="claude-opus-4.5",
+    rag_subagent_model="claude-opus-4.6",
     rag_subagent_api_key="your-api-key",
 )
 
@@ -58,7 +58,7 @@ result = env.execute('@amd:query {"topic": "HIP optimization"}')
 from minisweagent.utils.subagent import SubAgentConfig, RAGFilterSubAgent
 
 config = SubAgentConfig(
-    model_name="claude-opus-4.5",      # LLM model to use
+    model_name="claude-opus-4.6",      # LLM model to use
     api_key="your-api-key",             # API key (or use env vars)
     system_prompt="custom prompt...",   # Custom system prompt (optional)
     enabled=True,                       # Enable/disable sub-agent

--- a/examples/test_subagent.py
+++ b/examples/test_subagent.py
@@ -37,7 +37,7 @@ def test_standalone_subagent(run_api_test: bool = False):
     
     # Create sub-agent
     subagent = create_rag_filter_subagent(
-        model_name="claude-opus-4.5",
+        model_name="claude-opus-4.6",
         api_key=os.getenv("AMD_LLM_API_KEY"),  # Set in .env or environment
         enabled=True,
     )
@@ -84,7 +84,7 @@ def test_mcp_environment_integration():
     env = MCPEnabledEnvironment(
         auto_build_index=False,  # Skip index build for demo
         enable_rag_subagent=True,
-        rag_subagent_model="claude-opus-4.5",
+        rag_subagent_model="claude-opus-4.6",
         rag_subagent_api_key=os.getenv("RAG_SUBAGENT_API_KEY"),  # Set in .env or environment
     )
     

--- a/examples/verify_config.py
+++ b/examples/verify_config.py
@@ -12,7 +12,7 @@ from minisweagent.mcp_integration.mcp_environment import MCPEnvironmentConfig, M
 print("Test 1: Creating MCPEnvironmentConfig...")
 config = MCPEnvironmentConfig(
     enable_rag_subagent=True,
-    rag_subagent_model="claude-opus-4.5",
+    rag_subagent_model="claude-opus-4.6",
     rag_subagent_api_key="test-key"
 )
 print(f"✅ Config created: enable_rag_subagent={config.enable_rag_subagent}")
@@ -24,7 +24,7 @@ try:
     env = MCPEnabledEnvironment(
         auto_build_index=False,
         enable_rag_subagent=True,
-        rag_subagent_model="claude-opus-4.5",
+        rag_subagent_model="claude-opus-4.6",
         rag_subagent_api_key="test-key"
     )
     print(f"✅ Environment created successfully!")

--- a/src/minisweagent/config/geak.yaml
+++ b/src/minisweagent/config/geak.yaml
@@ -12,8 +12,8 @@ env:
   timeout: 3600
 model:
   model_class: amd_llm
-  # claude-opus-4.5, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
-  model_name: claude-opus-4.5
+  # claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
+  model_name: claude-opus-4.6
   api_key: ""
   model_kwargs:
     temperature: 0.0

--- a/src/minisweagent/config/mini.yaml
+++ b/src/minisweagent/config/mini.yaml
@@ -152,8 +152,8 @@ env:
   timeout: 3600
 model:
   model_class: amd_llm
-  # claude-opus-4.5, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
-  model_name: claude-opus-4.5
+  # claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
+  model_name: claude-opus-4.6
   # API key is read from AMD_LLM_API_KEY environment variable
   # Set it in .env file or: export AMD_LLM_API_KEY=your_key_here
   api_key: null

--- a/src/minisweagent/config/mini_select_patch.yaml
+++ b/src/minisweagent/config/mini_select_patch.yaml
@@ -95,5 +95,5 @@ agent:
 
 model:
   model_class: amd_llm
-  model_name: claude-opus-4.5
+  model_name: claude-opus-4.6
   api_key: ""

--- a/src/minisweagent/config/mini_unit_test_agent.yaml
+++ b/src/minisweagent/config/mini_unit_test_agent.yaml
@@ -162,8 +162,8 @@ env:
 
 model:
   model_class: amd_llm
-  # claude-opus-4.5, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
-  model_name: claude-opus-4.5
+  # claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
+  model_name: claude-opus-4.6
   api_key: ""
   # model_kwargs:
   #   temperature: 0.0

--- a/src/minisweagent/mcp_integration/mcp_environment.py
+++ b/src/minisweagent/mcp_integration/mcp_environment.py
@@ -103,7 +103,7 @@ class MCPEnabledEnvironment(LocalEnvironment):
         self._bm25_weight = fusion.get("bm25_weight", 0.3)
 
         self._enable_rag_subagent = summary.get("enable_rag_subagent", True)
-        self._rag_subagent_model = summary.get("rag_subagent_model", "claude-opus-4.5")
+        self._rag_subagent_model = summary.get("rag_subagent_model", "claude-opus-4.6")
 
         self._verbose = debug.get("verbose", False)
 

--- a/src/minisweagent/mcp_integration/subagent.py
+++ b/src/minisweagent/mcp_integration/subagent.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class SubAgentConfig:
     """Configuration for sub-agent behavior."""
 
-    model_name: str = "claude-opus-4.5"
+    model_name: str = "claude-opus-4.6"
     api_key: str | None = None
     system_prompt: str | None = None
     enabled: bool = True

--- a/src/minisweagent/models/amd_llm.py
+++ b/src/minisweagent/models/amd_llm.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     # Quick smoke test
     model_list = [
         "gpt-5",
-        "claude-opus-4.5",
+        "claude-opus-4.6",
         "claude-sonnet-4.5",
         "gemini-3-pro-preview",
     ]

--- a/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
@@ -317,8 +317,8 @@ env:
 
 model:
   model_class: amd_llm
-  # claude-opus-4.5, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
-  model_name: claude-opus-4.5
+  # claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
+  model_name: claude-opus-4.6
   api_key: ""
   # model_kwargs:
   #   temperature: 0.0


### PR DESCRIPTION
Add four topk kernel examples to quick_start.md covering all combinations of NL vs explicit CLI flags and with/without a pre-built test harness.

Update default model_name from claude-opus-4.5 to claude-opus-4.6 across all configs, docs, and examples.

Made-with: Cursor

