### PR TITLE
fix(preprocess): harden UTA, shape fixer, and baseline reruns

### DIFF
--- a/src/minisweagent/run/pipeline_helpers.py
+++ b/src/minisweagent/run/pipeline_helpers.py
@@ -388,10 +388,10 @@ def execute_harness_validation(
     Parameters
     ----------
     benchmark_extra_args:
-        Extra CLI args appended to benchmark/full-benchmark invocations
-        (e.g. ``"--iterations 50"``).  Passed via the
-        ``GEAK_BENCHMARK_EXTRA_ARGS`` env var so both direct invocations
-        and COMMANDMENT-based scripts use the same settings.
+        Extra benchmark tuning args. ``--iterations N`` is normalized into
+        ``GEAK_BENCHMARK_ITERATIONS`` so harnesses do not need to expose it
+        as a CLI flag. Any remaining args are passed via
+        ``GEAK_BENCHMARK_EXTRA_ARGS``.
 
     Returns
     -------
@@ -410,15 +410,19 @@ def execute_harness_validation(
     if not benchmark_extra_args:
         env_overrides["GEAK_BENCHMARK_ITERATIONS"] = "5"
     else:
-        env_overrides["GEAK_BENCHMARK_EXTRA_ARGS"] = benchmark_extra_args
-        # Extract --iterations N from extra_args and also set the env var
-        # so harnesses that read GEAK_BENCHMARK_ITERATIONS (instead of
-        # parsing --iterations from argv) get the right count.
         import re as _re
 
-        _iter_match = _re.search(r"--iterations\s+(\d+)", benchmark_extra_args)
+        remaining_extra_args = benchmark_extra_args.strip()
+        _iter_match = _re.search(r"(?:^|\s)--iterations\s+(\d+)(?=\s|$)", remaining_extra_args)
         if _iter_match:
             env_overrides["GEAK_BENCHMARK_ITERATIONS"] = _iter_match.group(1)
+            remaining_extra_args = _re.sub(
+                r"(?:^|\s)--iterations\s+\d+(?=\s|$)",
+                " ",
+                remaining_extra_args,
+            ).strip()
+        if remaining_extra_args:
+            env_overrides["GEAK_BENCHMARK_EXTRA_ARGS"] = remaining_extra_args
 
     results = run_harness(
         harness_path,

--- a/src/minisweagent/run/preprocess/INSTRUCTIONS.md
+++ b/src/minisweagent/run/preprocess/INSTRUCTIONS.md
@@ -199,6 +199,17 @@ script that imports the kernel, creates test inputs, and provides
    x = torch.randn(S, B, H, D, dtype=torch.float16, device='cpu').to('cuda')
    ```
 
+9. **Preserve the source benchmark/test's full execution contract, not just
+   shapes.**
+   - Keep per-tensor semantics independent: dtype, device, layout,
+     contiguity, index dtypes, auxiliary buffers/caches/scales, and any
+     helper-side preprocessing.
+   - Do NOT normalize every tensor to the main activation dtype just because
+     the benchmark uses that dtype for `query`, `key`, or other primary
+     activations.
+   - If a harness mode fails, understand why it fails before editing. Prefer
+     the smallest source-faithful fix over rewriting working harness logic.
+
 **Language-specific test harness notes:**
 
 When the kernel is NOT a Python/Triton kernel, the test harness approach varies:

--- a/src/minisweagent/run/preprocess/config/mini_shape_fixer.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_shape_fixer.yaml
@@ -1,6 +1,8 @@
 agent:
   system_template: |
-    You are a meta-checking agent. Read two files, compare shapes, done.
+    You are a harness repair agent. Start by comparing the authoritative
+    source file against the generated harness, then apply the smallest
+    source-faithful fix needed to make the sampled modes work.
 
     Step 1: Read the SHAPE SOURCE FILE. What configs does it benchmark?
       (Look for the config variables, loops, products, helper functions, and
@@ -20,11 +22,14 @@ agent:
       Then determine the exact sampled cases that the harness will use for
       `--benchmark`, `--correctness`, and `--profile`.
 
-    Step 3: Compare EXACT sampled semantics, not just the config universe.
+    Step 3: Compare full sampled semantics, not just the config universe.
       - SAME VALUES / SAME COUNT is NOT sufficient if a different order causes
         `_pick()` (or equivalent logic) to choose different sampled cases.
-      - If the source file already defines a case list/helper, that ordering is
-        authoritative.
+      - Preserve the source file's helper semantics and per-tensor contracts:
+        dtype, device, layout, contiguity, auxiliary buffers/caches/scales,
+        index dtypes, and helper-side preprocessing.
+      - Do NOT normalize all tensors to a single dtype just because the main
+        activations use that dtype.
       - If a task-runner exists, preserve it only insofar as it faithfully
         wraps the same repo-native benchmark/test semantics. Do NOT approve a
         wrapper that invents new commands, unsupported flags, or a different
@@ -32,12 +37,21 @@ agent:
       - If the source file uses nested loops, preserve that loop nesting order.
       - Tuple vs list syntax is fine only when the resulting sampled cases are
         exactly the same.
-      - YES: exact sampled cases for `--benchmark`, `--correctness`, and
-        `--profile` all match the source file. Print SHAPES_VERIFIED. Stop.
-      - NO: fix the harness so it preserves the source ordering and yields the
-        exact same sampled cases. Print SHAPES_FIXED. Stop.
 
-    That is all. Do not run anything. Do not explore. Just read and compare.
+    Step 4: Validate and repair minimally.
+      - If validation commands are provided, you MAY run them from the repo
+        root to understand why a mode fails.
+      - Understand failures from stderr before editing.
+      - Re-run only the relevant failing mode(s) after each edit.
+      - Prefer the smallest source-faithful fix over rewriting working harness
+        logic.
+      - If no edit is needed and the relevant validation commands pass, print
+        SHAPES_VERIFIED. Stop.
+      - If you edited the harness and the relevant validation commands pass,
+        print SHAPES_FIXED. Stop.
+
+    Stay focused: read the source file, the harness, and directly imported
+    helper files when needed. Do not broad-explore the repo.
   step_limit: 80
   cost_limit: 5.0
   instance_template: |

--- a/src/minisweagent/run/preprocess/config/mini_shape_fixer.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_shape_fixer.yaml
@@ -38,8 +38,8 @@ agent:
         exact same sampled cases. Print SHAPES_FIXED. Stop.
 
     That is all. Do not run anything. Do not explore. Just read and compare.
-  step_limit: 0.0
-  cost_limit: 0.0
+  step_limit: 80
+  cost_limit: 5.0
   instance_template: |
     Your task is: {{task}}
   action_observation_template: |

--- a/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
@@ -44,11 +44,13 @@ agent:
        This resolves all dependency issues upfront. Do NOT manually search for packages.
     3) Your task context contains **pre-scanned discovery results** from an automated scan.
        Review the Kernel Analysis, discovered test files, and language-specific guidance provided.
-    4) **If `src/minisweagent/run/preprocess/INSTRUCTIONS.md` exists** in the repository, read sections 1a and 1b for:
+    4) GEAK's harness instructions live at the repo-relative path
+       `src/minisweagent/run/preprocess/INSTRUCTIONS.md` inside the GEAK repo.
+       This file may not exist inside the target kernel repository.
+       If you can read that exact relative path directly, use sections 1a and 1b for:
        - Test harness requirements (the `--correctness`, `--profile`, `--benchmark`, `--full-benchmark` modes)
        - COMMANDMENT format rules (the harness will be referenced in COMMANDMENT.md)
-       Follow these rules when creating or adapting the test harness.
-       If `src/minisweagent/run/preprocess/INSTRUCTIONS.md` does not exist, follow the rules in this system prompt instead.
+       If that exact path is not directly readable, follow the rules in this system prompt instead.
     5) Determine the **absolute path** of the repo root (run `pwd` or use task context).
     6) If discovery found high-confidence existing tests or benchmarks, **read and validate them first**:
        - If a benchmark script exists (e.g. `benchmarks/benchmark_*.py`), read it — it shows the correct import pattern and shapes.
@@ -56,7 +58,9 @@ agent:
        - If it needs adaptation (adding `--profile` mode, `GEAK_RESULT_LATENCY_MS` output), adapt it.
        - Prefer adapting existing tests/benchmarks over creating new ones from scratch.
     7) Do NOT use interactive terminal programs (`view`, `less`, `vi`, `vim`, etc.).
-    8) Do NOT waste steps searching for packages with `find`. If step 2 succeeded, imports should work.
+    8) Do NOT waste steps searching for packages or `INSTRUCTIONS.md` with `find`.
+       In particular, never use broad searches like `find /` or `find .`.
+       Use the provided GEAK repo-relative path directly, or continue with the rules in this prompt.
     9) For multi-file kernel repos: the `pip install -e .` in step 2 handles PYTHONPATH. If not installable, add the repo root to sys.path in the harness.
 
     Part 2: Creating a new test harness

--- a/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
@@ -218,6 +218,15 @@ agent:
        - Fixed seed: torch.manual_seed(42).
        - Keep harness outside kernel directory.
        - For fused tasks: test BOTH unfused and fused paths.
+       - Preserve the source benchmark/test's full execution contract, not just
+         shapes: per-tensor dtype, device, layout, contiguity, index dtypes,
+         auxiliary buffers/caches/scales, helper-side preprocessing, and
+         supported CLI mode semantics.
+       - Do NOT normalize all tensors to a single dtype just because the main
+         activations use it.
+       - Before submitting, reason through why each CLI mode could fail. If a
+         mode would fail, apply the smallest source-faithful fix instead of
+         rewriting the harness.
 
     After deciding which benchmark file to wrap, write its path:
        echo "/absolute/path/to/bench_file.py" > harness_shapes_source.txt

--- a/src/minisweagent/run/preprocess/harness_utils.py
+++ b/src/minisweagent/run/preprocess/harness_utils.py
@@ -1118,10 +1118,10 @@ def execute_harness_validation(
     Parameters
     ----------
     benchmark_extra_args:
-        Extra CLI args appended to benchmark/full-benchmark invocations
-        (e.g. ``"--iterations 50"``).  Passed via the
-        ``GEAK_BENCHMARK_EXTRA_ARGS`` env var so both direct invocations
-        and COMMANDMENT-based scripts use the same settings.
+        Extra benchmark tuning args. ``--iterations N`` is normalized into
+        ``GEAK_BENCHMARK_ITERATIONS`` so harnesses do not need to expose it
+        as a CLI flag. Any remaining args are passed via
+        ``GEAK_BENCHMARK_EXTRA_ARGS``.
     use_uta_timeouts:
         When True, use ``UTA_MODE_TIMEOUTS`` instead of the default
         ``MODE_TIMEOUTS``.  The UTA timeout for ``--correctness`` is more
@@ -1146,15 +1146,21 @@ def execute_harness_validation(
     if not benchmark_extra_args:
         env_overrides["GEAK_BENCHMARK_ITERATIONS"] = "5"
     else:
-        env_overrides["GEAK_BENCHMARK_EXTRA_ARGS"] = benchmark_extra_args
-        # Extract --iterations N from extra_args and also set the env var
-        # so harnesses that read GEAK_BENCHMARK_ITERATIONS (instead of
-        # parsing --iterations from argv) get the right count.
         import re as _re
 
-        _iter_match = _re.search(r"--iterations\s+(\d+)", benchmark_extra_args)
+        remaining_extra_args = benchmark_extra_args.strip()
+        # Extract --iterations N into the env var so benchmark reruns work
+        # even when the harness argparse only accepts mode flags.
+        _iter_match = _re.search(r"(?:^|\s)--iterations\s+(\d+)(?=\s|$)", remaining_extra_args)
         if _iter_match:
             env_overrides["GEAK_BENCHMARK_ITERATIONS"] = _iter_match.group(1)
+            remaining_extra_args = _re.sub(
+                r"(?:^|\s)--iterations\s+\d+(?=\s|$)",
+                " ",
+                remaining_extra_args,
+            ).strip()
+        if remaining_extra_args:
+            env_overrides["GEAK_BENCHMARK_EXTRA_ARGS"] = remaining_extra_args
 
     mode_timeouts = UTA_MODE_TIMEOUTS if use_uta_timeouts else None
 

--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -850,28 +850,46 @@ def run_preprocessor(
                             logger.info("  Shape source (fallback to top test): %s", bench_file)
                         if harness_file.is_file() and bench_file is not None and bench_file.is_file():
                             original_harness_source = harness_file.read_text()
-                            shapes_ok = run_shape_fixer(
-                                model=_uta_model,
-                                repo=Path(repo_root),
-                                harness_path=harness_file,
-                                benchmark_file=bench_file,
-                                kernel_path=Path(kernel_path),
-                                log_dir=output_dir,
-                                gpu_id=gpu_id,
-                            )
-                            if shapes_ok:
-                                logger.info("  Shape verification: OK")
-                                ok_revalidate, _, harness_results = execute_harness_validation(
-                                    str(harness_file),
-                                    repo_root=repo_root,
+                            shape_feedback: list[str] | None = None
+                            shape_fix_attempt = 0
+                            while True:
+                                shapes_ok = run_shape_fixer(
+                                    model=_uta_model,
+                                    repo=Path(repo_root),
+                                    harness_path=harness_file,
+                                    benchmark_file=bench_file,
+                                    kernel_path=Path(kernel_path),
+                                    log_dir=output_dir,
                                     gpu_id=gpu_id,
+                                    validation_feedback=shape_feedback,
                                 )
-                                if ok_revalidate:
-                                    logger.info("  Re-validation after shape fix: ALL MODES PASSED")
-                                else:
-                                    restored = (
-                                        original_harness_source is not None
-                                        and _restore_harness_file(harness_file, original_harness_source)
+                                if shapes_ok:
+                                    if shape_feedback:
+                                        logger.info("  Shape repair with failure context: OK")
+                                    else:
+                                        logger.info("  Shape verification: OK")
+
+                                    ok_revalidate, revalidate_errors, candidate_results = execute_harness_validation(
+                                        str(harness_file),
+                                        repo_root=repo_root,
+                                        gpu_id=gpu_id,
+                                    )
+                                    if ok_revalidate:
+                                        harness_results = candidate_results
+                                        logger.info("  Re-validation after shape fix: ALL MODES PASSED")
+                                        break
+
+                                    if shape_fix_attempt == 0:
+                                        shape_feedback = revalidate_errors
+                                        shape_fix_attempt += 1
+                                        logger.info(
+                                            "  Re-validation after shape fix: FAILED "
+                                            "(retrying shape fixer with failure context)"
+                                        )
+                                        continue
+
+                                    restored = original_harness_source is not None and _restore_harness_file(
+                                        harness_file, original_harness_source
                                     )
                                     if restored:
                                         logger.info(
@@ -880,12 +898,17 @@ def run_preprocessor(
                                         )
                                     else:
                                         logger.info("  Re-validation after shape fix: FAILED")
-                            else:
-                                logger.info("  Shape fixer did not complete successfully")
+                                    break
+
+                                if shape_feedback:
+                                    logger.info("  Shape fixer repair attempt did not complete successfully")
+                                else:
+                                    logger.info("  Shape fixer did not complete successfully")
                                 if original_harness_source is not None and _restore_harness_file(
                                     harness_file, original_harness_source
                                 ):
                                     logger.info("  Restored original harness after incomplete shape fixer run")
+                                break
                     except Exception as exc:
                         if (
                             harness_file is not None

--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -169,6 +169,19 @@ def _focused_harness_candidate(disc_dict: dict[str, Any]) -> tuple[str, str] | N
     return focused_cmd, focused_harness
 
 
+def _restore_harness_file(harness_path: Path, original_source: str) -> bool:
+    try:
+        if not harness_path.is_file():
+            return False
+        current_source = harness_path.read_text()
+        if current_source == original_source:
+            return False
+        harness_path.write_text(original_source)
+        return True
+    except OSError:
+        return False
+
+
 def _normalize_candidate_identifier(value: str | Path) -> str:
     text = Path(str(value)).stem.lower()
     for prefix in ("benchmark_", "bench_", "test_", "focused_", "example_"):
@@ -817,6 +830,8 @@ def run_preprocessor(
                 # ── 3d. Shape fixer: verify shapes match benchmark/test file ──
                 if (benchmarks or tests) and _uta_model:
                     logger.info("--- Step 3d: Shape fixer (verify shapes) ---")
+                    harness_file: Path | None = None
+                    original_harness_source: str | None = None
                     try:
                         from minisweagent.run.preprocess.shape_fixer_agent import run_shape_fixer
 
@@ -834,6 +849,7 @@ def run_preprocessor(
                             bench_file = Path(tests[0]["file"])
                             logger.info("  Shape source (fallback to top test): %s", bench_file)
                         if harness_file.is_file() and bench_file is not None and bench_file.is_file():
+                            original_harness_source = harness_file.read_text()
                             shapes_ok = run_shape_fixer(
                                 model=_uta_model,
                                 repo=Path(repo_root),
@@ -853,10 +869,30 @@ def run_preprocessor(
                                 if ok_revalidate:
                                     logger.info("  Re-validation after shape fix: ALL MODES PASSED")
                                 else:
-                                    logger.info("  Re-validation after shape fix: FAILED (reverting)")
+                                    restored = (
+                                        original_harness_source is not None
+                                        and _restore_harness_file(harness_file, original_harness_source)
+                                    )
+                                    if restored:
+                                        logger.info(
+                                            "  Re-validation after shape fix: FAILED "
+                                            "(restored original harness and kept the pre-fix validation results)"
+                                        )
+                                    else:
+                                        logger.info("  Re-validation after shape fix: FAILED")
                             else:
                                 logger.info("  Shape fixer did not complete successfully")
+                                if original_harness_source is not None and _restore_harness_file(
+                                    harness_file, original_harness_source
+                                ):
+                                    logger.info("  Restored original harness after incomplete shape fixer run")
                     except Exception as exc:
+                        if (
+                            harness_file is not None
+                            and original_harness_source is not None
+                            and _restore_harness_file(harness_file, original_harness_source)
+                        ):
+                            logger.info("  Restored original harness after shape fixer failure")
                         logger.warning("Shape fixer failed: %s", exc, exc_info=True)
             except Exception as exc:
                 logger.warning(

--- a/src/minisweagent/run/preprocess/shape_fixer_agent.py
+++ b/src/minisweagent/run/preprocess/shape_fixer_agent.py
@@ -5,12 +5,17 @@ correct shapes from the benchmark file. Runs after the UnitTestAgent
 produces a harness and BEFORE runtime validation.
 """
 
+from __future__ import annotations
+
 import logging
+import os
+import signal
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
 from minisweagent import Environment, Model
-from minisweagent.agents.default import AgentConfig, DefaultAgent
+from minisweagent.agents.default import AgentConfig, DefaultAgent, Submitted
 from minisweagent.environments.local import LocalEnvironment, LocalEnvironmentConfig
 from minisweagent.run.preprocess.config_loader import load_preprocess_agent_config
 
@@ -25,6 +30,16 @@ class ShapeFixerConfig(AgentConfig):
 class ShapeFixerAgent(DefaultAgent):
     def __init__(self, model: Model, env: Environment, **kwargs):
         super().__init__(model, env, config_class=ShapeFixerConfig, **kwargs)
+
+    def query(self) -> dict:
+        """Terminate immediately when the model emits a final shape verdict."""
+        response = super().query()
+        content = (response.get("content") or "").strip()
+        if not response.get("tools") and not self._will_use_bash(response):
+            for verdict in ("SHAPES_VERIFIED", "SHAPES_FIXED"):
+                if verdict in content:
+                    raise Submitted(verdict)
+        return response
 
 
 SYSTEM_PROMPT = """\
@@ -67,6 +82,35 @@ Step 3: Compare EXACT sampled semantics, not just the config universe.
 
 That is all. Do not run anything. Do not explore. Just read and compare.
 """
+
+
+class ShapeFixerTimeoutError(RuntimeError):
+    """Raised when the shape fixer exceeds its wall-clock timeout."""
+
+
+def _shape_fixer_timeout_handler(_signum, _frame) -> None:
+    raise ShapeFixerTimeoutError("Shape fixer timed out")
+
+
+@contextmanager
+def _shape_fixer_timeout(timeout_s: int):
+    if timeout_s <= 0 or os.name == "nt" or not hasattr(signal, "SIGALRM"):
+        yield
+        return
+
+    try:
+        previous_handler = signal.getsignal(signal.SIGALRM)
+        signal.signal(signal.SIGALRM, _shape_fixer_timeout_handler)
+        signal.setitimer(signal.ITIMER_REAL, timeout_s)
+    except (AttributeError, ValueError):
+        yield
+        return
+
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
 
 
 def run_shape_fixer(
@@ -116,7 +160,9 @@ def run_shape_fixer(
         f"correct is NOT sufficient if sampled modes drift. Fix if needed.\n"
     )
 
-    exit_status, result = agent.run(task)
+    timeout_s = int(os.environ.get("GEAK_SHAPE_FIXER_TIMEOUT", "300"))
+    with _shape_fixer_timeout(timeout_s):
+        exit_status, result = agent.run(task)
 
     if "SHAPES_VERIFIED" in (result or ""):
         return True

--- a/src/minisweagent/run/preprocess/shape_fixer_agent.py
+++ b/src/minisweagent/run/preprocess/shape_fixer_agent.py
@@ -1,14 +1,16 @@
 """Preprocess-owned shape fixer agent.
 
-Lightweight post-UTA agent that verifies the generated harness uses the
-correct shapes from the benchmark file. Runs after the UnitTestAgent
-produces a harness and BEFORE runtime validation.
+Lightweight post-UTA harness-repair agent that verifies the generated
+harness preserves the benchmark/test sampling contract and can apply
+minimal fixes before the preprocess stage performs authoritative
+re-validation.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import shlex
 import signal
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -43,7 +45,9 @@ class ShapeFixerAgent(DefaultAgent):
 
 
 SYSTEM_PROMPT = """\
-You are a meta-checking agent. Read two files, compare shapes, done.
+You are a harness repair agent. Start by comparing the authoritative
+source file against the generated harness, then apply the smallest
+source-faithful fix needed to make the sampled modes work.
 
 Step 1: Read the SHAPE SOURCE FILE. What configs does it benchmark?
   (Look for the config variables, loops, products, helper functions, and
@@ -63,11 +67,14 @@ Step 2: Read the HARNESS FILE. What configs does it use?
   Then determine the exact sampled cases that the harness will use for
   `--benchmark`, `--correctness`, and `--profile`.
 
-Step 3: Compare EXACT sampled semantics, not just the config universe.
+Step 3: Compare full sampled semantics, not just the config universe.
   - SAME VALUES / SAME COUNT is NOT sufficient if a different order causes
     `_pick()` (or equivalent logic) to choose different sampled cases.
-  - If the source file already defines a case list/helper, that ordering is
-    authoritative.
+  - Preserve the source file's helper semantics and per-tensor contracts:
+    dtype, device, layout, contiguity, auxiliary buffers/caches/scales,
+    index dtypes, and helper-side preprocessing.
+  - Do NOT normalize all tensors to a single dtype just because the main
+    activations use that dtype.
   - If a task-runner exists, preserve it only insofar as it faithfully
     wraps the same repo-native benchmark/test semantics. Do NOT approve a
     wrapper that invents new commands, unsupported flags, or a different
@@ -75,12 +82,21 @@ Step 3: Compare EXACT sampled semantics, not just the config universe.
   - If the source file uses nested loops, preserve that loop nesting order.
   - Tuple vs list syntax is fine only when the resulting sampled cases are
     exactly the same.
-  - YES: exact sampled cases for `--benchmark`, `--correctness`, and
-    `--profile` all match the source file. Print SHAPES_VERIFIED. Stop.
-  - NO: fix the harness so it preserves the source ordering and yields the
-    exact same sampled cases. Print SHAPES_FIXED. Stop.
 
-That is all. Do not run anything. Do not explore. Just read and compare.
+Step 4: Validate and repair minimally.
+  - If validation commands are provided, you MAY run them from the repo
+    root to understand why a mode fails.
+  - Understand failures from stderr before editing.
+  - Re-run only the relevant failing mode(s) after each edit.
+  - Prefer the smallest source-faithful fix over rewriting working harness
+    logic.
+  - If no edit is needed and the relevant validation commands pass, print
+    SHAPES_VERIFIED. Stop.
+  - If you edited the harness and the relevant validation commands pass,
+    print SHAPES_FIXED. Stop.
+
+Stay focused: read the source file, the harness, and directly imported
+helper files when needed. Do not broad-explore the repo.
 """
 
 
@@ -113,6 +129,60 @@ def _shape_fixer_timeout(timeout_s: int):
         signal.signal(signal.SIGALRM, previous_handler)
 
 
+def _build_shape_fixer_task(
+    *,
+    benchmark_file: Path,
+    harness_path: Path,
+    kernel_path: Path | None,
+    gpu_id: int,
+    validation_feedback: list[str] | None,
+) -> str:
+    quoted_harness = shlex.quote(str(harness_path))
+    validation_prefix = f"HIP_VISIBLE_DEVICES={gpu_id} GEAK_BENCHMARK_ITERATIONS=5"
+    validation_commands = [
+        f"{validation_prefix} python {quoted_harness} --correctness",
+        f"{validation_prefix} python {quoted_harness} --profile",
+        f"{validation_prefix} python {quoted_harness} --benchmark",
+    ]
+
+    lines = [
+        f"SHAPE SOURCE FILE: {benchmark_file}",
+        f"HARNESS FILE: {harness_path}",
+    ]
+    if kernel_path is not None:
+        lines.append(f"KERNEL FILE: {kernel_path}")
+
+    lines.extend(
+        [
+            "",
+            "Read the source file and harness first. The source file is authoritative for the full harness contract, not just shapes.",
+            "Preserve the source file's ordered full case stream and the per-tensor execution contract: dtype, device, layout, contiguity, auxiliary buffers/caches/scales, index dtypes, helper-side preprocessing, and supported flags.",
+            "Check whether the harness chooses the exact same sampled cases for `--benchmark`, `--correctness`, and `--profile`.",
+            "Full-benchmark being correct is NOT sufficient if sampled modes drift.",
+            "Do NOT normalize all tensors to a single dtype just because the main activations use that dtype.",
+            "Prefer the smallest source-faithful fix; do not rewrite working parts of the harness.",
+            "",
+            "Suggested validation commands (run from the repo root only if you need them):",
+            *[f"- {cmd}" for cmd in validation_commands],
+            "",
+            "If a validation command fails, understand the reason from stderr before editing. After each edit, rerun only the relevant failing command(s) until the harness is source-faithful and the edited modes pass.",
+        ]
+    )
+
+    if validation_feedback:
+        lines.extend(
+            [
+                "",
+                "PREVIOUS REVALIDATION FAILURES:",
+                *[f"- {err}" for err in validation_feedback],
+                "",
+                "Use the failure feedback above to guide the minimal repair. Do not make unrelated changes.",
+            ]
+        )
+
+    return "\n".join(lines) + "\n"
+
+
 def run_shape_fixer(
     *,
     model: Model,
@@ -122,6 +192,7 @@ def run_shape_fixer(
     kernel_path: Path | None = None,
     log_dir: Path | None = None,
     gpu_id: int = 0,
+    validation_feedback: list[str] | None = None,
 ) -> bool:
     """Run the shape fixer agent. Returns True if shapes were verified or fixed."""
     try:
@@ -151,13 +222,12 @@ def run_shape_fixer(
         log_dir.mkdir(parents=True, exist_ok=True)
         agent.log_file = log_dir / "shape_fixer_agent.log"
 
-    task = (
-        f"SHAPE SOURCE FILE: {benchmark_file}\n"
-        f"HARNESS FILE: {harness_path}\n"
-        f"\nRead both files. Preserve the source file's ordered full case stream.\n"
-        f"Check whether the harness would choose the exact same sampled cases for\n"
-        f"`--benchmark`, `--correctness`, and `--profile`. Full-benchmark being\n"
-        f"correct is NOT sufficient if sampled modes drift. Fix if needed.\n"
+    task = _build_shape_fixer_task(
+        benchmark_file=benchmark_file,
+        harness_path=harness_path,
+        kernel_path=kernel_path,
+        gpu_id=gpu_id,
+        validation_feedback=validation_feedback,
     )
 
     timeout_s = int(os.environ.get("GEAK_SHAPE_FIXER_TIMEOUT", "300"))

--- a/src/minisweagent/run/preprocess/unit_test_agent.py
+++ b/src/minisweagent/run/preprocess/unit_test_agent.py
@@ -28,6 +28,9 @@ class UnitTestAgent(DefaultAgent):
         super().__init__(model, env, config_class=UnitTestAgentConfig, **kwargs)
 
 
+_GEAK_PREPROCESS_INSTRUCTIONS_RELATIVE_PATH = "src/minisweagent/run/preprocess/INSTRUCTIONS.md"
+
+
 def _extract_test_command(text: str) -> str:
     match = re.search(r"TEST_COMMAND:\s*(.+)\s*$", text.strip(), re.MULTILINE)
     if not match:
@@ -212,8 +215,11 @@ def run_unit_test_agent(
     task = (
         f"Create a fixed test harness for kernel: {kernel_name}\n"
         f"Repository: {repo}\n\n"
-        f"IMPORTANT: Read src/minisweagent/run/preprocess/INSTRUCTIONS.md in the repository for test harness requirements\n"
-        f"and COMMANDMENT format rules before creating the harness."
+        f"IMPORTANT: The GEAK tooling instructions live at the repo-relative path "
+        f"{_GEAK_PREPROCESS_INSTRUCTIONS_RELATIVE_PATH} inside the GEAK repo, not inside the target kernel repository.\n"
+        f"Use that exact relative path for harness requirements and COMMANDMENT rules if it is directly readable.\n"
+        f"Do NOT use broad recursive searches such as `find /`, `find .`, or other global filesystem scans to locate it.\n"
+        f"If that exact path is not directly readable, follow the harness and COMMANDMENT rules already provided in your system prompt."
     )
     if preferred_harness_path is not None:
         task += (

--- a/tests/run/test_preprocess_unit.py
+++ b/tests/run/test_preprocess_unit.py
@@ -504,6 +504,15 @@ class TestUnitTestAgentPrompt:
         assert "Do NOT use broad recursive searches" in task
         assert "find /" in task
 
+    def test_prompt_mentions_tensor_contract_preservation(self):
+        from minisweagent.run.preprocess.config_loader import load_preprocess_agent_config
+
+        agent_cfg, _ = load_preprocess_agent_config("mini_unit_test_agent")
+        prompt = agent_cfg["system_template"]
+
+        assert "full execution contract" in prompt
+        assert "Do NOT normalize all tensors to a single dtype" in prompt
+
 
 class TestShapeFixerTermination:
 
@@ -533,6 +542,64 @@ class TestShapeFixerTermination:
         with patch.object(DefaultAgent, "query", return_value={"content": "SHAPES_FIXED"}):
             with pytest.raises(Submitted, match="SHAPES_FIXED"):
                 agent.query()
+
+
+class TestShapeFixerPrompt:
+
+    @pytest.fixture(autouse=True)
+    def _setup_path(self):
+        import sys
+        repo = Path(__file__).resolve().parent.parent.parent
+        if str(repo / "src") not in sys.path:
+            sys.path.insert(0, str(repo / "src"))
+
+    def test_shape_fixer_prompt_mentions_validation_and_minimal_fix(self):
+        from minisweagent.run.preprocess.config_loader import load_preprocess_agent_config
+
+        agent_cfg, _ = load_preprocess_agent_config("mini_shape_fixer")
+        prompt = agent_cfg["system_template"]
+
+        assert "validation commands are provided" in prompt
+        assert "smallest source-faithful fix" in prompt
+        assert "Do NOT normalize all tensors to a single dtype" in prompt
+
+    def test_run_shape_fixer_task_includes_validation_feedback(self):
+        from minisweagent.run.preprocess.shape_fixer_agent import run_shape_fixer
+
+        captured = {}
+
+        def _fake_run(self, task):
+            captured["task"] = task
+            return "Submitted", "SHAPES_FIXED"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            harness = repo / "test_harness.py"
+            source = repo / "bench_kernel.py"
+            kernel = repo / "kernel.py"
+            harness.write_text("print('harness')\n")
+            source.write_text("print('bench')\n")
+            kernel.write_text("print('kernel')\n")
+
+            with patch("minisweagent.run.preprocess.shape_fixer_agent.ShapeFixerAgent.run", new=_fake_run):
+                ok = run_shape_fixer(
+                    model=object(),
+                    repo=repo,
+                    harness_path=harness,
+                    benchmark_file=source,
+                    kernel_path=kernel,
+                    gpu_id=7,
+                    validation_feedback=["--correctness mode failed (exit code 1):\nValueError: demo"],
+                )
+
+        assert ok is True
+        task = captured["task"]
+        assert "PREVIOUS REVALIDATION FAILURES" in task
+        assert "ValueError: demo" in task
+        assert "HIP_VISIBLE_DEVICES=7 GEAK_BENCHMARK_ITERATIONS=5 python" in task
+        assert "--correctness" in task
+        assert "--profile" in task
+        assert "--benchmark" in task
 
 
 class TestHarnessRestore:

--- a/tests/run/test_preprocess_unit.py
+++ b/tests/run/test_preprocess_unit.py
@@ -292,7 +292,21 @@ class TestExecuteHarnessEnvVars:
                 call_kwargs = mock_run.call_args
                 env = call_kwargs.kwargs.get("env_overrides", {})
                 assert env.get("GEAK_BENCHMARK_ITERATIONS") == "30"
-                assert env.get("GEAK_BENCHMARK_EXTRA_ARGS") == "--iterations 30"
+                assert env.get("GEAK_BENCHMARK_EXTRA_ARGS") is None
+        os.unlink(f.name)
+
+    def test_preserves_non_iteration_extra_args(self):
+        from minisweagent.run.pipeline_helpers import execute_harness_validation
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("pass")
+            f.flush()
+            with patch("minisweagent.run.preprocess.run_harness.run_harness") as mock_run:
+                mock_run.return_value = [{"mode": "correctness", "success": True, "returncode": 0, "stdout": "", "stderr": "", "duration_s": 0.1}]
+                execute_harness_validation(f.name, benchmark_extra_args="--warmup 7")
+                call_kwargs = mock_run.call_args
+                env = call_kwargs.kwargs.get("env_overrides", {})
+                assert env.get("GEAK_BENCHMARK_ITERATIONS") is None
+                assert env.get("GEAK_BENCHMARK_EXTRA_ARGS") == "--warmup 7"
         os.unlink(f.name)
 
 
@@ -455,6 +469,92 @@ class TestImports:
     def test_commandment_import(self):
         from minisweagent.run.preprocess.commandment import generate_commandment
         assert callable(generate_commandment)
+
+
+class TestUnitTestAgentPrompt:
+
+    @pytest.fixture(autouse=True)
+    def _setup_path(self):
+        import sys
+        repo = Path(__file__).resolve().parent.parent.parent
+        if str(repo / "src") not in sys.path:
+            sys.path.insert(0, str(repo / "src"))
+
+    def test_prompt_scopes_instructions_to_geak_relative_path(self):
+        from minisweagent.run.preprocess.unit_test_agent import run_unit_test_agent
+
+        captured = {}
+
+        def _fake_run(self, task):
+            captured["task"] = task
+            return "Submitted", "TEST_COMMAND: python /tmp/test_harness.py --correctness"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            with patch("minisweagent.run.preprocess.unit_test_agent.UnitTestAgent.run", new=_fake_run):
+                run_unit_test_agent(
+                    model=object(),
+                    repo=repo,
+                    kernel_name="demo_kernel",
+                )
+
+        task = captured["task"]
+        assert "src/minisweagent/run/preprocess/INSTRUCTIONS.md" in task
+        assert "not inside the target kernel repository" in task
+        assert "Do NOT use broad recursive searches" in task
+        assert "find /" in task
+
+
+class TestShapeFixerTermination:
+
+    @pytest.fixture(autouse=True)
+    def _setup_path(self):
+        import sys
+        repo = Path(__file__).resolve().parent.parent.parent
+        if str(repo / "src") not in sys.path:
+            sys.path.insert(0, str(repo / "src"))
+
+    def test_shape_fixer_agent_submits_on_plaintext_verdict(self):
+        from minisweagent.agents.default import DefaultAgent, Submitted
+        from minisweagent.run.preprocess.shape_fixer_agent import ShapeFixerAgent
+
+        class _DummyModel:
+            n_calls = 0
+            cost = 0.0
+
+        class _DummyEnvConfig:
+            cwd = str(Path.cwd())
+            env = {}
+
+        class _DummyEnv:
+            config = _DummyEnvConfig()
+
+        agent = ShapeFixerAgent(_DummyModel(), _DummyEnv(), system_template="shape fixer")
+        with patch.object(DefaultAgent, "query", return_value={"content": "SHAPES_FIXED"}):
+            with pytest.raises(Submitted, match="SHAPES_FIXED"):
+                agent.query()
+
+
+class TestHarnessRestore:
+
+    @pytest.fixture(autouse=True)
+    def _setup_path(self):
+        import sys
+        repo = Path(__file__).resolve().parent.parent.parent
+        if str(repo / "src") not in sys.path:
+            sys.path.insert(0, str(repo / "src"))
+
+    def test_restore_harness_file_reverts_mutation(self):
+        from minisweagent.run.preprocess.preprocessor import _restore_harness_file
+
+        with tempfile.TemporaryDirectory() as tmp:
+            harness = Path(tmp) / "harness.py"
+            harness.write_text("print('mutated')\n")
+
+            restored = _restore_harness_file(harness, "print('original')\n")
+
+            assert restored is True
+            assert harness.read_text() == "print('original')\n"
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- Close #154 by making the shape fixer stop on `SHAPES_VERIFIED`/`SHAPES_FIXED`, adding a wall-clock timeout, bounding the mini shape-fixer budget, and restoring the original harness if a fix attempt fails or produces an invalid harness.
- Close #156 by telling the Unit Test Agent the exact GEAK-relative path for `src/minisweagent/run/preprocess/INSTRUCTIONS.md` and explicitly forbidding broad filesystem scans such as `find /` and `find .`.
- Close #157 by normalizing `--iterations N` into `GEAK_BENCHMARK_ITERATIONS` so baseline reruns no longer depend on harnesses exposing an `--iterations` CLI flag, while preserving any non-iteration benchmark extra args.
- Add regression coverage for the new UTA prompt guidance, shape-fixer termination, harness restoration, and benchmark extra-arg normalization.

## Validation
- Ran `pytest tests/run/test_preprocess_unit.py`.
- Ran a preprocess-focused smoke test in the `geak-agent-upandey` container against the `topkGatingSoftmax` HIP kernel flow.
- Ran a full `geak -t ... --yolo --exit-immediately` smoke test in the same container for `topkGatingSoftmax`, monitored it through preprocessing, and stopped it immediately after preprocessing completed.
- Result: the UTA no longer performed broad `find` scans, the shape fixer no longer hung the pipeline and failed open when needed, the preprocessing flow generated the expected artifacts (`profile.json`, `baseline_metrics.json`, `COMMANDMENT.md`), and the baseline rerun no longer crashed on an unsupported `--iterations 30` CLI flag.

## Issues
Closes #154.
Closes #156.
Closes #157.

