### PR TITLE
  fix: replace site.main() with sys.path.insert and pass api_key to RAG postprocessor

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -139,7 +139,7 @@ class DefaultAgent:
             self.toolruntime.disable_tools(self.config.disabled_tools)
         # Always wrap RAG MCP tools with postprocessor filter
         try:
-            self.toolruntime.wrap_rag_tools_with_postprocessor()
+            self.toolruntime.wrap_rag_tools_with_postprocessor(api_key=self.model.config.api_key)
         except Exception as e:
             logger.warning("Failed to wrap RAG tools with RAG postprocessor: %s", e)
         # Propagate agent's env vars (HIP_VISIBLE_DEVICES etc.) to tools

--- a/src/minisweagent/agents/heterogeneous/orchestrator.py
+++ b/src/minisweagent/agents/heterogeneous/orchestrator.py
@@ -216,7 +216,7 @@ def run_heterogeneous_orchestrator(
         toolruntime.disable_tools(["query", "optimize"])
     else:
         try:
-            toolruntime.wrap_rag_tools_with_postprocessor()
+            toolruntime.wrap_rag_tools_with_postprocessor(api_key=model.config.api_key)
         except Exception as e:
             logger.warning("Failed to wrap RAG tools with RAG postprocessor: %s", e)
 

--- a/src/minisweagent/agents/strategy_agent.py
+++ b/src/minisweagent/agents/strategy_agent.py
@@ -67,7 +67,7 @@ class StrategyAgent(InteractiveAgent):
 
         # Re-apply RAG postprocessor wrapping after ToolRuntime rebuild
         try:
-            self.toolruntime.wrap_rag_tools_with_postprocessor()
+            self.toolruntime.wrap_rag_tools_with_postprocessor(api_key=self.model.config.api_key)
         except Exception as e:
             logger.warning("Failed to wrap RAG tools with RAG postprocessor: %s", e)
 

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -232,9 +232,8 @@ def main(
             logger.info("rag-mcp installed successfully.")
             # Refresh sys.path so the newly installed package is discoverable
             import importlib
-            import site
+            sys.path.insert(0, str(_rag_mcp_path / "src"))
             importlib.invalidate_caches()
-            site.main()
             import rag_mcp  # noqa: F401
         # Auto-build semantic index if missing
         _index_path = Path.home() / ".cache" / "amd-ai-devtool" / "semantic-index"

--- a/src/minisweagent/tools/tools_runtime.py
+++ b/src/minisweagent/tools/tools_runtime.py
@@ -163,11 +163,11 @@ class ToolRuntime:
         self.use_strategy_manager = use_strategy_manager
         self._codebase_context: str | None = None
 
-    def wrap_rag_tools_with_postprocessor(self) -> None:
+    def wrap_rag_tools_with_postprocessor(self, api_key: str | None = None) -> None:
         """Wrap RAG MCP tools with RAGPostProcessor for result filtering."""
         from minisweagent.tools.rag_postprocessor import RAGPostProcessor, RAGPostProcessorConfig
 
-        postprocessor = RAGPostProcessor(RAGPostProcessorConfig(enabled=True))
+        postprocessor = RAGPostProcessor(RAGPostProcessorConfig(enabled=True, api_key=api_key))
 
         def _wrap(tool_callable):
             def wrapper(**kwargs):


### PR DESCRIPTION
  ## Summary

  Two follow-up fixes from PR #90 merge:

  1. **Replace `site.main()` with `sys.path.insert()`** in rag-mcp auto-install flow (`mini.py`)
     - `site.main()` reinitializes all site-packages, which is overkill
     - `sys.path.insert(0, ...)` only adds the specific path needed, with fewer side effects
     - Addresses review feedback from @sdubagun-amd on PR #90

  2. **Pass `api_key` to RAG postprocessor** (fixes #169)
     - The RAG postprocessor creates its own `AmdLlmModel` but never received the `api_key` from yaml config
     - Without env var `AMD_LLM_API_KEY`, the postprocessor would fail with `ValueError: API key not provided`
     - Now `api_key` is passed through from the agent's model config to `wrap_rag_tools_with_postprocessor()`

  ## Changes

  | File | Change |
  |------|--------|
  | `run/mini.py` | `site.main()` → `sys.path.insert()` |
  | `tools/tools_runtime.py` | Add `api_key` param to `wrap_rag_tools_with_postprocessor()` |
  | `agents/default.py` | Pass `self.model.config.api_key` |
  | `agents/strategy_agent.py` | Pass `self.model.config.api_key` |
  | `agents/heterogeneous/orchestrator.py` | Pass `model.config.api_key` |