### PR TITLE
fix(save_and_test): prevent empty patch from overwriting non-empty capture

### DIFF
--- a/src/minisweagent/tools/save_and_test.py
+++ b/src/minisweagent/tools/save_and_test.py
@@ -961,7 +961,10 @@ class SaveAndTestTool:
     def _save_patch_file(self, patch_name: str, patch_content: str):
         output_dir = Path(self.context.patch_output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        (output_dir / f"{patch_name}.patch").write_text(patch_content)
+        patch_path = output_dir / f"{patch_name}.patch"
+        if not patch_content.strip() and patch_path.exists() and patch_path.stat().st_size > 0:
+            return
+        patch_path.write_text(patch_content)
 
     def _save_test_output(self, patch_name: str, test_output: str):
         output_dir = Path(self.context.patch_output_dir)


### PR DESCRIPTION
## Summary

Fixes a bug in `_save_patch_file` where an empty `git diff` result (from calling `save_and_test` after reverting changes) overwrites a previously-captured valid patch with 0 bytes.

## Root cause

When the agent calls `save_and_test` after `git checkout kernel.py` (to revert and try a different approach), `_get_patch_content()` returns an empty string. `_save_patch_file` then calls `write_text("")` on the existing `patch_N.patch`, destroying the previously-captured non-empty patch.

The post-round evaluation then tries to `git apply` the 0-byte file and fails with:
- `Patch file is empty: .../patch_N.patch`
- `git apply failed (rc=1): error: kernel.py: No such file or directory`

## Evidence

Observed across multiple L3 kernel runs on canonical ROCm 7.0 stack:

| Kernel | Run | Rounds affected | Agent claimed | Manually verified |
|--------|-----|----------------|---------------|-------------------|
| fused_qkv_rope | 184525 | 5/5 | 1.14x (R3) | **1.119x** (patch applied & benchmarked manually) |
| fused_rms_fp8 | 044231 | 2/5 | 1.66x (R5) | patch destroyed — strategy reproduced in later run at 1.80x |
| fused_rms_fp8 | 093627 | 1/5 | 1.66x (R5) | same strategy, same 0-byte issue |

## Fix

Skip `write_text()` when `patch_content` is empty AND the file already exists with non-zero size:

```python
patch_path = output_dir / f"{patch_name}.patch"
if not patch_content.strip() and patch_path.exists() and patch_path.stat().st_size > 0:
    return
patch_path.write_text(patch_content)
```

## Test plan

- [x] Manual verification: R3 `fuse-cos-sin-cache-lookup-into-kernel/patch_3.patch` (7595 bytes) applies cleanly and achieves 1.119x on full-benchmark (0.0565ms → 0.0505ms)
- [ ] Run fused_qkv_rope with fix applied — expect 0 patch-apply failures across 5 rounds
- [ ] Verify no regression on fused_rms_fp8 (1.80x) and gemm_a16wfp4 (1.43x)


Made with [Cursor](https://cursor.com)