### PR TITLE
docs: remove --heterogeneous from quickstart, clarify GEAK_ARTIFACTS and harness

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -136,13 +136,15 @@ geak --num-parallel 4 \
 
 The four invocations below show every combination of **natural-language (NL) task description** versus **explicit CLI flags**, and **with / without a pre-built test harness**. All target the same kernel (`topk.py` in [aiter](https://github.com/ROCm/aiter)) on 8 GPUs.
 
+> **Note:** In the examples below, suppose `/workspace/GEAK_ARTIFACTS` is the folder where all GEAK-related outputs will be saved. The `test_topk_harness.py` referenced in some examples is a user-created harness file for testing the topk kernel.
+
 **Task 1 — Without NL, without harness**
 
 GEAK discovers the kernel structure, generates its own harness, and runs optimization — all from CLI flags.
 
 ```bash
 geak --kernel-url 'https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py' \
-  --gpu-ids '0,1,2,3,4,5,6,7' --heterogeneous --yolo \
+  --gpu-ids '0,1,2,3,4,5,6,7' --yolo \
   --task 'Optimize the topk kernel.' --exit-immediately \
   -o '/workspace/GEAK_ARTIFACTS/topk_wo_task_wo_harness' \
   2>&1 | tee '/workspace/GEAK_ARTIFACTS/topk_wo_task_wo_harness.log'
@@ -155,7 +157,7 @@ Same CLI-flag style, but a pre-existing test harness is supplied via `--test-com
 ```bash
 geak --kernel-url 'https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py' \
   --test-command 'python3 /workspace/GEAK_ARTIFACTS/test_topk_harness.py --correctness && python3 /workspace/GEAK_ARTIFACTS/test_topk_harness.py --full-benchmark' \
-  --gpu-ids '0,1,2,3,4,5,6,7' --heterogeneous --yolo \
+  --gpu-ids '0,1,2,3,4,5,6,7' --yolo \
   --task 'Optimize the topk kernel.' --exit-immediately \
   -o '/workspace/GEAK_ARTIFACTS/topk_wo_task_w_harness' \
   2>&1 | tee '/workspace/GEAK_ARTIFACTS/topk_wo_task_w_harness.log'
@@ -166,7 +168,7 @@ geak --kernel-url 'https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk
 Everything is expressed in a single natural-language `-t` string; GEAK parses the kernel URL, GPU count, and mode from the text.
 
 ```bash
-geak -t 'Optimize the topk kernel at https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py. Use GPUs 0-7 and heterogeneous mode.' \
+geak -t 'Optimize the topk kernel at https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py. Use GPUs 0-7.' \
   --yolo --exit-immediately \
   -o '/workspace/GEAK_ARTIFACTS/topk_w_task_wo_harness' \
   2>&1 | tee '/workspace/GEAK_ARTIFACTS/topk_w_task_wo_harness.log'
@@ -177,7 +179,7 @@ geak -t 'Optimize the topk kernel at https://github.com/ROCm/aiter/blob/main/ait
 Natural-language task that also references an external test harness URL.
 
 ```bash
-geak -t 'Optimize the topk kernel at https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py, using the harness at https://github.com/AMD-AGI/AIG-Eval/blob/sdubagun/fix-kernel-harness-parity/tasks/geak_eval/topk/test_topk_harness.py. Use GPUs 0-7 and heterogeneous mode.' \
+geak -t 'Optimize the topk kernel at https://github.com/ROCm/aiter/blob/main/aiter/ops/triton/topk.py, using the harness at https://github.com/AMD-AGI/AIG-Eval/blob/sdubagun/fix-kernel-harness-parity/tasks/geak_eval/topk/test_topk_harness.py. Use GPUs 0-7.' \
   --yolo --exit-immediately \
   -o '/workspace/GEAK_ARTIFACTS/topk_w_task_w_harness' \
   2>&1 | tee '/workspace/GEAK_ARTIFACTS/topk_w_task_w_harness.log'


### PR DESCRIPTION
## Summary

- Removed `--heterogeneous` flag and "heterogeneous mode" references from all four end-to-end example tasks in `docs/quick_start.md`.
- Added a note explaining that `/workspace/GEAK_ARTIFACTS` is the folder where all GEAK-related outputs will be saved.
- Added a note clarifying that `test_topk_harness.py` is a user-created harness file for testing the topk kernel.

## Test plan

- [x] Verify the four end-to-end example commands in the quickstart no longer reference `--heterogeneous`.
- [x] Verify the new note about `GEAK_ARTIFACTS` and `test_topk_harness.py` renders correctly in the markdown.