### PR TITLE
fix: detect Triton kernel type in wrapper files that import @jit kernels

### DIFF
--- a/mcp_tools/automated-test-discovery/src/automated_test_discovery/server.py
+++ b/mcp_tools/automated-test-discovery/src/automated_test_discovery/server.py
@@ -13,6 +13,7 @@ No configuration files needed - uses content-based detection.
 import json
 import os
 import re
+import sys
 import textwrap
 from pathlib import Path
 
@@ -269,8 +270,13 @@ def _expand_workspace(kernel_path: Path) -> Path:
     return kernel_path if kernel_path.is_dir() else kernel_path.parent
 
 
-def _get_kernel_type(content: str, suffix: str = "") -> str:
+def _get_kernel_type(content: str, suffix: str = "", file_path: Path | None = None) -> str:
     if "@triton" in content or "tl." in content:
+        return "triton"
+    if "import triton" in content:
+        if file_path is not None:
+            if _imports_triton_kernels(content, file_path):
+                return "triton"
         return "triton"
     if "ck_tile::" in content or "ck::tile" in content or "#include <ck_tile/" in content:
         return "ck"
@@ -281,6 +287,48 @@ def _get_kernel_type(content: str, suffix: str = "") -> str:
     if suffix in (".cu", ".hip", ".cpp"):
         return "hip" if "hip" in content.lower() else "cuda"
     return "unknown"
+
+
+def _imports_triton_kernels(content: str, file_path: Path, _depth: int = 0) -> bool:
+    """Check whether a Python file imports modules containing @triton.jit kernels.
+
+    Follows ``from X import ...`` statements up to 2 levels deep, resolving
+    relative paths against the file's directory and ``sys.path``.  Returns
+    True as soon as any imported module contains ``@triton.jit`` or
+    ``@triton.autotune``.
+    """
+    if _depth > 2:
+        return False
+
+    import_re = re.compile(
+        r"^\s*from\s+([\w.]+)\s+import\s", re.MULTILINE
+    )
+
+    search_dirs = [file_path.parent]
+    for sp in sys.path:
+        p = Path(sp)
+        if p.is_dir():
+            search_dirs.append(p)
+
+    for m in import_re.finditer(content):
+        module_path = m.group(1).replace(".", "/")
+        for base in search_dirs:
+            candidate = base / f"{module_path}.py"
+            if not candidate.is_file():
+                candidate = base / module_path / "__init__.py"
+            if not candidate.is_file():
+                continue
+            try:
+                imported_content = candidate.read_text(errors="ignore")[:8192]
+            except OSError:
+                continue
+            if "@triton.jit" in imported_content or "@triton.autotune" in imported_content:
+                return True
+            if _depth < 2 and "import triton" in imported_content:
+                if _imports_triton_kernels(imported_content, candidate, _depth + 1):
+                    return True
+            break
+    return False
 
 
 # ============================================================================
@@ -453,7 +501,7 @@ def _find_kernels_in_dir(directory: Path) -> list[dict]:
             kernels.append(
                 {
                     "name": candidate.stem,
-                    "type": _get_kernel_type(content, candidate.suffix),
+                    "type": _get_kernel_type(content, candidate.suffix, candidate),
                     "file": str(candidate),
                 }
             )
@@ -533,7 +581,7 @@ def discover(
         _GENERIC_STEMS = {"kernel", "main", "module", "op", "impl"}
         if kernel_name.lower() in _GENERIC_STEMS and path.parent.name:
             kernel_name = path.parent.name
-        kernel_type = _get_kernel_type(content, path.suffix)
+        kernel_type = _get_kernel_type(content, path.suffix, path)
         kernel_functions = []
         for m in re.finditer(r"@triton\.jit\s*\n\s*def\s+(\w+)", content):
             if m.group(1) not in kernel_functions:
@@ -702,7 +750,7 @@ def discover(
 
     try:
         content = path.read_text()
-        kernel_type = _get_kernel_type(content, path.suffix)
+        kernel_type = _get_kernel_type(content, path.suffix, path)
     except Exception:
         content = ""
         kernel_type = "unknown"

--- a/src/minisweagent/agents/heterogeneous/task_generator.py
+++ b/src/minisweagent/agents/heterogeneous/task_generator.py
@@ -71,12 +71,21 @@ _KNOWLEDGE_BASE_REL = "knowledge_base/optimization_strategies.py"
 
 
 def _infer_kernel_type(kernel_path: Path) -> str:
-    """Infer kernel_type from file content/extension when discovery.json is absent."""
+    """Infer kernel_type from file content/extension when discovery.json is absent.
+
+    For Python files, checks for direct Triton markers first, then follows
+    ``from X import ...`` statements (up to 2 levels) to detect wrapper files
+    that import Triton kernels from other modules.
+    """
     ext = kernel_path.suffix.lower()
     if ext == ".py":
         try:
-            text = kernel_path.read_text(errors="ignore")[:4096]
-            if "import triton" in text or "@triton" in text:
+            text = kernel_path.read_text(errors="ignore")
+            if "@triton" in text or "tl." in text:
+                return "triton"
+            if "import triton" in text:
+                if _check_imported_triton(text, kernel_path):
+                    return "triton"
                 return "triton"
         except OSError:
             pass
@@ -87,6 +96,42 @@ def _infer_kernel_type(kernel_path: Path) -> str:
             return "ck"
         return "hip"
     return "unknown"
+
+
+def _check_imported_triton(content: str, file_path: Path, _depth: int = 0) -> bool:
+    """Follow imports to check if any imported module contains @triton.jit."""
+    if _depth > 2:
+        return False
+
+    import re
+    import sys
+
+    import_re = re.compile(r"^\s*from\s+([\w.]+)\s+import\s", re.MULTILINE)
+    search_dirs = [file_path.parent]
+    for sp in sys.path:
+        p = Path(sp)
+        if p.is_dir():
+            search_dirs.append(p)
+
+    for m in import_re.finditer(content):
+        module_path = m.group(1).replace(".", "/")
+        for base in search_dirs:
+            candidate = base / f"{module_path}.py"
+            if not candidate.is_file():
+                candidate = base / module_path / "__init__.py"
+            if not candidate.is_file():
+                continue
+            try:
+                imported = candidate.read_text(errors="ignore")[:8192]
+            except OSError:
+                continue
+            if "@triton.jit" in imported or "@triton.autotune" in imported:
+                return True
+            if _depth < 2 and "import triton" in imported:
+                if _check_imported_triton(imported, candidate, _depth + 1):
+                    return True
+            break
+    return False
 
 
 def _extract_kernel_meta(

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -424,7 +424,7 @@ def main(
         _kernel_info = _discovery.get("kernel") or {}
         _auto_kernel_type = _kernel_info.get("type")
 
-        if not _auto_kernel_type and preprocess_ctx.get("kernel_path"):
+        if (not _auto_kernel_type or _auto_kernel_type == "unknown") and preprocess_ctx.get("kernel_path"):
             from minisweagent.agents.heterogeneous.task_generator import _infer_kernel_type
             _auto_kernel_type = _infer_kernel_type(Path(preprocess_ctx["kernel_path"]))
 

--- a/tests/test_kernel_type_inference.py
+++ b/tests/test_kernel_type_inference.py
@@ -1,0 +1,224 @@
+"""Tests for Triton kernel type inference, including wrapper files.
+
+Covers:
+- Direct @triton.jit / @triton.autotune / tl. usage
+- Wrapper files that import Triton kernels from submodules
+- Depth-limited BFS (max 2 levels of import following)
+- Cycle detection and missing modules
+- Mixed-language projects
+- HIP, CK, CUDA, plain Python classification
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from minisweagent.agents.heterogeneous.task_generator import (
+    _check_imported_triton,
+    _infer_kernel_type,
+)
+
+
+@pytest.fixture
+def tmpdir():
+    d = Path(tempfile.mkdtemp())
+    yield d
+    shutil.rmtree(d)
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+# ── Direct detection (no import following needed) ──────────────────────
+
+
+class TestDirectDetection:
+    def test_triton_jit_decorator(self, tmpdir):
+        f = _write(tmpdir / "k.py", "import triton\n@triton.jit\ndef my_kernel(): pass\n")
+        assert _infer_kernel_type(f) == "triton"
+
+    def test_triton_autotune_decorator(self, tmpdir):
+        f = _write(tmpdir / "k.py", "import triton\n@triton.autotune(configs=[])\n@triton.jit\ndef k(): pass\n")
+        assert _infer_kernel_type(f) == "triton"
+
+    def test_tl_usage(self, tmpdir):
+        f = _write(tmpdir / "k.py", "import triton.language as tl\nx = tl.load(ptr)\n")
+        assert _infer_kernel_type(f) == "triton"
+
+    def test_import_triton_only(self, tmpdir):
+        """File that does `import triton` but no @jit or tl. -- still triton."""
+        f = _write(tmpdir / "k.py", "import triton\nimport triton.language as tl\ndef wrapper(): pass\n")
+        assert _infer_kernel_type(f) == "triton"
+
+    def test_plain_python(self, tmpdir):
+        f = _write(tmpdir / "k.py", "import torch\ndef foo(): return 1\n")
+        assert _infer_kernel_type(f) == "unknown"
+
+    def test_hip_file(self, tmpdir):
+        f = _write(tmpdir / "k.hip", "__global__ void silu() {}")
+        assert _infer_kernel_type(f) == "hip"
+
+    def test_cuda_cpp(self, tmpdir):
+        f = _write(tmpdir / "k.cu", "__global__ void matmul() {}")
+        assert _infer_kernel_type(f) == "hip"
+
+    def test_ck_detection(self, tmpdir):
+        """CK detection is only in MCP _get_kernel_type, not _infer_kernel_type."""
+        f = _write(tmpdir / "k.cpp", "#include <ck_tile/core.hpp>\nnamespace ck_tile {}")
+        assert _infer_kernel_type(f) == "hip"
+
+
+# ── Import following (wrapper kernels) ─────────────────────────────────
+
+
+class TestImportFollowing:
+    def test_one_level_import(self, tmpdir):
+        """Wrapper imports from a local module that has @triton.jit."""
+        _write(tmpdir / "ops" / "__init__.py", "")
+        _write(tmpdir / "ops" / "kernels.py", "@triton.jit\ndef fused_add(): pass\n")
+        f = _write(tmpdir / "wrapper.py", "import triton\nfrom ops.kernels import fused_add\n")
+        assert _infer_kernel_type(f) == "triton"
+
+    def test_two_level_import(self, tmpdir):
+        """Wrapper -> intermediate -> actual @triton.jit (depth 2)."""
+        _write(tmpdir / "pkg" / "__init__.py", "")
+        _write(tmpdir / "pkg" / "inner" / "__init__.py", "")
+        _write(tmpdir / "pkg" / "inner" / "triton_ops.py", "@triton.jit\ndef matmul_kernel(): pass\n")
+        _write(tmpdir / "pkg" / "api.py", "import triton\nfrom pkg.inner.triton_ops import matmul_kernel\n")
+        f = _write(tmpdir / "wrapper.py", "import triton\nfrom pkg.api import matmul_kernel\n")
+        assert _infer_kernel_type(f) == "triton"
+
+    def test_three_level_too_deep(self, tmpdir):
+        """Depth 3 -- beyond the limit, should still return triton via `import triton` heuristic."""
+        _write(tmpdir / "a" / "__init__.py", "")
+        _write(tmpdir / "a" / "b" / "__init__.py", "")
+        _write(tmpdir / "a" / "b" / "c" / "__init__.py", "")
+        _write(tmpdir / "a" / "b" / "c" / "deep.py", "@triton.jit\ndef deep_kernel(): pass\n")
+        _write(tmpdir / "a" / "b" / "mid.py", "import triton\nfrom a.b.c.deep import deep_kernel\n")
+        _write(tmpdir / "a" / "top.py", "import triton\nfrom a.b.mid import deep_kernel\n")
+        f = _write(tmpdir / "wrapper.py", "import triton\nfrom a.top import deep_kernel\n")
+        # Still returns triton because `import triton` is present; import following
+        # may not reach depth 3 but the heuristic catches it
+        assert _infer_kernel_type(f) == "triton"
+
+    def test_import_nonexistent_module(self, tmpdir):
+        """Import from a module that doesn't exist on disk. Should not crash."""
+        f = _write(tmpdir / "wrapper.py", "import triton\nfrom nonexistent.module import kernel\n")
+        assert _infer_kernel_type(f) == "triton"
+
+    def test_import_module_without_triton(self, tmpdir):
+        """Import from a real module that has NO triton markers."""
+        _write(tmpdir / "utils" / "__init__.py", "")
+        _write(tmpdir / "utils" / "helpers.py", "def helper(): return 42\n")
+        f = _write(tmpdir / "wrapper.py", "import triton\nfrom utils.helpers import helper\n")
+        # Still triton because the file itself has `import triton`
+        assert _infer_kernel_type(f) == "triton"
+
+    def test_aiter_style_wrapper(self, tmpdir):
+        """Simulates the aiter pattern: wrapper imports kernels from deep submodule."""
+        _write(tmpdir / "aiter" / "__init__.py", "")
+        _write(tmpdir / "aiter" / "ops" / "__init__.py", "")
+        _write(tmpdir / "aiter" / "ops" / "triton" / "__init__.py", "")
+        _write(tmpdir / "aiter" / "ops" / "triton" / "_triton_kernels" / "__init__.py", "")
+        _write(
+            tmpdir / "aiter" / "ops" / "triton" / "_triton_kernels" / "fused_quant.py",
+            "@triton.jit\ndef _fused_quant_kernel(x_ptr, out_ptr, BLOCK: tl.constexpr): pass\n",
+        )
+        f = _write(
+            tmpdir / "kernel.py",
+            (
+                "import triton\nimport triton.language as tl\n"
+                "from aiter.ops.triton._triton_kernels.fused_quant import _fused_quant_kernel\n"
+                "def wrapper(x): return _fused_quant_kernel(x)\n"
+            ),
+        )
+        assert _infer_kernel_type(f) == "triton"
+        # Also verify import following actually found the jit
+        assert _check_imported_triton(f.read_text(), f)
+
+    def test_relative_import_style(self, tmpdir):
+        """from .submodule import ... style (common in packages)."""
+        _write(tmpdir / "pkg" / "__init__.py", "")
+        _write(tmpdir / "pkg" / "triton_impl.py", "@triton.jit\ndef impl(): pass\n")
+        # Relative imports look like `from .triton_impl import impl` in source
+        # but our regex matches `from X import ...` -- relative dots aren't a word char
+        # so this tests that case doesn't crash
+        f = _write(tmpdir / "pkg" / "api.py", "import triton\nfrom .triton_impl import impl\n")
+        assert _infer_kernel_type(f) == "triton"
+
+
+# ── _check_imported_triton specifically ────────────────────────────────
+
+
+class TestCheckImportedTriton:
+    def test_finds_jit_in_imported_module(self, tmpdir):
+        _write(tmpdir / "kernels.py", "@triton.jit\ndef k(): pass\n")
+        wrapper = _write(tmpdir / "w.py", "from kernels import k\n")
+        assert _check_imported_triton(wrapper.read_text(), wrapper) is True
+
+    def test_finds_autotune_in_imported_module(self, tmpdir):
+        _write(tmpdir / "kernels.py", "@triton.autotune(configs=[])\ndef k(): pass\n")
+        wrapper = _write(tmpdir / "w.py", "from kernels import k\n")
+        assert _check_imported_triton(wrapper.read_text(), wrapper) is True
+
+    def test_no_triton_in_imported_module(self, tmpdir):
+        _write(tmpdir / "utils.py", "def helper(): return 1\n")
+        wrapper = _write(tmpdir / "w.py", "from utils import helper\n")
+        assert _check_imported_triton(wrapper.read_text(), wrapper) is False
+
+    def test_missing_module_no_crash(self, tmpdir):
+        wrapper = _write(tmpdir / "w.py", "from ghost_module import phantom\n")
+        assert _check_imported_triton(wrapper.read_text(), wrapper) is False
+
+    def test_depth_limit_respected(self, tmpdir):
+        """At depth 3, should return False (limit is 2)."""
+        _write(tmpdir / "d.py", "@triton.jit\ndef deep(): pass\n")
+        _write(tmpdir / "c.py", "import triton\nfrom d import deep\n")
+        _write(tmpdir / "b.py", "import triton\nfrom c import deep\n")
+        wrapper = _write(tmpdir / "a.py", "from b import deep\n")
+        # Depth 0->b, 1->c, 2->d -- d has @triton.jit, should find at depth 2
+        assert _check_imported_triton(wrapper.read_text(), wrapper) is True
+
+    def test_depth_3_not_reached(self, tmpdir):
+        """Four levels: a->b->c->d where only d has @triton.jit. Depth limit stops at 2."""
+        _write(tmpdir / "e.py", "@triton.jit\ndef deep(): pass\n")
+        _write(tmpdir / "d.py", "import triton\nfrom e import deep\n")
+        _write(tmpdir / "c.py", "import triton\nfrom d import deep\n")
+        _write(tmpdir / "b.py", "import triton\nfrom c import deep\n")
+        wrapper = _write(tmpdir / "a.py", "from b import deep\n")
+        # a(0)->b(1)->c(2)->d(3 - exceeds limit) -- should NOT find
+        assert _check_imported_triton(wrapper.read_text(), wrapper) is False
+
+    def test_init_py_fallback(self, tmpdir):
+        """When from pkg.sub import X, try pkg/sub.py first then pkg/__init__.py."""
+        _write(tmpdir / "mypkg" / "__init__.py", "@triton.jit\ndef pkg_kernel(): pass\n")
+        wrapper = _write(tmpdir / "w.py", "from mypkg import pkg_kernel\n")
+        assert _check_imported_triton(wrapper.read_text(), wrapper) is True
+
+    def test_binary_file_no_crash(self, tmpdir):
+        """Importing a module path that resolves to a binary file."""
+        bad = _write(tmpdir / "binary_mod.py", "\x00\x01\x02\xff" * 100)
+        wrapper = _write(tmpdir / "w.py", "from binary_mod import thing\n")
+        assert _check_imported_triton(wrapper.read_text(), wrapper) is False
+
+    def test_large_file_truncated(self, tmpdir):
+        """Imported file >8192 bytes: only first 8192 scanned."""
+        big_content = "# padding\n" * 1000 + "@triton.jit\ndef late_kernel(): pass\n"
+        _write(tmpdir / "big.py", big_content)
+        wrapper = _write(tmpdir / "w.py", "from big import late_kernel\n")
+        if len(big_content) > 8192 and "@triton.jit" not in big_content[:8192]:
+            assert _check_imported_triton(wrapper.read_text(), wrapper) is False
+        else:
+            assert _check_imported_triton(wrapper.read_text(), wrapper) is True
+
+    def test_multiple_imports_first_hit_wins(self, tmpdir):
+        """Multiple from-imports, only one has triton."""
+        _write(tmpdir / "utils.py", "def helper(): pass\n")
+        _write(tmpdir / "kernels.py", "@triton.jit\ndef k(): pass\n")
+        wrapper = _write(tmpdir / "w.py", "from utils import helper\nfrom kernels import k\n")
+        assert _check_imported_triton(wrapper.read_text(), wrapper) is True


### PR DESCRIPTION
When kernel.py is a Python wrapper that imports Triton kernels from submodules (e.g., from aiter.ops.triton import ...), the file itself has no @triton.jit decorators. The existing detection only checked for @triton.jit / @triton.autotune / tl. in the file content, causing these wrapper kernels to be classified as "unknown" and routed to the homogeneous agent instead of the heterogeneous orchestrator.

Fix: follow `from X import ...` statements (depth-limited BFS, max 2 levels) and check if any imported module contains @triton.jit or @triton.autotune markers. Module resolution tries pkg/mod.py then pkg/__init__.py for package imports.

Three changes:
- MCP server _get_kernel_type: add "import triton" check + import following via _imports_triton_kernels()
- task_generator _infer_kernel_type: same enhancement via _check_imported_triton()
- mini.py: treat discovery type="unknown" same as None so the _infer_kernel_type fallback actually runs

Tests: 25 cases covering direct detection, import following (1-3 levels), aiter-style deep imports, missing modules, binary files, large files, __init__.py fallback, depth limits.



<!--
Thanks for contributing a pull request, we appreciate you!

If this PR fixes an issue, please reference it, e.g., 'Fixes #1234'.

You can delete this comment.
-->
