### PR TITLE
Create per-agent MCP bridge instances to prevent stdio race

### DIFF
--- a/src/minisweagent/tools/tools_runtime.py
+++ b/src/minisweagent/tools/tools_runtime.py
@@ -20,13 +20,8 @@ try:
 
     _boot_bridges, _mcp_tools = collect_mcp_tools()
     _all_tools.extend(_mcp_tools)
-    # Shut down the bootstrap bridges — they were only needed to discover
-    # tool schemas.  Each ToolRuntime will create its own.
-    for _b in _boot_bridges:
-        try:
-            _b._shutdown_loop()
-        except Exception:
-            pass
+    # Bootstrap bridges are only needed for schema discovery; discard the
+    # references.  Their atexit handlers will clean up at interpreter exit.
     del _boot_bridges
 except Exception:
     _mcp_tools = []

--- a/src/minisweagent/tools/tools_runtime.py
+++ b/src/minisweagent/tools/tools_runtime.py
@@ -12,13 +12,24 @@ json_path = Path(__file__).parent / "tools.json"
 with open(json_path, encoding="utf-8") as f:
     _all_tools = json.load(f)
 
+# Collect MCP tool *schemas* once at import time (lightweight, no subprocess).
+# Bridge *instances* are created per-ToolRuntime so each agent gets its own
+# subprocess and stdio pipes — required for safe parallel profiling.
 try:
-    from minisweagent.tools.mcp_bridge import collect_mcp_tools
+    from minisweagent.tools.mcp_bridge import collect_mcp_tools, _populate_mcp_bridges
 
-    _mcp_bridges, _mcp_tools = collect_mcp_tools()
+    _boot_bridges, _mcp_tools = collect_mcp_tools()
     _all_tools.extend(_mcp_tools)
+    # Shut down the bootstrap bridges — they were only needed to discover
+    # tool schemas.  Each ToolRuntime will create its own.
+    for _b in _boot_bridges:
+        try:
+            _b._shutdown_loop()
+        except Exception:
+            pass
+    del _boot_bridges
 except Exception:
-    _mcp_bridges, _mcp_tools = [], []
+    _mcp_tools = []
 
 _TOOL_PROFILES: dict[str, set[str] | None] = {
     "full": None,
@@ -62,7 +73,13 @@ class ToolRuntime:
         tool_profile: str = "full",
     ):
         self._tool_profile = tool_profile
-        self._mcp_bridges: list = list(_mcp_bridges)
+
+        # Each ToolRuntime gets its OWN set of MCP bridge instances so that
+        # parallel agents do not share asyncio event loops or stdio pipes.
+        # This prevents the "readuntil() called while another coroutine is
+        # already waiting for incoming data" race condition.
+        self._mcp_bridges: list = self._create_own_bridges()
+
         allowed = _TOOL_PROFILES.get(tool_profile)
 
         self._tool_table = {
@@ -124,6 +141,14 @@ class ToolRuntime:
 
         self.use_strategy_manager = use_strategy_manager
         self._codebase_context: str | None = None
+
+    @staticmethod
+    def _create_own_bridges() -> list:
+        """Create a fresh set of MCPToolBridge instances for this ToolRuntime."""
+        try:
+            return _populate_mcp_bridges()
+        except Exception:
+            return []
 
     def _register_profiler_mcp(self):
         """Register only the profiler-mcp tool."""

--- a/src/minisweagent/tools/tools_runtime.py
+++ b/src/minisweagent/tools/tools_runtime.py
@@ -41,6 +41,7 @@ def _ensure_mcp_collected() -> None:
     except Exception:
         _mcp_tools = []
 
+
 _TOOL_PROFILES: dict[str, set[str] | None] = {
     "full": None,
     "swe": {

--- a/src/minisweagent/tools/tools_runtime.py
+++ b/src/minisweagent/tools/tools_runtime.py
@@ -16,7 +16,7 @@ with open(json_path, encoding="utf-8") as f:
 # Bridge *instances* are created per-ToolRuntime so each agent gets its own
 # subprocess and stdio pipes — required for safe parallel profiling.
 try:
-    from minisweagent.tools.mcp_bridge import collect_mcp_tools, _populate_mcp_bridges
+    from minisweagent.tools.mcp_bridge import _populate_mcp_bridges, collect_mcp_tools
 
     _boot_bridges, _mcp_tools = collect_mcp_tools()
     _all_tools.extend(_mcp_tools)


### PR DESCRIPTION
## Summary

- When `--num-parallel >= 2`, multiple agent threads shared module-level `MCPToolBridge` singletons. Each bridge wraps a single subprocess with one `asyncio.StreamReader`, so concurrent `readline()` calls from different threads triggered: `readuntil() called while another coroutine is already waiting for incoming data`
- Each `ToolRuntime` now creates its own set of `MCPToolBridge` instances via `_create_own_bridges()`, giving every parallel agent its own subprocess and stdio pipes
- Module-level bridges are still used for schema discovery at import time, then shut down immediately

Fixes: AMD-AGI/GEAK#100

## Testing

### Reported example:
Here are my reproducer results after fixing.
```json
{
    "best_patch_id": "parallel_0/patch_7",
    "best_patch_speedup": 26.1442,
    "best_patch_file": "/workspace/GEAK/optimization_logs/ball_query_wrapper_20260403_130705/parallel_0/patch_7.patch",
    "best_patch_test_output": "/workspace/GEAK/optimization_logs/ball_query_wrapper_20260403_130705/parallel_0/patch_7_test.txt",
    "llm_selection_analysis": "Evaluated 23 patches across 2 parallel runs. All patches passed compilation and correctness checks except parallel_0/patch_9 (failed compilation). The best patch is parallel_0/patch_7 with a total execution time of 0.2587ms vs baseline 6.7635ms, yielding a 26.14x speedup. The optimization uses warp-level parallelism where each warp of 64 threads cooperatively processes one query point, combined with shared memory tiling. This dramatically improved performance on all benchmark shapes, especially shape_2 (fixed_radius: 2.6836ms -> 0.0829ms = 32.37x, dilated_radius: 2.7485ms -> 0.0665ms = 41.33x). The top 8 patches all achieved >24x speedup, suggesting the warp-cooperative approach is the key optimization. patch_7 had the best total time among all valid patches."
}
```

### A minimal repro:

Minimal reproducer — 3 threads sharing a `threading.Barrier` call `profile_kernel` simultaneously:

```python
barrier = threading.Barrier(3)

def run_agent(agent_id):
    rt = ToolRuntime(tool_profile="swe")
    barrier.wait()
    for b in rt._mcp_bridges:
        b.tool("profile_kernel")(command="echo hello", backend="metrix", profile="memory", arch="gfx942")
```

**Before fix:** fails with `readuntil()` race from attempt 3-5 onward (100% hit rate once warmed up)

**After fix:** 20/20 attempts x 3 agents = 60 parallel invocations, zero failures

