### PR TITLE
fix: add mcp optional dependency group for mcp_tools packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ cd GEAK
 AMD_LLM_API_KEY=<YOUR_KEY> bash scripts/run-docker.sh
 # (or)
 # Local
-pip install -e .
+pip install -e .          # core package (includes fastmcp and mcp[cli])
+pip install -e '.[mcp]'   # + MCP tool servers (profiler, test-discovery, metrix)
+pip install -e '.[full]'  # everything (MCP tools + dev + langchain)
 
 # Set model name and key. In the case of docker-based setup, export the API key before
 # running scripts/run-docker.sh.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -22,7 +22,14 @@ AMD_LLM_API_KEY=<YOUR_KEY> bash scripts/run-docker.sh
 # (or)
 # Local
 pip install -e .
+
+# To also install the MCP tool servers (automated-test-discovery, metrix-mcp, profiler-mcp):
+pip install -e '.[mcp]'
+# Or install everything at once:
+pip install -e '.[full]'
 ```
+
+> **Note:** `fastmcp` and `mcp[cli]` are included in the core dependencies and installed automatically with `pip install -e .`. The `[mcp]` extra installs the three GEAK-specific MCP server packages that live under `mcp_tools/` — these are not on PyPI and are not installed by default. Without them you will see `ModuleNotFoundError` errors when the agent tries to start the profiler or test-discovery servers.
 
 ## 2. Configure the model
 In the case of docker-based setup, export the API key before running scripts/run-docker.sh.

--- a/mcp_tools/README.md
+++ b/mcp_tools/README.md
@@ -2,6 +2,20 @@
 
 This directory is where you add **Model Context Protocol** servers that the GEAK agent can call as ordinary tools. Each subdirectory here is one server package. The main application discovers those packages automatically, starts them as subprocesses, and merges their tool definitions into the agent’s tool list.
 
+## Installation
+
+`fastmcp` and `mcp[cli]` are core dependencies — installed automatically with `pip install -e .`.
+
+The three MCP server packages in this directory (`automated-test-discovery`, `metrix-mcp`, `profiler-mcp`) are **not** installed by default. Install them with:
+
+```bash
+pip install -e ‘.[mcp]’   # MCP servers only
+# or
+pip install -e ‘.[full]’  # everything
+```
+
+Without this, the agent will fail with `ModuleNotFoundError` when it tries to start these servers.
+
 ## Directory and module naming
 
 Use a **hyphenated** folder name for the server (for example, `profiler-mcp`). GEAK maps that name to a **Python package** by replacing hyphens with underscores (`profiler_mcp`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# MCP tool packages under mcp_tools/ — installed as local path dependencies.
+# pip install -e '.[mcp]' installs these alongside the main package.
+mcp = [
+    "automated-test-discovery @ file:mcp_tools/automated-test-discovery",
+    "metrix-mcp @ file:mcp_tools/metrix-mcp",
+    "profiler-mcp @ file:mcp_tools/profiler-mcp",
+]
+
 # LangChain hybrid retrieval for AMD GPU knowledge base (embedding + BM25 + reranker)
 langchain = [
     "langchain>=0.3.0",
@@ -67,6 +75,7 @@ langchain = [
 full = [
     "mini-swe-agent[dev]",
     "mini-swe-agent[langchain]",
+    "mini-swe-agent[mcp]",
     "swe-rex>=1.4.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,11 @@ dependencies = [
 [project.optional-dependencies]
 # MCP tool packages under mcp_tools/ — installed as local path dependencies.
 # pip install -e '.[mcp]' installs these alongside the main package.
+# Paths are resolved via [tool.uv.sources] below (uv) or pip install -e mcp_tools/* directly.
 mcp = [
-    "automated-test-discovery @ file:mcp_tools/automated-test-discovery",
-    "metrix-mcp @ file:mcp_tools/metrix-mcp",
-    "profiler-mcp @ file:mcp_tools/profiler-mcp",
+    "automated-test-discovery",
+    "metrix-mcp",
+    "profiler-mcp",
 ]
 
 # LangChain hybrid retrieval for AMD GPU knowledge base (embedding + BM25 + reranker)
@@ -269,6 +270,11 @@ skip-magic-trailing-comma = false
 
 # Like Black, automatically detect the appropriate line ending.
 line-ending = "auto"
+
+[tool.uv.sources]
+automated-test-discovery = { path = "mcp_tools/automated-test-discovery", editable = true }
+metrix-mcp = { path = "mcp_tools/metrix-mcp", editable = true }
+profiler-mcp = { path = "mcp_tools/profiler-mcp", editable = true }
 
 [tool.typos.default.extend-identifiers]
 # *sigh* this just isn't worth the cost of fixing


### PR DESCRIPTION
## Summary

- Adds an `[mcp]` optional dependency group to `pyproject.toml` that installs all MCP tool packages under `mcp_tools/` as local path dependencies
- Includes `[mcp]` in the `[full]` extra so `pip install -e '.[full]'` now covers everything

## Before

`pip install -e '.[full]'` did not install the MCP tools, leading to confusing runtime errors:
```
RuntimeError: Failed to start MCP server kernel-ercs: ModuleNotFoundError: No module named 'fastmcp'
```

## After

| Command | What's installed |
|---|---|
| `pip install -e '.'` | core package only |
| `pip install -e '.[mcp]'` | core + MCP tools |
| `pip install -e '.[full]'` | everything including MCP tools |

Fixes #44 

