### PR TITLE
feat(heterogeneous): thread user -t instructions into orchestrator an…

### DIFF
--- a/src/minisweagent/agents/heterogeneous/orchestrator.py
+++ b/src/minisweagent/agents/heterogeneous/orchestrator.py
@@ -244,7 +244,7 @@ def run_heterogeneous_orchestrator(
     if not cmd:
         logger.error("No commandment found in preprocess_ctx.")
         raise ValueError("No commandment found in preprocess_ctx.")
-    cmd_excerpt = cmd[:1500] + ("..." if len(cmd) > 1500 else "") if cmd else "Not available"
+    cmd_excerpt = cmd[:4000] + ("..." if len(cmd) > 4000 else "") if cmd else "Not available"
 
     codebase_ctx = ""
     _codebase_ctx_path = preprocess_dir / "CODEBASE_CONTEXT.md"

--- a/src/minisweagent/agents/heterogeneous/prompts.py
+++ b/src/minisweagent/agents/heterogeneous/prompts.py
@@ -319,6 +319,22 @@ It is acceptable to leave some GPUs idle rather than padding the batch with
 low-priority wrapper / dispatch work.
 Each task uses 1 GPU.
 {% endif %}
+{% if base_task_context %}
+## User-Provided Context
+
+**IMPORTANT**:
+1. Any performance numbers below (durations, invocation counts, efficiency
+   percentages) come from the user's full-model profiling under different
+   conditions (batch sizes, graph replay, concurrency). They provide
+   qualitative context (e.g., "this kernel is memory-bound") but MUST NOT
+   be used as baselines for speedup comparison. Always use the GEAK-measured
+   baseline metrics from the baseline_metrics file for before/after comparisons.
+2. If the user prescribes optimization strategies below, prioritize them in
+   early rounds. But if prior round tasks already attempted a strategy,
+   do NOT regenerate it -- follow the deduplication rules in the system prompt.
+
+{{ base_task_context }}
+{% endif %}
 ## Instructions
 
 Read the profiling file first to understand the sub-kernel landscape. Then
@@ -327,8 +343,6 @@ dependency listed is in-repo code that could be an optimization target.
 Read the discovery file for additional kernel metadata, and consult the
 knowledge base for applicable strategies. Finally, submit your task list
 as JSON via the `submit` tool.
-
-{{ base_task_context }}
 """)
 
 

--- a/src/minisweagent/agents/heterogeneous/tools.py
+++ b/src/minisweagent/agents/heterogeneous/tools.py
@@ -39,8 +39,21 @@ def tool_generate_tasks(
     taskgen_model = ctx["model_factory"]() if ctx.get("model_factory") else ctx["model"]
 
     kernel_meta = ctx.get("kernel_meta") or {}
+    _MAX_BASE_TASK_CONTEXT = 4000
+    _user_instr = ctx.get("user_instructions", "")
+    if len(_user_instr) > _MAX_BASE_TASK_CONTEXT:
+        _cutoff = _user_instr.rfind("\n\n", 0, _MAX_BASE_TASK_CONTEXT)
+        if _cutoff < _MAX_BASE_TASK_CONTEXT // 2:
+            _cutoff = _MAX_BASE_TASK_CONTEXT
+        _user_instr = _user_instr[:_cutoff] + "\n\n[... truncated ...]"
+        logger.warning(
+            "Truncated user_instructions from %d to %d chars for task generator.",
+            len(ctx.get("user_instructions", "")),
+            _cutoff,
+        )
+
     kwargs: dict[str, Any] = {
-        "base_task_context": "",
+        "base_task_context": _user_instr,
         "agent_class": ctx["agent_class"],
         "model": taskgen_model,
         "kernel_path": kernel_meta.get("kernel_path", str(ctx.get("kernel_path", ""))),

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -26,7 +26,12 @@ from minisweagent.models import get_model
 from minisweagent.run.extra.config import configure_if_first_time
 from minisweagent.run.orchestrator import run_orchestrator
 from minisweagent.run.preprocess.preprocessor import run_preprocessor
-from minisweagent.run.utils.task_parser import _resolve_path_case, display_parsed_config, parse_task_info
+from minisweagent.run.utils.task_parser import (
+    _resolve_path_case,
+    display_parsed_config,
+    extract_user_constraints,
+    parse_task_info,
+)
 from minisweagent.utils.log import DEFAULT_LOG_FILENAME, add_file_handler
 
 logger = logging.getLogger(__name__)
@@ -465,12 +470,33 @@ def main(
             logger.error(error_message)
             raise RuntimeError(error_message)
 
-        task_content = f"{commandment}\n\n---\n\n{task_content}"
-        logger.info(
-            "Prepended COMMANDMENT.md to task content (total length %d chars).",
-            len(task_content),
-        )
-        logger.debug("Task content after commandment prepend: %s", task_content)
+        preprocess_ctx["user_instructions"] = task_content
+
+        extracted = extract_user_constraints(task_content, model)
+        _addendum_parts: list[str] = []
+        if extracted["constraints"]:
+            _addendum_parts.append("## USER-SPECIFIED CONSTRAINTS\n\nThese are mandatory. Violation means rejection.\n")
+            _addendum_parts.extend(f"- {c}" for c in extracted["constraints"])
+        if extracted["directives"]:
+            _addendum_parts.append(
+                "\n## PRESCRIBED OPTIMIZATION DIRECTIVES\n\n"
+                "These are the user's prescribed optimization strategies. Prioritize them, but\n"
+                "also explore additional directions beyond these.\n"
+                "NOTE: Any performance numbers in the original user request come from full-model\n"
+                "profiling under different conditions. Use ONLY the GEAK-measured baseline metrics\n"
+                "for before/after speedup comparisons.\n"
+            )
+            _addendum_parts.extend(f"- {d}" for d in extracted["directives"])
+        if _addendum_parts:
+            preprocess_ctx["commandment"] = commandment + "\n\n" + "\n".join(_addendum_parts)
+            _commandment_path = preprocess_output_dir / "COMMANDMENT.md"
+            _commandment_path.write_text(preprocess_ctx["commandment"], encoding="utf-8")
+            logger.info(
+                "Enriched commandment with %d constraints and %d directives (written to %s).",
+                len(extracted["constraints"]),
+                len(extracted["directives"]),
+                _commandment_path,
+            )
 
         report = run_orchestrator(
             preprocess_ctx=preprocess_ctx,

--- a/src/minisweagent/run/utils/prompts.py
+++ b/src/minisweagent/run/utils/prompts.py
@@ -66,3 +66,56 @@ Return ONLY a valid JSON object. Example:
 Here is the task content:
 {task_content}
 """
+
+EXTRACT_USER_CONSTRAINTS_TEMPLATE = """Analyze the following optimization task and extract mandatory constraints and prescribed optimization directives.
+
+Extract TWO categories:
+
+1. **constraints**: Hard rules that MUST NOT be violated (rejection criteria).
+   Look for:
+   - Function name constraints ("function name MUST be exactly X", "do NOT rename")
+   - Signature constraints ("function signature MUST be identical")
+   - Numerical correctness requirements ("output must be numerically identical")
+   - Compatibility constraints ("keep all template parameters compatible")
+   - Forbidden actions ("do NOT modify the test harness")
+   - Any other explicit MUST / MUST NOT / DO NOT rules
+
+2. **directives**: Prescribed optimization strategies that agents SHOULD follow as their primary approach, while retaining freedom to explore additional directions beyond these.
+   Look for:
+   - Specific optimization strategies ("tune block sizes", "optimize shared memory usage")
+   - Memory access guidance ("improve memory coalescing", "vectorize loads/stores")
+   - Architecture-specific tuning ("tune for MI355X gfx950 304 CUs")
+   - Performance targets ("close efficiency gap toward 75-100% of peak HBM bandwidth")
+
+Do NOT extract:
+- Hardware descriptions without an actionable directive
+- Model-level or end-to-end profiling numbers (e.g., "89.72 ms across 12288 invocations",
+  "4.77% of total GPU compute time", "38.57% of 8.0 TB/s peak HBM bandwidth"). These come
+  from full-model benchmarking under different conditions and MUST NOT be used as baselines
+  for comparison. GEAK runs its own isolated baseline measurements.
+- Workload context descriptions ("LLM inference serving", "decode path")
+- File paths or kernel identifiers
+
+IMPORTANT: Performance targets like "close efficiency gap toward 75-100% of peak bandwidth"
+are valid directives. But absolute numbers from the user's profiling (durations, invocation
+counts, efficiency percentages) are NOT — they reflect a different measurement environment.
+
+Return ONLY a valid JSON object. Example:
+{{
+  "constraints": [
+    "The output function name MUST be EXACTLY: topkGatingSoftmax. Do NOT rename it.",
+    "The function signature MUST be IDENTICAL to the original.",
+    "Output must be numerically identical to the original."
+  ],
+  "directives": [
+    "Tune block sizes and wave occupancy for MI355X gfx950 (304 CUs).",
+    "Optimize shared memory (LDS) usage for expert gating softmax.",
+    "Improve memory coalescing for top-k routing output writes."
+  ]
+}}
+
+If a category has no items, return an empty list for it.
+
+Here is the task content:
+{task_content}
+"""

--- a/src/minisweagent/run/utils/task_parser.py
+++ b/src/minisweagent/run/utils/task_parser.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 from minisweagent.run.utils.prompts import (
+    EXTRACT_USER_CONSTRAINTS_TEMPLATE,
     JSON_EXTRACTION_SYSTEM_PROMPT,
     PARSE_PIPELINE_PARAMS_USER_TEMPLATE,
     PARSE_TASK_INFO_USER_TEMPLATE,
@@ -285,6 +286,57 @@ def parse_pipeline_params(task_content: str, model) -> dict:
             exc_info=logger.isEnabledFor(logging.DEBUG),
         )
         return _EMPTY_PIPELINE_PARAMS.copy()
+
+
+_EMPTY_USER_CONSTRAINTS: dict[str, list[str]] = {"constraints": [], "directives": []}
+
+
+def extract_user_constraints(task_content: str, model) -> dict[str, list[str]]:
+    """Extract mandatory constraints and optimization directives from task text via LLM.
+
+    Returns dict with:
+        "constraints": list of hard rules (violation = rejection)
+        "directives": list of prescribed optimization strategies (should follow, may explore beyond)
+    """
+    prompt = EXTRACT_USER_CONSTRAINTS_TEMPLATE.format(task_content=task_content)
+    logger.debug("extract_user_constraints: querying model (task_content length=%d chars)", len(task_content))
+
+    try:
+        response = model.query(
+            [
+                {"role": "system", "content": JSON_EXTRACTION_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ]
+        )
+        parsed = _load_json_object_from_model_response(response, log_prefix="extract_user_constraints")
+    except json.JSONDecodeError as e:
+        logger.warning("extract_user_constraints: model response JSON decode failed: %s", e)
+        return _EMPTY_USER_CONSTRAINTS.copy()
+    except Exception as e:
+        logger.warning(
+            "extract_user_constraints: unexpected error (%s): %s",
+            type(e).__name__,
+            e,
+            exc_info=logger.isEnabledFor(logging.DEBUG),
+        )
+        return _EMPTY_USER_CONSTRAINTS.copy()
+
+    constraints = parsed.get("constraints", [])
+    directives = parsed.get("directives", [])
+    if not isinstance(constraints, list):
+        constraints = []
+    if not isinstance(directives, list):
+        directives = []
+    result = {
+        "constraints": [str(c) for c in constraints if c],
+        "directives": [str(d) for d in directives if d],
+    }
+    logger.debug(
+        "extract_user_constraints: extracted %d constraints, %d directives.",
+        len(result["constraints"]),
+        len(result["directives"]),
+    )
+    return result
 
 
 def generate_patch_output_dir(kernel_name: str | None, base_dir: str = "optimization_logs") -> str:


### PR DESCRIPTION
When a user provides rich context via `-t` (hardware specs, optimization strategies, mandatory constraints), the heterogeneous pipeline now preserves and uses that information instead of silently dropping it.

Changes:
- Extract constraints and directives from user text via LLM and append them to the in-memory and on-disk COMMANDMENT.md so both the orchestrator and sub-agents see them
- Forward the full user text to the task generator via base_task_context so it can plan relevant tasks informed by user-provided context
- Relocate base_task_context in the task generator template to a dedicated User-Provided Context section with disclaimers about model-level profiling numbers vs GEAK baselines
- Increase commandment excerpt limit from 1500 to 4000 chars so appended constraints are visible to the orchestrator
- Remove dead task_content prepend that was never consumed by run_orchestrator

Made-with: Cursor
