### PR TITLE
fix(install errors): Fix MCP tool installation: switch from pip extras to Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,28 @@
-.PHONY: install install-dev
+.PHONY: install install-dev install-full
 
-# Production install (used by Dockerfile)
+# Production install (used by Dockerfile): core + MCP tools
 install:
-	pip install .
+	pip install '.[langchain]'
 	pip install mcp_tools/automated-test-discovery/ \
 	            mcp_tools/metrix-mcp/ \
-	            mcp_tools/profiler-mcp/
+	            mcp_tools/profiler-mcp/ \
+	            mcp_tools/cross-session-memory-mcp/ \
+	            mcp_tools/rag-mcp/
 
-# Editable install (used by developers / GEAK_EDITABLE=1)
+# Full install: core + MCP tools + dev + swe-rex
+install-full:
+	pip install '.[dev,langchain]' 'swe-rex>=1.4.0'
+	pip install mcp_tools/automated-test-discovery/ \
+	            mcp_tools/metrix-mcp/ \
+	            mcp_tools/profiler-mcp/ \
+	            mcp_tools/cross-session-memory-mcp/ \
+	            mcp_tools/rag-mcp/
+
+# Editable full install (for developers)
 install-dev:
-	pip install -e .
+	pip install -e '.[dev,langchain]' 'swe-rex>=1.4.0'
 	pip install -e mcp_tools/automated-test-discovery/ \
 	            -e mcp_tools/metrix-mcp/ \
-	            -e mcp_tools/profiler-mcp/
+	            -e mcp_tools/profiler-mcp/ \
+	            -e mcp_tools/cross-session-memory-mcp/ \
+	            -e mcp_tools/rag-mcp/

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ cd GEAK
 AMD_LLM_API_KEY=<YOUR_KEY> bash scripts/run-docker.sh
 
 # Local install
-pip install -e .          # core package (includes fastmcp and mcp[cli])
-pip install -e '.[mcp]'   # + MCP tool servers (profiler, test-discovery, metrix)
-pip install -e '.[full]'  # everything (MCP tools + dev + langchain)
+make install              # core + MCP tools (same as Docker)
+make install-full         # + dev tools + swe-rex
+make install-dev          # install-full, editable (for developers)
 
 # Set model name and key. In the case of docker-based setup, export the API key before
 # running scripts/run-docker.sh.
@@ -63,7 +63,7 @@ export AMD_LLM_API_KEY="YOUR_KEY"
 GPU/ROCm/HIP optimization knowledge base, powered by hybrid retrieval (FAISS + BM25 + reranker).
 
 ```bash
-pip install -e mcp_tools/rag-mcp
+# rag-mcp is included in `make install` — just build the index:
 python scripts/build_index.py --force
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,18 +47,20 @@ dependencies = [
     "google-genai",
     "openai != 1.100.0,!=1.100.1",  # https://github.com/SWE-agent/mini-swe-agent/issues/446
     "metrix @ git+https://github.com/AMDResearch/intellikit.git@bcbfa0252df9d55f3aab68c95dd3ce45ccbe5b46#subdirectory=metrix",  # AMD GPU profiling — pinned for production stability
+    "fastmcp>=2.0.0",
+    "mcp[cli]>=1.2.0",
 ]
 
 [project.optional-dependencies]
-# MCP tool packages and their transitive deps.
+# MCP tool servers (local packages).
 # Local package names resolve via [tool.uv.sources] (uv only).
 # With pip, use `make install` or `make install-dev` instead.
 mcp = [
     "automated-test-discovery",
     "metrix-mcp",
     "profiler-mcp",
-    "mcp[cli]>=1.2.0",
-    "fastmcp>=0.2.0",
+    "cross-session-memory-mcp",
+    "rag-mcp",
 ]
 
 # LangChain hybrid retrieval for AMD GPU knowledge base (embedding + BM25 + reranker)
@@ -275,6 +277,8 @@ line-ending = "auto"
 automated-test-discovery = { path = "mcp_tools/automated-test-discovery", editable = true }
 metrix-mcp = { path = "mcp_tools/metrix-mcp", editable = true }
 profiler-mcp = { path = "mcp_tools/profiler-mcp", editable = true }
+cross-session-memory-mcp = { path = "mcp_tools/cross-session-memory-mcp", editable = true }
+rag-mcp = { path = "mcp_tools/rag-mcp", editable = true }
 
 [tool.typos.default.extend-identifiers]
 # *sigh* this just isn't worth the cost of fixing


### PR DESCRIPTION
#167 

  ## Root Cause                                                                                                                                                                                                                     
                                                                                                                                                                                                                                    
  `pip install .[mcp]` does not support installing local path-based packages listed in                                                                                                                                              
  `[project.optional-dependencies]`. The `[tool.uv.sources]` path mappings (e.g.,
  `profiler-mcp = { path = "mcp_tools/profiler-mcp" }`) are uv-specific and silently                                                                                                                                                
  ignored by pip, causing MCP tool installation to fail.                                                                                                                                                                            
                                                                                                                                                                                                                                    
  Replaced the pip extras approach with explicit `make install` / `make install-dev` targets                                                                                                                                        
  that call `pip install` directly on each local MCP package.  

## Summary                                                

  - Switch MCP tool installation from `pip install .[mcp]` extras to `make install` targets                                                                                                                                         
  - Move `fastmcp` and `mcp[cli]` from `[mcp]` optional-dependencies to core dependencies
  - Add missing MCP tools (`cross-session-memory-mcp`, `rag-mcp`) to Makefile and pyproject.toml                                                                                                                                    
  - Update README install instructions accordingly                                                                                                                                                                                  
             
