### PR TITLE
fix(preprocess): use full Metrix profile for baseline runs

### DIFF
--- a/src/minisweagent/run/pipeline_helpers.py
+++ b/src/minisweagent/run/pipeline_helpers.py
@@ -903,6 +903,6 @@ def run_baseline_profile(test_command: str, gpu_id: int = 0) -> dict:
         command=profile_cmd,
         backend="metrix",
         num_replays=3,
-        quick=True,
+        quick=False,
         gpu_devices=str(gpu_id),
     )

--- a/src/minisweagent/run/preprocess/harness_utils.py
+++ b/src/minisweagent/run/preprocess/harness_utils.py
@@ -1648,6 +1648,6 @@ def run_baseline_profile(test_command: str, gpu_id: int = 0) -> dict:
         command=profile_cmd,
         backend="metrix",
         num_replays=3,
-        quick=True,
+        quick=False,
         gpu_devices=str(gpu_id),
     )

--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -1042,7 +1042,7 @@ def run_preprocessor(
                     command=perf_cmd,
                     backend="metrix",
                     num_replays=3,
-                    quick=True,
+                    quick=False,
                     gpu_devices=str(gpu_id),
                     workdir=_cwd,
                 )


### PR DESCRIPTION
## Summary
- switch preprocess baseline profiling from Metrix quick mode to the full memory profile so baseline artifacts include the full hardware counter set
- update both preprocess entry paths plus the shared baseline profiling helper to keep Metrix behavior consistent
- leave benchmark-duration override behavior unchanged so downstream scoring still uses the intended canonical wall-clock metric

## Test plan
- [x] `python3 -m py_compile src/minisweagent/run/preprocess/preprocessor.py src/minisweagent/run/preprocess/harness_utils.py src/minisweagent/run/pipeline_helpers.py`
- [x] `pytest tests/run/test_pipeline_helpers.py -q`
- [x] `pytest tests/run/test_preprocess_unit.py -q`