### PR TITLE
fix: use GEAK_RESULT_LATENCY_MS as canonical latency source of truth

### DIFF
--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -437,11 +437,6 @@ def run_profile(
         "optimized": optimized_metrics,
     }
 
-    base_dur = baseline_metrics.get("duration_us")
-    opt_dur = optimized_metrics.get("duration_us")
-    if isinstance(base_dur, (int, float)) and isinstance(opt_dur, (int, float)) and base_dur > 0:
-        comparison["duration_change_pct"] = round((opt_dur - base_dur) / base_dur * 100, 1)
-
     base_bn = baseline_metrics.get("bottleneck", "unknown")
     opt_bn = optimized_metrics.get("bottleneck", "unknown")
     if base_bn != opt_bn:

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -460,7 +460,8 @@ def write_eval_results(
     else:
         round_eval["speedup_source"] = (
             "agent-reported benchmark (no FULL_BENCHMARK verified result available — "
-            "please run the FULL_BENCHMARK section from COMMANDMENT.md to verify this speedup)"
+            "the orchestrator will run FULL_BENCHMARK automatically after this round; "
+            "do not use this speedup for final selection)"
         )
     eval_path = output_dir / f"round_{round_num}_evaluation.json"
     eval_path.write_text(json.dumps(round_eval, indent=2, default=str))

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -458,7 +458,10 @@ def write_eval_results(
     if isinstance(fb_raw_check, dict) and fb_raw_check.get("verified_speedup") is not None:
         round_eval["speedup_source"] = "FULL_BENCHMARK verified result"
     else:
-        round_eval["speedup_source"] = "agent-reported benchmark (no FULL_BENCHMARK verified result available)"
+        round_eval["speedup_source"] = (
+            "agent-reported benchmark (no FULL_BENCHMARK verified result available — "
+            "please run the FULL_BENCHMARK section from COMMANDMENT.md to verify this speedup)"
+        )
     eval_path = output_dir / f"round_{round_num}_evaluation.json"
     eval_path.write_text(json.dumps(round_eval, indent=2, default=str))
     logger.info("Round evaluation written to: %s", eval_path)

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -454,6 +454,11 @@ def write_eval_results(
     round_num: int,
 ) -> Any:
     """Write evaluation artifacts to disk and return a typed RoundEvaluation."""
+    fb_raw_check = round_eval.get("full_benchmark") or round_eval.get("benchmark") or {}
+    if isinstance(fb_raw_check, dict) and fb_raw_check.get("verified_speedup") is not None:
+        round_eval["speedup_source"] = "FULL_BENCHMARK verified result"
+    else:
+        round_eval["speedup_source"] = "agent-reported benchmark (no FULL_BENCHMARK verified result available)"
     eval_path = output_dir / f"round_{round_num}_evaluation.json"
     eval_path.write_text(json.dumps(round_eval, indent=2, default=str))
     logger.info("Round evaluation written to: %s", eval_path)

--- a/src/minisweagent/run/postprocess/results.py
+++ b/src/minisweagent/run/postprocess/results.py
@@ -499,7 +499,8 @@ def auto_finalize(
 
     report["speedup_source"] = (
         "agent-reported benchmark (no FULL_BENCHMARK verified result available — "
-        "please run the FULL_BENCHMARK section from COMMANDMENT.md to verify this speedup)"
+        "the orchestrator will run FULL_BENCHMARK automatically after this round; "
+        "do not use this speedup for final selection)"
     )
     report_path.write_text(json.dumps(report, indent=2))
     logger.info("Auto-finalized: %s", summary_text)

--- a/src/minisweagent/run/postprocess/results.py
+++ b/src/minisweagent/run/postprocess/results.py
@@ -497,7 +497,10 @@ def auto_finalize(
         logger.info("Report written to: %s", report_path)
         return merged
 
-    report["speedup_source"] = "agent-reported benchmark (no FULL_BENCHMARK verified result available)"
+    report["speedup_source"] = (
+        "agent-reported benchmark (no FULL_BENCHMARK verified result available — "
+        "please run the FULL_BENCHMARK section from COMMANDMENT.md to verify this speedup)"
+    )
     report_path.write_text(json.dumps(report, indent=2))
     logger.info("Auto-finalized: %s", summary_text)
     logger.info("Report written to: %s", report_path)

--- a/src/minisweagent/run/postprocess/results.py
+++ b/src/minisweagent/run/postprocess/results.py
@@ -308,7 +308,21 @@ def post_round_evaluate(
         # Falling back to the agent's self-reported benchmark_speedup risks
         # promoting a hallucinated or inflated speedup as the global best.
         current = fb.verified_speedup if fb and fb.verified_speedup is not None else None
-        if current is not None and current >= ctx.get("_best_global_speedup", 0):
+        if current is None:
+            agent_speedup = round_eval.benchmark_speedup
+            note = (
+                f"No FULL_BENCHMARK verified speedup available; "
+                f"agent reported {agent_speedup:.4f}x (not used for global best selection)"
+            )
+            logger.warning("Round %d: %s", round_num, note)
+            eval_path = output_dir / f"round_{round_num}_evaluation.json"
+            try:
+                eval_dict = json.loads(eval_path.read_text())
+                eval_dict["verified_speedup_skipped"] = note
+                eval_path.write_text(json.dumps(eval_dict, indent=2, default=str))
+            except (json.JSONDecodeError, OSError):
+                pass
+        elif current >= ctx.get("_best_global_speedup", 0):
             ctx["starting_patch"] = round_eval.best_patch
             ctx["_best_global_speedup"] = current
     return round_eval

--- a/src/minisweagent/run/postprocess/results.py
+++ b/src/minisweagent/run/postprocess/results.py
@@ -304,10 +304,11 @@ def post_round_evaluate(
     ctx[f"round_{round_num}_eval"] = round_eval
     if round_eval.best_patch:
         fb = round_eval.full_benchmark
-        current = (
-            fb.verified_speedup if fb and fb.verified_speedup is not None else None
-        ) or round_eval.benchmark_speedup
-        if current >= ctx.get("_best_global_speedup", 0):
+        # Only count rounds with an independently verified FULL_BENCHMARK result.
+        # Falling back to the agent's self-reported benchmark_speedup risks
+        # promoting a hallucinated or inflated speedup as the global best.
+        current = fb.verified_speedup if fb and fb.verified_speedup is not None else None
+        if current is not None and current >= ctx.get("_best_global_speedup", 0):
             ctx["starting_patch"] = round_eval.best_patch
             ctx["_best_global_speedup"] = current
     return round_eval

--- a/src/minisweagent/run/postprocess/results.py
+++ b/src/minisweagent/run/postprocess/results.py
@@ -486,6 +486,7 @@ def auto_finalize(
     best_verified_round_eval = select_best_verified_round_evaluation(output_dir)
     report_path = output_dir / "final_report.json"
     if best_verified_round_eval is not None:
+        report["speedup_source"] = "FULL_BENCHMARK verified result"
         merged = merge_round_evaluation_into_final_report(
             ctx,
             output_dir,
@@ -496,6 +497,7 @@ def auto_finalize(
         logger.info("Report written to: %s", report_path)
         return merged
 
+    report["speedup_source"] = "agent-reported benchmark (no FULL_BENCHMARK verified result available)"
     report_path.write_text(json.dumps(report, indent=2))
     logger.info("Auto-finalized: %s", summary_text)
     logger.info("Report written to: %s", report_path)

--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -1127,6 +1127,11 @@ def run_preprocessor(
         _bm_val = extract_latency_ms(bb_text)
         if _bm_val is not None:
             baseline_metrics["benchmark_duration_us"] = _bm_val * 1000.0
+            # Preserve profiler value separately, then override duration_us with
+            # the harness-measured value so all consumers use the same source.
+            if "duration_us" in baseline_metrics:
+                baseline_metrics["profiler_duration_us"] = baseline_metrics["duration_us"]
+            baseline_metrics["duration_us"] = _bm_val * 1000.0
         _sm = _re.search(r"(\d+)\s+shapes", bb_text, _re.IGNORECASE)
         if _sm:
             baseline_metrics["benchmark_shape_count"] = int(_sm.group(1))


### PR DESCRIPTION
## Summary

Three related fixes to make harness-measured latency (`GEAK_RESULT_LATENCY_MS`) the single source of truth, removing places where profiler `duration_us` was used instead and causing agent confusion or wrong best-round selection.

**1. `preprocessor.py` — `duration_us` now reflects harness latency**

After `baseline_metrics` is built from profiler data, the benchmark baseline enrichment block now overrides `duration_us` with the value parsed from `GEAK_RESULT_LATENCY_MS` in `benchmark_baseline.txt`. The original profiler value is preserved as `profiler_duration_us` for diagnostic use.

**2. `evaluation.py` — remove `duration_change_pct` from profile comparison**

The `duration_change_pct` field compared `duration_us` from the baseline profiler run against `duration_us` from the patch profiler run. Since these are profiler-instrumented GPU times (not wall-clock), they diverge from what the harness actually measures. The agent was reading this field and hallucinating speedup claims based on it. Removed entirely.

**3. `results.py` — fix best-round selection to require verified speedup**

`post_round_evaluate` was falling back to `round_eval.benchmark_speedup` (agent self-reported) when `fb.verified_speedup` was `None`. This meant a round where FULL_BENCHMARK failed or was skipped could still set `ctx["_best_global_speedup"]` using an unverified, potentially inflated speedup — exactly the scenario in #113 where the agent claimed 3.53× but FULL_BENCHMARK showed it was slower. Now only rounds with a real `verified_speedup` update the global best. Fixes #113.

