### PR TITLE
Pin metrix to intellikit@bcbfa02 for production stability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "openai != 1.100.0,!=1.100.1",  # https://github.com/SWE-agent/mini-swe-agent/issues/446
     "mcp[cli]>=1.2.0",  # required by automated test discovery MCP server
     "fastmcp>=0.2.0",  # required by profiler-mcp and metrix-mcp
-    "metrix @ git+https://github.com/AMDResearch/intellikit.git#subdirectory=metrix",  # AMD GPU profiling
+    "metrix @ git+https://github.com/AMDResearch/intellikit.git@bcbfa0252df9d55f3aab68c95dd3ce45ccbe5b46#subdirectory=metrix",  # AMD GPU profiling — pinned for production stability
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR:                                                                                                                       
                                                                  
- Pins metrix from tracking IntelliKit main HEAD to commit bcbfa02 for deterministic builds                                    - Ensures users get consistent behavior across installs — upgrades happen intentionally via version bumps, not silently from upstream pushes                                                                                                                
                                                                  
We can bump the pinned commit as needed for bug fixes, requested features, or on demand.                                        
                                                                  
Tests:                                                                                                                         
- Verified pip install -e . resolves and installs metrix 0.1.0 from pinned commit
- Verified import metrix works on MI325X node