### PR TITLE
fix /bin/sh not support source

### DIFF
--- a/src/minisweagent/agents/parallel_agent.py
+++ b/src/minisweagent/agents/parallel_agent.py
@@ -446,7 +446,7 @@ class ParallelAgent(DefaultAgent):
         def run_single_agent(agent_id: int):
             """Run a single parallel agent instance."""
             # All repos use git worktree (non-git repos are initialized as git above)
-            worktree_path = create_worktree(repo_path, worktree_base / f"agent_{agent_id}")
+            worktree_path = create_worktree(repo_path, worktree_base / f"slot_{agent_id}")
             worktree_path_str = str(worktree_path.resolve())
 
             logger.debug("Created worktree for agent %d: %s", agent_id, worktree_path)

--- a/src/minisweagent/agents/parallel_agent.py
+++ b/src/minisweagent/agents/parallel_agent.py
@@ -14,7 +14,7 @@ from typing import Any
 from minisweagent import Environment, Model
 from minisweagent.agents.default import AgentConfig, DefaultAgent
 from minisweagent.agents.select_patch_agent import run_select_patch
-from minisweagent.run.task_file import create_worktree
+from minisweagent.run.task_file import _neutralize_nested_git_repos, create_worktree
 from minisweagent.run.utils.parallel_helpers import (
     _stdout_lock as _stdout_lock,
 )
@@ -213,37 +213,6 @@ class ParallelAgent(DefaultAgent):
                 pass
 
     @staticmethod
-    def _create_worktree(repo_path: Path, worktree_path: Path) -> Path:
-        """Create a git worktree, cleaning up any existing one first."""
-        return create_worktree(repo_path, worktree_path)
-
-    @staticmethod
-    def _neutralize_nested_git_repos(repo_path: Path) -> list[Path]:
-        """Rename .git directories in nested repos to .git.bak.
-
-        This prevents git from treating nested directories as submodules,
-        allowing all content to be properly added to the parent repo.
-
-        Returns list of paths that were renamed (for potential restoration).
-        """
-        renamed = []
-        for git_dir in repo_path.rglob(".git"):
-            # Skip the repo's own .git (if it exists)
-            if git_dir.parent == repo_path:
-                continue
-            # Only process directories (not .git files from worktrees)
-            if git_dir.is_dir():
-                backup_path = git_dir.parent / ".git.bak"
-                try:
-                    if backup_path.exists():
-                        shutil.rmtree(backup_path)
-                    git_dir.rename(backup_path)
-                    renamed.append(backup_path)
-                except Exception:
-                    pass  # Best effort
-        return renamed
-
-    @staticmethod
     def _has_valid_head(repo_path: Path) -> bool:
         """Check if the git repo has a valid HEAD (at least one commit)."""
         try:
@@ -290,7 +259,7 @@ class ParallelAgent(DefaultAgent):
         try:
             # Neutralize nested git repos first (rename .git -> .git.bak)
             # This ensures nested content is added as regular files, not submodules
-            ParallelAgent._neutralize_nested_git_repos(repo_path)
+            _neutralize_nested_git_repos(repo_path)
 
             # Initialize git repo (use --initial-branch to ensure new repo creation)
             subprocess.run(
@@ -452,7 +421,7 @@ class ParallelAgent(DefaultAgent):
         def run_single_agent(agent_id: int):
             """Run a single parallel agent instance."""
             # All repos use git worktree (non-git repos are initialized as git above)
-            worktree_path = cls._create_worktree(repo_path, worktree_base / f"agent_{agent_id}")
+            worktree_path = create_worktree(repo_path, worktree_base / f"agent_{agent_id}")
             worktree_path_str = str(worktree_path.resolve())
 
             if console:

--- a/src/minisweagent/agents/parallel_agent.py
+++ b/src/minisweagent/agents/parallel_agent.py
@@ -14,6 +14,7 @@ from typing import Any
 from minisweagent import Environment, Model
 from minisweagent.agents.default import AgentConfig, DefaultAgent
 from minisweagent.agents.select_patch_agent import run_select_patch
+from minisweagent.run.task_file import create_worktree
 from minisweagent.run.utils.parallel_helpers import (
     _stdout_lock as _stdout_lock,
 )
@@ -214,128 +215,7 @@ class ParallelAgent(DefaultAgent):
     @staticmethod
     def _create_worktree(repo_path: Path, worktree_path: Path) -> Path:
         """Create a git worktree, cleaning up any existing one first."""
-        worktree_str = str(worktree_path.resolve())
-
-        # Clean up any existing worktree
-        try:
-            result = subprocess.run(
-                ["git", "worktree", "list"],
-                cwd=repo_path,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            worktree_exists = any(
-                worktree_str in line or str(worktree_path) in line for line in result.stdout.splitlines()
-            )
-
-            if worktree_exists:
-                try:
-                    subprocess.run(
-                        ["git", "worktree", "remove", str(worktree_path), "--force"],
-                        cwd=repo_path,
-                        check=True,
-                        capture_output=True,
-                        text=True,
-                    )
-                except subprocess.CalledProcessError:
-                    subprocess.run(
-                        ["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True
-                    )
-        except subprocess.CalledProcessError:
-            subprocess.run(["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True)
-        except Exception:
-            pass
-
-        # Remove directory if it still exists
-        if worktree_path.exists():
-            try:
-                shutil.rmtree(worktree_path)
-            except Exception:
-                pass
-
-        worktree_path.parent.mkdir(parents=True, exist_ok=True)
-        ParallelAgent._ensure_safe_directory(repo_path)
-
-        # Create new worktree with detached HEAD to avoid branch name conflicts
-        try:
-            subprocess.run(
-                ["git", "worktree", "add", "--detach", str(worktree_path)],
-                cwd=repo_path,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as e:
-            error_msg = e.stderr if e.stderr else (e.stdout if e.stdout else str(e))
-            if "missing but already registered worktree" in error_msg.lower():
-                subprocess.run(["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True)
-                subprocess.run(
-                    ["git", "worktree", "add", "--detach", "-f", str(worktree_path)],
-                    cwd=repo_path,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            elif "dubious ownership" in error_msg.lower():
-                ParallelAgent._ensure_safe_directory(repo_path)
-                ParallelAgent._ensure_safe_directory(worktree_path)
-                subprocess.run(
-                    ["git", "worktree", "add", "--detach", str(worktree_path)],
-                    cwd=repo_path,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            elif "already used by worktree" in error_msg.lower():
-                # Branch name conflict - remove old worktree and retry
-                subprocess.run(["git", "worktree", "prune"], cwd=repo_path, check=False, capture_output=True, text=True)
-                # Extract branch name from error message if possible, otherwise use worktree path
-                subprocess.run(
-                    ["git", "worktree", "remove", "--force", str(worktree_path)],
-                    cwd=repo_path,
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                )
-                subprocess.run(
-                    ["git", "worktree", "add", "--detach", str(worktree_path)],
-                    cwd=repo_path,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-            else:
-                raise RuntimeError(f"Failed to create worktree: {error_msg}") from e
-
-        # Ensure worktree path is also marked as safe
-        ParallelAgent._ensure_safe_directory(worktree_path)
-
-        # Copy untracked files from repo to worktree (e.g., newly created test files)
-        ParallelAgent._copy_untracked_files(repo_path, worktree_path)
-
-        return worktree_path
-
-    @staticmethod
-    def _copy_untracked_files(repo_path: Path, worktree_path: Path) -> None:
-        """Copy untracked files from repo to worktree."""
-        try:
-            result = subprocess.run(
-                ["git", "ls-files", "--others", "--exclude-standard"],
-                cwd=repo_path,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            untracked_files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
-            for rel_path in untracked_files:
-                src = repo_path / rel_path
-                dst = worktree_path / rel_path
-                if src.is_file():
-                    dst.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(src, dst)
-        except subprocess.CalledProcessError:
-            pass  # If git command fails, skip copying untracked files
+        return create_worktree(repo_path, worktree_path)
 
     @staticmethod
     def _neutralize_nested_git_repos(repo_path: Path) -> list[Path]:

--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -1009,6 +1009,7 @@ def run_preprocessor(
             result = subprocess.run(
                 correctness_cmd,
                 shell=True,
+                executable="/bin/bash",
                 capture_output=True,
                 text=True,
                 timeout=3600,
@@ -1057,6 +1058,7 @@ def run_preprocessor(
                 result = subprocess.run(
                     perf_cmd,
                     shell=True,
+                    executable="/bin/bash",
                     capture_output=True,
                     text=True,
                     timeout=benchmark_timeout,

--- a/src/minisweagent/run/task_file.py
+++ b/src/minisweagent/run/task_file.py
@@ -145,6 +145,29 @@ def _ensure_safe_directory(repo_path: Path, env: dict[str, str] | None = None) -
             pass
 
 
+def _neutralize_nested_git_repos(root: Path) -> list[Path]:
+    """Rename ``.git`` dirs in nested repos to ``.git.bak``.
+
+    This turns nested git repos / submodules into plain directories so that
+    git treats their content as regular files.
+    """
+    root = root.resolve()
+    renamed: list[Path] = []
+    for git_dir in root.rglob(".git"):
+        if git_dir.parent == root:
+            continue
+        if git_dir.is_dir():
+            backup = git_dir.parent / ".git.bak"
+            try:
+                if backup.exists():
+                    shutil.rmtree(backup)
+                git_dir.rename(backup)
+                renamed.append(backup)
+            except Exception:
+                pass
+    return renamed
+
+
 def _copy_nested_git_repos(repo_path: Path, worktree_path: Path) -> None:
     """Copy nested git repositories that are invisible to the top-level repo.
 
@@ -377,6 +400,9 @@ def create_worktree(repo_path: Path, worktree_path: Path) -> Path:
     _apply_dirty_tracked_changes(repo_path, worktree_path, git_env)
     _copy_untracked_files(repo_path, worktree_path, git_env)
     _copy_nested_git_repos(repo_path, worktree_path)
+    # Neutralize .git dirs in copied nested repos so the worktree's git
+    # treats their content as regular files (clean diffs, no gitlink noise).
+    _neutralize_nested_git_repos(worktree_path)
     return worktree_path
 
 

--- a/src/minisweagent/run/task_file.py
+++ b/src/minisweagent/run/task_file.py
@@ -145,6 +145,37 @@ def _ensure_safe_directory(repo_path: Path, env: dict[str, str] | None = None) -
             pass
 
 
+def _copy_nested_git_repos(repo_path: Path, worktree_path: Path) -> None:
+    """Copy nested git repositories that are invisible to the top-level repo.
+
+    `git worktree add` and `git ls-files` skip directories containing their own
+    `.git`. This function finds all such nested repos under *repo_path* and
+    copies them into *worktree_path* so the worktree has a complete snapshot.
+    """
+    repo_path = repo_path.resolve()
+    worktree_path = worktree_path.resolve()
+    top_git = repo_path / ".git"
+
+    for dirpath, dirnames, _filenames in os.walk(repo_path):
+        current = Path(dirpath)
+        # Skip the top-level .git directory itself and anything inside worktrees
+        if current == top_git or ".git" in current.parts[len(repo_path.parts) :]:
+            dirnames.clear()
+            continue
+
+        if ".git" in dirnames or (current / ".git").is_file():
+            # current is a nested git repo root — skip descending further
+            # via os.walk (copytree will handle the full subtree).
+            dirnames.clear()
+
+            rel = current.relative_to(repo_path)
+            dst = worktree_path / rel
+            if dst.exists():
+                shutil.rmtree(dst)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(current, dst, symlinks=True)
+
+
 def _copy_untracked_files(repo_path: Path, worktree_path: Path, env: dict[str, str] | None = None) -> None:
     """Copy untracked files from repo to worktree."""
     run_env = env if env is not None else None
@@ -331,6 +362,7 @@ def create_worktree(repo_path: Path, worktree_path: Path) -> Path:
     _ensure_safe_directory(worktree_path, git_env)
     _apply_dirty_tracked_changes(repo_path, worktree_path, git_env)
     _copy_untracked_files(repo_path, worktree_path, git_env)
+    _copy_nested_git_repos(repo_path, worktree_path)
     return worktree_path
 
 

--- a/src/minisweagent/run/task_file.py
+++ b/src/minisweagent/run/task_file.py
@@ -163,6 +163,12 @@ def _copy_nested_git_repos(repo_path: Path, worktree_path: Path) -> None:
             dirnames.clear()
             continue
 
+        # Skip the worktree directory itself to avoid infinite recursion when
+        # the worktree is created inside the repo (e.g. optimization_logs/).
+        if current == worktree_path or worktree_path in current.parents:
+            dirnames.clear()
+            continue
+
         if ".git" in dirnames or (current / ".git").is_file():
             # current is a nested git repo root — skip descending further
             # via os.walk (copytree will handle the full subtree).
@@ -179,6 +185,7 @@ def _copy_nested_git_repos(repo_path: Path, worktree_path: Path) -> None:
 def _copy_untracked_files(repo_path: Path, worktree_path: Path, env: dict[str, str] | None = None) -> None:
     """Copy untracked files from repo to worktree."""
     run_env = env if env is not None else None
+    resolved_wt = worktree_path.resolve()
     try:
         result = subprocess.run(
             ["git", "ls-files", "--others", "--exclude-standard"],
@@ -191,6 +198,13 @@ def _copy_untracked_files(repo_path: Path, worktree_path: Path, env: dict[str, s
         for rel_path in (f.strip() for f in result.stdout.splitlines() if f.strip()):
             src = repo_path / rel_path
             dst = worktree_path / rel_path
+            # Skip files inside the worktree to avoid infinite recursion when
+            # the worktree is created inside the repo.
+            try:
+                src.resolve().relative_to(resolved_wt)
+                continue
+            except ValueError:
+                pass
             if src.is_file():
                 dst.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(src, dst)

--- a/src/minisweagent/run/utils/parallel_helpers.py
+++ b/src/minisweagent/run/utils/parallel_helpers.py
@@ -23,7 +23,11 @@ from typing import Any
 
 from minisweagent.agents.default import TerminatingException
 from minisweagent.debug_runtime import emit_debug_log
-from minisweagent.run.task_file import create_worktree, create_worktree_with_patch
+from minisweagent.run.task_file import (
+    _neutralize_nested_git_repos,
+    create_worktree,
+    create_worktree_with_patch,
+)
 
 # ============================================================================
 # Thread-local stdout/stderr redirection
@@ -209,6 +213,10 @@ def bootstrap_git_repo(repo_path: Path, console=None) -> bool:
                 gitignore_path.write_text(existing + "\n" + gitignore_content)
         else:
             gitignore_path.write_text(gitignore_content)
+
+        # Neutralize nested git repos so their content is added as regular files
+        # instead of gitlink/submodule entries.
+        _neutralize_nested_git_repos(repo_path)
 
         subprocess.run(
             ["git", "add", "-A"],

--- a/src/minisweagent/tools/save_and_test.py
+++ b/src/minisweagent/tools/save_and_test.py
@@ -496,6 +496,7 @@ class SaveAndTestTool:
                 "*.egg-info/",
                 "*.so",
                 ".geak_resolved/",
+                ".git.bak/",
                 *self._generated_helper_excludes(),
             ]
             exclude_args = " ".join(f"':(exclude){entry}'" for entry in excludes)

--- a/tests/agents/test_homogeneous_agent.py
+++ b/tests/agents/test_homogeneous_agent.py
@@ -16,6 +16,7 @@ from minisweagent.agents.homogeneous.homogeneous_agent import (
     run_homogeneous_agent,
 )
 from minisweagent.agents.parallel_agent import BestPatchResult, ParallelAgent
+from minisweagent.run.task_file import create_worktree
 from minisweagent.environments.local import LocalEnvironment
 from minisweagent.models.test_models import DeterministicModel
 
@@ -432,7 +433,7 @@ class TestParallelAgentIntegration:
         worktree_path = temp_git_repo.parent / "worktree_test"
 
         try:
-            result = ParallelAgent._create_worktree(temp_git_repo, worktree_path)
+            result = create_worktree(temp_git_repo, worktree_path)
             assert result.exists()
             assert (result / "test.py").exists()
         finally:


### PR DESCRIPTION
fix #135 

In subprocess.run(), use /bin/bash instead of /bin/sh

fix #138 
For nested hip repo, copy all submodules