### PR TITLE
fix(preprocess): route invalid split harness to UTA instead of crashing

### DIFF
--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -506,9 +506,16 @@ def run_preprocessor(
         kernel_path = _clean_kernel
         # For merged kernels, the split helper may produce a GEAK-compatible
         # wrapper harness (e.g. HIP/CUDA mixed-source cases). Reuse it directly
-        # when the caller did not already provide a harness.
+        # when the caller did not already provide a harness — but only if the
+        # split harness passes static validation (has argparse + all required
+        # flags). Pure Triton merged files produce raw test logic without
+        # argparse, which fails validate_harness and causes a hard crash (#128).
         if not harness:
-            harness = _new_harness
+            from minisweagent.run.preprocess.harness_utils import validate_harness as _validate_harness
+
+            _split_valid, _ = _validate_harness(_new_harness)
+            if _split_valid:
+                harness = _new_harness
 
     _print(f"  Kernel: {kernel_path}")
 


### PR DESCRIPTION
## Summary

Fixes #128 — hard crash when running GEAK on a merged Triton file.

**Root cause:** When a merged Triton file (kernel + test logic in one file) is split in Step 1, the extracted test logic is raw Python — no argparse, no `--correctness`/`--profile`/`--benchmark`/`--full-benchmark` flags. The preprocessor was unconditionally treating this split file as the harness, then calling `validate_harness()` which immediately raised a `RuntimeError` instead of falling through to UnitTestAgent.

**Fix:** Run a static validation check on the split harness before accepting it. If it fails (Triton case), skip it so the normal UTA/discovery path generates a proper GEAK-compatible harness. HIP/CUDA splits that produce valid wrappers are unaffected.

## Test plan

- [x] All 483 tests pass
- [x] Triton merged files now route to UTA instead of crashing
- [x] HIP split harnesses (which are valid) still accepted directly

