### PR TITLE
fix: prevent geak --help from hanging by deferring MCP server startup

### DIFF
--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -188,7 +188,8 @@ def main(
     tee_out, tee_err = TeeOutput(sys.stdout), TeeOutput(sys.stderr)
     sys.stdout, sys.stderr = tee_out, tee_err
 
-    configure_if_first_time()
+    if sys.stdin.isatty():
+        configure_if_first_time()
 
     # 1) Config merge
     base_config_path = builtin_config_dir / "mini_kernel_strategy_list.yaml"

--- a/src/minisweagent/tools/tools_runtime.py
+++ b/src/minisweagent/tools/tools_runtime.py
@@ -12,13 +12,30 @@ json_path = Path(__file__).parent / "tools.json"
 with open(json_path, encoding="utf-8") as f:
     _all_tools = json.load(f)
 
-try:
-    from minisweagent.tools.mcp_bridge import collect_mcp_tools
+_mcp_bridges: list = []
+_mcp_tools: list = []
+_mcp_collected = False
 
-    _mcp_bridges, _mcp_tools = collect_mcp_tools()
-    _all_tools.extend(_mcp_tools)
-except Exception:
-    _mcp_bridges, _mcp_tools = [], []
+
+def _ensure_mcp_collected() -> None:
+    """Lazily start MCP servers and collect their tools.
+
+    Called on first ToolRuntime instantiation rather than at module import
+    time, so that ``geak --help`` and other import-only paths do not spawn
+    MCP server subprocesses and hang.
+    """
+    global _mcp_bridges, _mcp_tools, _mcp_collected
+    if _mcp_collected:
+        return
+    _mcp_collected = True
+    try:
+        from minisweagent.tools.mcp_bridge import collect_mcp_tools
+
+        _mcp_bridges, _mcp_tools = collect_mcp_tools()
+        _all_tools.extend(_mcp_tools)
+    except Exception:
+        pass
+
 
 _TOOL_PROFILES: dict[str, set[str] | None] = {
     "full": None,
@@ -61,6 +78,7 @@ class ToolRuntime:
         patch_output_dir: str | None = None,
         tool_profile: str = "full",
     ):
+        _ensure_mcp_collected()
         self._tool_profile = tool_profile
         self._mcp_bridges: list = list(_mcp_bridges)
         allowed = _TOOL_PROFILES.get(tool_profile)


### PR DESCRIPTION
Two changes:
- tools_runtime: collect_mcp_tools() was called at module import time, spawning 3 MCP server subprocesses on every `import minisweagent`. This caused `geak --help` (and any sub-agent that probed the geak CLI) to hang indefinitely waiting for MCP handshakes. Fixed by deferring to _ensure_mcp_collected(), called lazily on the first ToolRuntime instantiation instead.

- mini.py: guard configure_if_first_time() with sys.stdin.isatty() so the interactive setup wizard does not block piped / non-TTY invocations that lack the MSWEA_CONFIGURED env var.

