### PR TITLE
feat: add --cleanup flag to geak for post-run apply + commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ geak --repo /path/to/kernel/repo \
 - `--kernel-url`: required; path to the target kernel file (local path or URL)
 - `--num-parallel`: number of optimization agents
 - `--gpu-ids`: comma-separated GPU IDs for agents
+- `--cleanup`: after the run finishes, apply the winning patch to `--repo` on the current
+  branch, commit it with a message pointing at `final_report.json`, and prune per-run
+  artifacts (keeping only `final_report.json` and the winning `.diff`). Requires a clean
+  working tree on `--repo`; if apply or commit fails, the artifact dir is left intact for
+  debugging. When the repo has no configured git identity (typical inside the GEAK
+  container), the commit falls back to `GEAK Agent <geak@amd.com>`; override via the
+  `GEAK_GIT_AUTHOR_NAME` / `GEAK_GIT_AUTHOR_EMAIL` environment variables (passed through
+  by `entrypoint.sh`).
 
 ### Runnable examples
 

--- a/README.md
+++ b/README.md
@@ -99,16 +99,43 @@ geak --repo /path/to/kernel/repo \
 - `--kernel-url`: required; path to the target kernel file (local path or URL)
 - `--num-parallel`: number of optimization agents
 - `--gpu-ids`: comma-separated GPU IDs for agents
-- `--apply-best-patch` / `--no-apply-best-patch` (default: on): after the run finishes,
-  apply the winning patch to `--repo` on the current branch and commit it with a message
-  pointing at `final_report.json`. Requires a clean working tree on `--repo`. When the
-  repo has no configured git identity (typical inside the GEAK container), the commit
-  falls back to `GEAK Agent <geak@amd.com>`; override via the `GEAK_GIT_AUTHOR_NAME` /
-  `GEAK_GIT_AUTHOR_EMAIL` environment variables (passed through by `entrypoint.sh`).
-- `--cleanup` / `--no-cleanup` (default: on): prune per-run artifacts under the output
-  directory, keeping only `final_report.json` and the winning `.diff`. Independent of
-  `--apply-best-patch` (you can prune artifacts without committing, or commit without
-  pruning).
+- `--apply-best-patch` / `--no-apply-best-patch` (default: on): after the run completes
+  *without raising*, apply the winning patch to `--repo` on the current branch and commit
+  it with a message pointing at `final_report.json`. Requires a clean working tree on
+  `--repo`. A dirty tree is skipped in the log AND printed in yellow on the console so
+  the no-op isn't easy to miss. When the repo has no configured git identity (typical
+  inside the GEAK container), the commit falls back to `GEAK Agent <geak@amd.com>`;
+  override via the `GEAK_GIT_AUTHOR_NAME` / `GEAK_GIT_AUTHOR_EMAIL` environment variables
+  (passed through by `entrypoint.sh`).
+- `--cleanup` / `--no-cleanup` (default: on): runs at every cooperative exit — success,
+  exception during preprocess or run, and the Ctrl-C escalation path — and prunes
+  per-run artifacts to the **keep-set**: `final_report.json`, the winning `.diff`,
+  `geak_agent.log`, and `COMMANDMENT.md`. A Ctrl-C *during* cleanup leaves it partial
+  (cleanup wraps in `try/except Exception` and `KeyboardInterrupt` is a `BaseException`,
+  not an `Exception`). Hard-kill (wall-clock timeout) leaves the per-run dir alone for
+  forensic analysis regardless of `--cleanup`, and prints a loud red console line
+  naming the artifact path. Independent of `--apply-best-patch`.
+- `--keep-runs N` / `GEAK_KEEP_RUNS=N` (default: unlimited): after this run completes,
+  retain only the N most-recent auto-generated run dirs under output_dir's parent.
+  **Scope is `<cwd>/optimization_logs/`** — runs from other working directories are not
+  visible. Ignored under `--output` (a warning is logged). Concurrent runs in the same
+  parent are protected by a stale-only filter that prefers the agent log's mtime, but
+  the safest mode is one `geak` invocation at a time.
+- **Budget semantics.** `--mode quick` and `--mode full` are **absolute wall-clock caps**
+  of 60 min and 120 min respectively. The hard-kill watchdog `os._exit(124)`s at
+  `started_at + total_s` exactly — this anchor enforces the cap. Internally the
+  cooperative budget reserves ~60 s for finalize headroom; this is invisible to the
+  user and is not load-bearing for the cap promise.
+- **Operator log surface.** Every cooperative exit logs `[geak --cleanup] starting` and
+  `[geak --cleanup] completed: <status>`. If the completed line is missing, cleanup was
+  interrupted mid-flight (Ctrl-C during cleanup, or a rare race with hard-kill).
+- **Persistent caches not affected by `--cleanup`.** `~/.cache/amd-ai-devtool/semantic-index`
+  (the RAG FAISS index) and the auto-installed `rag-mcp` package. Both are intentional
+  caches reused across runs.
+- **Cooperative shutdown coverage** is tracked separately: the wall-clock cap is
+  enforced absolutely by the hard-kill watchdog, but reaching it should be rare. The
+  `subprocess.run` / LLM-client timeouts in the run path should all clamp via
+  `deadline.cap(...)`; a focused audit of those call sites is a follow-up.
 
 ### Runnable examples
 

--- a/README.md
+++ b/README.md
@@ -99,14 +99,16 @@ geak --repo /path/to/kernel/repo \
 - `--kernel-url`: required; path to the target kernel file (local path or URL)
 - `--num-parallel`: number of optimization agents
 - `--gpu-ids`: comma-separated GPU IDs for agents
-- `--cleanup`: after the run finishes, apply the winning patch to `--repo` on the current
-  branch, commit it with a message pointing at `final_report.json`, and prune per-run
-  artifacts (keeping only `final_report.json` and the winning `.diff`). Requires a clean
-  working tree on `--repo`; if apply or commit fails, the artifact dir is left intact for
-  debugging. When the repo has no configured git identity (typical inside the GEAK
-  container), the commit falls back to `GEAK Agent <geak@amd.com>`; override via the
-  `GEAK_GIT_AUTHOR_NAME` / `GEAK_GIT_AUTHOR_EMAIL` environment variables (passed through
-  by `entrypoint.sh`).
+- `--apply-best-patch` / `--no-apply-best-patch` (default: on): after the run finishes,
+  apply the winning patch to `--repo` on the current branch and commit it with a message
+  pointing at `final_report.json`. Requires a clean working tree on `--repo`. When the
+  repo has no configured git identity (typical inside the GEAK container), the commit
+  falls back to `GEAK Agent <geak@amd.com>`; override via the `GEAK_GIT_AUTHOR_NAME` /
+  `GEAK_GIT_AUTHOR_EMAIL` environment variables (passed through by `entrypoint.sh`).
+- `--cleanup` / `--no-cleanup` (default: on): prune per-run artifacts under the output
+  directory, keeping only `final_report.json` and the winning `.diff`. Independent of
+  `--apply-best-patch` (you can prune artifacts without committing, or commit without
+  pruning).
 
 ### Runnable examples
 

--- a/README.md
+++ b/README.md
@@ -96,14 +96,16 @@ geak --repo /path/to/kernel/repo \
 - `--kernel-url`: required; path to the target kernel file (local path or URL)
 - `--num-parallel`: number of optimization agents
 - `--gpu-ids`: comma-separated GPU IDs for agents
-- `--cleanup`: after the run finishes, apply the winning patch to `--repo` on the current
-  branch, commit it with a message pointing at `final_report.json`, and prune per-run
-  artifacts (keeping only `final_report.json` and the winning `.diff`). Requires a clean
-  working tree on `--repo`; if apply or commit fails, the artifact dir is left intact for
-  debugging. When the repo has no configured git identity (typical inside the GEAK
-  container), the commit falls back to `GEAK Agent <geak@amd.com>`; override via the
-  `GEAK_GIT_AUTHOR_NAME` / `GEAK_GIT_AUTHOR_EMAIL` environment variables (passed through
-  by `entrypoint.sh`).
+- `--apply-best-patch` / `--no-apply-best-patch` (default: on): after the run finishes,
+  apply the winning patch to `--repo` on the current branch and commit it with a message
+  pointing at `final_report.json`. Requires a clean working tree on `--repo`. When the
+  repo has no configured git identity (typical inside the GEAK container), the commit
+  falls back to `GEAK Agent <geak@amd.com>`; override via the `GEAK_GIT_AUTHOR_NAME` /
+  `GEAK_GIT_AUTHOR_EMAIL` environment variables (passed through by `entrypoint.sh`).
+- `--cleanup` / `--no-cleanup` (default: on): prune per-run artifacts under the output
+  directory, keeping only `final_report.json` and the winning `.diff`. Independent of
+  `--apply-best-patch` (you can prune artifacts without committing, or commit without
+  pruning).
 
 ### Runnable examples
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ geak --repo /path/to/kernel/repo \
 - `--kernel-url`: required; path to the target kernel file (local path or URL)
 - `--num-parallel`: number of optimization agents
 - `--gpu-ids`: comma-separated GPU IDs for agents
+- `--cleanup`: after the run finishes, apply the winning patch to `--repo` on the current
+  branch, commit it with a message pointing at `final_report.json`, and prune per-run
+  artifacts (keeping only `final_report.json` and the winning `.diff`). Requires a clean
+  working tree on `--repo`; if apply or commit fails, the artifact dir is left intact for
+  debugging. When the repo has no configured git identity (typical inside the GEAK
+  container), the commit falls back to `GEAK Agent <geak@amd.com>`; override via the
+  `GEAK_GIT_AUTHOR_NAME` / `GEAK_GIT_AUTHOR_EMAIL` environment variables (passed through
+  by `entrypoint.sh`).
 
 ### Runnable examples
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,12 @@ if [ "${GEAK_EDITABLE}" = "1" ]; then
     echo ""
 fi
 
+# Git identity for `geak --cleanup` commits (used only when the target repo
+# has no user.name/user.email configured). Values can be overridden by the
+# host at `docker run` time with `-e GEAK_GIT_AUTHOR_NAME=... -e GEAK_GIT_AUTHOR_EMAIL=...`.
+export GEAK_GIT_AUTHOR_NAME="${GEAK_GIT_AUTHOR_NAME:-GEAK Agent}"
+export GEAK_GIT_AUTHOR_EMAIL="${GEAK_GIT_AUTHOR_EMAIL:-geak@amd.com}"
+
 # Setup mini-swe-agent config from environment variables
 mkdir -p /root/.config/mini-swe-agent
 

--- a/mcp_tools/profiler-mcp/src/profiler_mcp/server.py
+++ b/mcp_tools/profiler-mcp/src/profiler_mcp/server.py
@@ -169,14 +169,16 @@ def _profile_with_rocprof(
     if os.environ.get("HIP_VISIBLE_DEVICES") == "":
         _hip_removed = os.environ.pop("HIP_VISIBLE_DEVICES")
 
-    analyzer = ProfilingAnalyzer(profiling_type=profiling_type)
+    # HIP env save/restore stays in this OUTER try/finally; the analyzer
+    # ``with`` block only owns analyzer lifecycle. The two concerns are
+    # independent and must not be collapsed.
     try:
-        raw = analyzer.profile_structured(
-            profiling_workdir=workdir or str(Path.cwd()),
-            profiling_cmd=command,
-        )
+        with ProfilingAnalyzer(profiling_type=profiling_type) as analyzer:
+            raw = analyzer.profile_structured(
+                profiling_workdir=workdir or str(Path.cwd()),
+                profiling_cmd=command,
+            )
     finally:
-        analyzer.cleanup()
         if _hip_removed is not None:
             os.environ["HIP_VISIBLE_DEVICES"] = _hip_removed
 

--- a/src/minisweagent/run/budget.py
+++ b/src/minisweagent/run/budget.py
@@ -3,14 +3,26 @@
 This module owns:
 
 - ``BudgetSpec``                   -- per-mode time knobs loaded from YAML.
+                                      ``total_s`` is the absolute wall-clock
+                                      cap (inclusive of ``kill_buffer_s``).
 - ``RunBudget``                    -- monotonic clock, ``soft_stop`` event,
-                                      a watchdog (``threading.Timer``) that flips
-                                      ``soft_stop`` ~``finalize_grace_s`` before
-                                      the optimization deadline, and a phase
-                                      counter that defuses the
-                                      ``Timer.cancel()``-vs-fire race.
-- ``Deadline``                     -- a snapshot view of the optimization deadline
-                                      that callers can poll cheaply.
+                                      a watchdog (``threading.Timer``) that
+                                      flips ``soft_stop`` ~``finalize_grace_s``
+                                      before the cooperative ``opt_deadline``,
+                                      and the hard-kill watchdog anchored on
+                                      ``started_at + total_s``.
+- ``Deadline``                     -- a snapshot view of the optimization
+                                      deadline that callers can poll cheaply.
+
+Two distinct guarantees:
+
+- **Cooperative**: ``soft_stop`` is set ~``finalize_grace_s`` before the
+  cooperative ``opt_deadline``; the cooperative deadline sits
+  ``kill_buffer_s`` before the absolute wall-clock cap.
+- **Absolute**: the hard-kill watchdog fires at exactly
+  ``started_at + total_s``. This is the cap enforcement -- it never
+  derives from the cooperative deadline, so preprocess overrun cannot
+  push it past ``total_s``.
 
 The module is pure stdlib; it intentionally does not install OS signal
 handlers (the SIGINT handler is owned by ``run/mini.py`` so it can also
@@ -40,18 +52,39 @@ Phase = Literal["preprocess", "optimization", "finalize", "done"]
 
 @dataclass
 class BudgetSpec:
-    """Per-mode budget knobs (loaded from ``run.budgets.<mode>`` in geak.yaml)."""
+    """Per-mode budget knobs (loaded from ``run.budgets.<mode>`` in geak.yaml).
+
+    ``total_s`` is the **absolute wall-clock cap** for the run, inclusive of
+    the internal ``kill_buffer_s`` margin. The hard-kill watchdog anchors on
+    ``started_at + total_s`` (see
+    :meth:`RunBudget.schedule_optimization_hard_kill_watchdog`); this anchor
+    is what makes the cap a guarantee. Do not refactor the watchdog to derive
+    its delay from ``opt_deadline_at + kill_buffer_s``: under preprocess
+    overrun that would push hard-kill past ``total_s``.
+
+    ``kill_buffer_s`` is the cooperative-finalize headroom the optimization
+    phase reserves up front (see :meth:`RunBudget.commit_preprocess`). It
+    widens the gap between the cooperative ``opt_deadline`` and the absolute
+    hard-kill point in the happy path, but is **not** load-bearing for the
+    cap promise -- removing it would only shrink finalize headroom, not push
+    hard-kill past ``started_at + total_s``.
+
+    Surprising-but-correct log surface: if a future config bumps
+    ``preprocess_hard_cap_fraction`` to 1.0 and preprocess actually consumes
+    the entire ``total_s``, the operator log will show
+    ``"preprocess committed at +<total_s>s; optimization budget = 0s"``
+    immediately followed by ``"[geak HARD-KILL] ..."``. This is the watchdog
+    correctly enforcing the absolute cap with no remaining cooperative time.
+    """
 
     mode: Mode
     total_s: float
     preprocess_soft_cap_s: float
     preprocess_hard_cap_fraction: float
     finalize_grace_s: float
-    # Grace period after ``opt_deadline`` before the hard-kill watchdog
-    # forcibly terminates registered subprocesses and ``os._exit``s the
-    # whole process. Defaults to 60s so a stuck inner tool call (e.g. a
-    # 30-min benchmark with no soft_stop poll inside it) cannot run the
-    # process indefinitely past the user-visible budget.
+    # Reserved up front by ``commit_preprocess`` so the cooperative
+    # ``opt_deadline`` sits ``kill_buffer_s`` before the absolute hard-kill
+    # anchor. Default 60s.
     kill_buffer_s: float = 60.0
 
     @property
@@ -249,11 +282,17 @@ class RunBudget:
     def schedule_optimization_hard_kill_watchdog(self, on_kill: Callable[[], None]) -> None:
         """Schedule the unconditional hard-kill watchdog for the optimization phase.
 
-        Fires at ``opt_deadline + kill_buffer_s``. Calls ``on_kill`` (typically
-        ``state.registry.terminate_all`` followed by ``os._exit(124)``) so a
-        stuck inner tool call -- one that never observes ``soft_stop`` because
-        it is mid-``subprocess.run`` -- still terminates the process within
-        ~``kill_buffer_s`` of the user-visible budget.
+        **Anchored on ``started_at + total_s``**, not on
+        ``opt_deadline_at + kill_buffer_s``. This makes ``total_s`` the
+        absolute wall-clock cap regardless of preprocess overrun. If
+        preprocess used the entire budget and ``opt_budget_s`` clamped to 0,
+        the timer simply fires close to immediately rather than slipping
+        ``kill_buffer_s`` past the cap.
+
+        Calls ``on_kill`` (typically ``state.registry.terminate_all`` followed
+        by ``os._exit(124)``) so a stuck inner tool call -- one that never
+        observes ``soft_stop`` because it is mid-``subprocess.run`` -- still
+        terminates the process at the advertised wall-clock cap.
 
         The phase guard intentionally keeps this callable in 'optimization'
         and 'finalize' phases (we transition to 'finalize' inside the
@@ -264,7 +303,8 @@ class RunBudget:
         if self._opt_deadline_at is None:
             raise RuntimeError("commit_preprocess must run before schedule_optimization_hard_kill_watchdog")
 
-        kill_delay_s = max(0.0, self._opt_deadline_at - time.monotonic() + self.spec.kill_buffer_s)
+        absolute_kill_at = self.started_at + self.spec.total_s
+        kill_delay_s = max(0.0, absolute_kill_at - time.monotonic())
 
         def _wrapper() -> None:
             # No phase guard: the kill is a backstop, not a cooperative
@@ -284,10 +324,11 @@ class RunBudget:
             self._timers.append(timer)
         timer.start()
         logger.debug(
-            "optimization hard-kill watchdog scheduled: kill @+%.0fs (opt_deadline @+%.0fs, buffer=%.0fs)",
+            "optimization hard-kill watchdog scheduled: kill @+%.0fs "
+            "(absolute_kill_at=started_at+%.0fs, opt_deadline @+%.0fs)",
             kill_delay_s,
+            self.spec.total_s,
             self._opt_deadline_at - time.monotonic(),
-            self.spec.kill_buffer_s,
         )
 
     def cancel_all_timers(self) -> None:
@@ -312,27 +353,40 @@ class RunBudget:
         """Transition phase ``preprocess -> optimization``.
 
         ``actual_preprocess_s`` is the wall-clock duration the preprocess
-        phase actually took. The optimization budget is
-        ``max(0.0, total_s - actual_preprocess_s)`` (the rollover formula:
-        any time preprocess didn't use, optimization gets; if preprocess
-        overran, optimization shrinks; if preprocess used the entire budget,
-        optimization gets 0 and finalize_grace_s).
+        phase actually took. The cooperative optimization budget reserves
+        ``kill_buffer_s`` up front so the cooperative ``opt_deadline`` lands
+        ``kill_buffer_s`` before the absolute hard-kill anchor in the happy
+        path (see :meth:`schedule_optimization_hard_kill_watchdog`):
+
+            opt_budget_s = max(0, total_s - kill_buffer_s - preprocess_actual)
+
+        This subtraction is **headroom**, not the wall-clock cap enforcer.
+        Even if preprocess overruns and clamps ``opt_budget_s`` to 0, the
+        hard-kill anchor is unaffected: it fires at ``started_at + total_s``
+        regardless.
 
         Phase is flipped *first* so that any preprocess timer mid-callback
         becomes a no-op as soon as it next checks ``_phase`` -- this is what
         defuses the cancel-vs-fire race.
         """
         self._set_phase("optimization")
-        opt_budget_s = max(0.0, self.spec.total_s - max(0.0, float(actual_preprocess_s)))
+        opt_budget_s = max(
+            0.0,
+            self.spec.total_s
+            - self.spec.kill_buffer_s
+            - max(0.0, float(actual_preprocess_s)),
+        )
         # opt_deadline is anchored on the *current* monotonic time so that the
-        # split-allocation rule "opt = total - preprocess_actual" composes
-        # correctly even when preprocess hit the hard cap.
+        # split-allocation rule "opt = total - kill_buffer - preprocess_actual"
+        # composes correctly even when preprocess hit the hard cap.
         self._opt_deadline_at = time.monotonic() + opt_budget_s
         logger.info(
-            "preprocess committed at +%.0fs; optimization budget = %.0fs (deadline @+%.0fs)",
+            "preprocess committed at +%.0fs; optimization budget = %.0fs "
+            "(deadline @+%.0fs, kill_buffer=%.0fs reserved)",
             actual_preprocess_s,
             opt_budget_s,
             opt_budget_s,
+            self.spec.kill_buffer_s,
         )
         return Deadline(self._opt_deadline_at, self.soft_stop)
 
@@ -349,8 +403,10 @@ class RunBudget:
     def banner_lines(self) -> list[str]:
         """Human-readable banner showing the budget layout."""
         return [
-            f"[budget] mode={self.spec.mode}, total={self.spec.total_s:.0f}s, "
+            f"[budget] mode={self.spec.mode}, total={self.spec.total_s:.0f}s "
+            f"(absolute wall-clock cap), "
             f"preprocess_soft_cap={self.spec.preprocess_soft_cap_s:.0f}s, "
             f"preprocess_hard_cap={self.spec.preprocess_hard_cap_s:.0f}s, "
-            f"finalize_grace={self.spec.finalize_grace_s:.0f}s",
+            f"finalize_grace={self.spec.finalize_grace_s:.0f}s, "
+            f"kill_buffer={self.spec.kill_buffer_s:.0f}s (internal margin)",
         ]

--- a/src/minisweagent/run/budget.py
+++ b/src/minisweagent/run/budget.py
@@ -372,9 +372,7 @@ class RunBudget:
         self._set_phase("optimization")
         opt_budget_s = max(
             0.0,
-            self.spec.total_s
-            - self.spec.kill_buffer_s
-            - max(0.0, float(actual_preprocess_s)),
+            self.spec.total_s - self.spec.kill_buffer_s - max(0.0, float(actual_preprocess_s)),
         )
         # opt_deadline is anchored on the *current* monotonic time so that the
         # split-allocation rule "opt = total - kill_buffer - preprocess_actual"

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -85,12 +85,18 @@ def _normalize_kernel_type(value: Any) -> str:
     return "other"
 
 
-def _derive_output_dir(output: Path | None, kernel_name: str | None) -> Path:
+def _derive_output_dir(output: Path | None, kernel_name: str | None) -> tuple[Path, bool]:
     """Derive the output directory from ``-o``/``--output``.
 
-    - If output is a file path: output_dir = output.parent
-    - If output is a directory: output_dir = output
+    Returns ``(path, auto)``. ``auto`` is True iff ``output`` was ``None`` and
+    geak generated the path under ``<cwd>/optimization_logs/``. The
+    ``--keep-runs`` retention policy is gated on ``auto`` so it only ever
+    touches directories geak owns.
+
+    - If output is a file path: output_dir = output.parent (auto=False)
+    - If output is a directory: output_dir = output (auto=False)
     - If output is not provided: use ./optimization_logs/<kernel_name>_<timestamp>
+      (auto=True)
 
     The returned path is always absolute. Several preprocess helpers
     (notably ``_resolve_deterministic_harness`` and the merged-file split
@@ -107,12 +113,12 @@ def _derive_output_dir(output: Path | None, kernel_name: str | None) -> Path:
     if output is None:
         from minisweagent.run.utils.task_parser import generate_patch_output_dir
 
-        return (Path.cwd() / Path(generate_patch_output_dir(kernel_name))).resolve()
+        return (Path.cwd() / Path(generate_patch_output_dir(kernel_name))).resolve(), True
 
     if output.suffix:
-        return output.parent.resolve()
+        return output.parent.resolve(), False
 
-    return output.resolve()
+    return output.resolve(), False
 
 
 def _final_report_to_bestpatchresult(report: Any) -> BestPatchResult | None:
@@ -166,15 +172,19 @@ There are two different user interfaces:
 [bold green]mini[/bold green] Simple REPL-style interface
 [bold green]mini -v[/bold green] Pager-style interface (Textual)
 
-After a successful run, two independent post-processing steps run by default:
+After a run completes, two independent post-processing steps run by default:
 
 - [bold green]--apply-best-patch[/bold green] applies the winning patch to
-  [bold]--repo[/bold] on the current branch and commits it.
-- [bold green]--cleanup[/bold green] prunes per-run artifacts under the output
-  directory, keeping only [bold]final_report.json[/bold] and the winning diff.
+  [bold]--repo[/bold] on the current branch and commits it. Requires the run
+  to have completed without raising.
+- [bold green]--cleanup[/bold green] runs on every cooperative exit -- success,
+  exception during preprocess or run, and the Ctrl-C escalation path -- and
+  prunes per-run artifacts to [bold]final_report.json[/bold], the winning
+  [bold].diff[/bold], [bold]geak_agent.log[/bold], and [bold]COMMANDMENT.md[/bold].
 
-Disable either independently with [bold]--no-apply-best-patch[/bold] /
-[bold]--no-cleanup[/bold].
+Hard-kill (wall-clock timeout) leaves artifacts in place for forensic analysis
+regardless of [bold]--cleanup[/bold]. Disable either step independently with
+[bold]--no-apply-best-patch[/bold] / [bold]--no-cleanup[/bold].
 [/not dim]
 """
 
@@ -231,8 +241,17 @@ def main(
         "--cleanup/--no-cleanup",
         help=(
             "After the run, prune per-run artifacts under the output dir (keeping "
-            "final_report.json and the winning diff). Independent of "
-            "--apply-best-patch. Default: on."
+            "final_report.json, the winning diff, geak_agent.log, COMMANDMENT.md). "
+            "Independent of --apply-best-patch. Default: on."
+        ),
+    ),
+    keep_runs: int | None = typer.Option(
+        None,
+        "--keep-runs",
+        help=(
+            "After this run completes, retain only the N most recent auto-generated "
+            "run dirs under output_dir's parent. Default: unlimited. Ignored when "
+            "--output is set explicitly. Env: GEAK_KEEP_RUNS."
         ),
     ),
 ):
@@ -512,9 +531,30 @@ def main(
         kernel_name_for_output = Path(kernel_target).stem
     logger.info("Using kernel_name_for_output: %s", kernel_name_for_output)
 
-    preprocess_output_dir = _derive_output_dir(output, kernel_name_for_output)
+    preprocess_output_dir, output_dir_auto = _derive_output_dir(output, kernel_name_for_output)
     preprocess_output_dir.mkdir(parents=True, exist_ok=True)
     add_file_handler(preprocess_output_dir / DEFAULT_LOG_FILENAME)
+
+    # Resolve --keep-runs precedence: CLI > GEAK_KEEP_RUNS env > unset.
+    # When the user supplied --output, retention is a no-op (we never prune
+    # a user-owned parent dir). Surface the no-op as a warning so a
+    # misconfigured flag doesn't silently disappear.
+    if keep_runs is None:
+        _env_keep_runs = os.environ.get("GEAK_KEEP_RUNS")
+        if _env_keep_runs:
+            try:
+                keep_runs = int(_env_keep_runs)
+            except ValueError:
+                logger.warning(
+                    "[geak --keep-runs] GEAK_KEEP_RUNS=%r is not an integer; ignored.",
+                    _env_keep_runs,
+                )
+                keep_runs = None
+    if keep_runs is not None and keep_runs > 0 and not output_dir_auto:
+        logger.warning(
+            "[geak --keep-runs] ignored: --output was set explicitly; "
+            "retention only applies to auto-generated dirs."
+        )
     _run_t0 = time.monotonic()
     config.setdefault("patch", {})["patch_output_dir"] = str(preprocess_output_dir)
     logger.info(
@@ -610,38 +650,46 @@ def main(
 
     signal.signal(signal.SIGINT, _sigint_handler)
 
-    _preprocess_kwargs = dict(
-        kernel_url=kernel_target,
-        repo=repo,
-        output_dir=preprocess_output_dir,
-        gpu_id=parsed_gpu_ids[0] if parsed_gpu_ids else 0,
-        model_factory=lambda: get_model(model_name, config.get("model", {})),
-        console=console,
-        target_language=_target_language,
-        budget=budget,
-        state=state,
-        user_task=task_content,
-        scoring_target=scoring_target_norm,
-    )
-    logger.debug("Preprocess kwargs: %s", _preprocess_kwargs)
-
-    # Schedule preprocess watchdogs that reach into ``state`` to apply the
-    # stage-aware soft/hard policy. Cancelled in the finally block.
-    budget.schedule_preprocess_watchdogs(
-        on_soft=lambda: preprocess_soft_stop_handler(
-            state,
-            soft_cap_s=budget.spec.preprocess_soft_cap_s,
-            hard_cap_s=budget.spec.preprocess_hard_cap_s,
-            console=console,
-        ),
-        on_hard=lambda: preprocess_hard_stop_handler(
-            state,
-            hard_cap_s=budget.spec.preprocess_hard_cap_s,
-            console=console,
-        ),
-    )
+    # State the outer ``finally`` will read. Declare here so the finally
+    # can't NameError on partial failure between this point and the first
+    # branch assignment.
+    result: BestPatchResult | None = None
+    repo_path: Path | None = None
+    effective_repo: Path | None = repo
+    _run_succeeded = False
 
     try:
+        _preprocess_kwargs = dict(
+            kernel_url=kernel_target,
+            repo=repo,
+            output_dir=preprocess_output_dir,
+            gpu_id=parsed_gpu_ids[0] if parsed_gpu_ids else 0,
+            model_factory=lambda: get_model(model_name, config.get("model", {})),
+            console=console,
+            target_language=_target_language,
+            budget=budget,
+            state=state,
+            user_task=task_content,
+            scoring_target=scoring_target_norm,
+        )
+        logger.debug("Preprocess kwargs: %s", _preprocess_kwargs)
+
+        # Schedule preprocess watchdogs that reach into ``state`` to apply the
+        # stage-aware soft/hard policy. Cancelled in the finally block.
+        budget.schedule_preprocess_watchdogs(
+            on_soft=lambda: preprocess_soft_stop_handler(
+                state,
+                soft_cap_s=budget.spec.preprocess_soft_cap_s,
+                hard_cap_s=budget.spec.preprocess_hard_cap_s,
+                console=console,
+            ),
+            on_hard=lambda: preprocess_hard_stop_handler(
+                state,
+                hard_cap_s=budget.spec.preprocess_hard_cap_s,
+                console=console,
+            ),
+        )
+
         if harness_spec:
             try:
                 preprocess_ctx = run_preprocessor(**_preprocess_kwargs, harness=harness_spec)
@@ -680,12 +728,15 @@ def main(
 
         # Hard-kill backstop: if cooperative shutdown stalls (e.g. a sub-agent
         # is mid-subprocess.run with no internal soft_stop poll), forcibly
-        # terminate the registry and ``os._exit`` after kill_buffer_s past
-        # the deadline. This is the only thing that guarantees the run exits
-        # within budget regardless of where the stall is.
+        # terminate the registry and ``os._exit`` at ``started_at + total_s``
+        # (the absolute wall-clock cap). This is the only thing that
+        # guarantees the run exits within budget regardless of where the
+        # stall is. Cleanup is intentionally NOT invoked here: the
+        # per-run dir is preserved for forensic analysis of WHY the
+        # watchdog fired.
         def _hard_kill_handler() -> None:
             logger.error(
-                "[budget] HARD KILL: opt_deadline + kill_buffer_s reached; terminating registry and exiting",
+                "[budget] HARD KILL: started_at + total_s reached; terminating registry and exiting",
             )
             # Best-effort stub final report so the operator has *something*
             # to point at when the run hits hard kill (the regular finalize
@@ -701,7 +752,7 @@ def main(
                                 "status": "hard_kill",
                                 "exit_code": 124,
                                 "elapsed_s": round(budget.elapsed(), 3),
-                                "reason": "opt_deadline + kill_buffer_s reached",
+                                "reason": "started_at + total_s reached",
                             },
                             indent=2,
                         )
@@ -712,6 +763,22 @@ def main(
                 state.registry.terminate_all(escalate_after_s=5.0)
             except Exception:
                 logger.exception("hard-kill: registry.terminate_all() failed")
+
+            # Loud user-facing warning identifying the artifact path and the
+            # fact that cleanup did NOT run. Operators reading a CI tail or
+            # subprocess.run capture can't miss it.
+            _msg = (
+                f"[geak HARD-KILL] Wall-clock budget exceeded "
+                f"(elapsed={budget.elapsed():.0f}s, budget={budget.spec.total_s:.0f}s). "
+                f"Per-run artifacts at {preprocess_output_dir} were PRESERVED for forensics. "
+                f"Cleanup did NOT run; inspect and prune manually when done."
+            )
+            logger.warning(_msg)
+            try:
+                console.print(f"[bold red]{_msg}[/bold red]")
+            except Exception:
+                pass  # never block os._exit on a console-render error
+
             # 124 is the conventional exit code for a wall-clock timeout
             # (matches GNU ``timeout``). Use ``os._exit`` (not sys.exit) to
             # bypass any atexit/cleanup that might block.
@@ -720,64 +787,55 @@ def main(
         budget.schedule_optimization_hard_kill_watchdog(_hard_kill_handler)
 
         logger.info(
-            "[budget] preprocess finished at +%.0fs; opt_deadline @+%.0fs (softstop_at @+%.0fs, hard_kill @+%.0fs)",
+            "[budget] preprocess finished at +%.0fs; opt_deadline @+%.0fs "
+            "(softstop_at @+%.0fs, hard_kill @+%.0fs)",
             _T_pp_end_elapsed,
             _T_pp_end_elapsed + opt_deadline.remaining(),
             _T_pp_end_elapsed + max(0.0, opt_deadline.remaining() - budget.spec.finalize_grace_s),
-            _T_pp_end_elapsed + opt_deadline.remaining() + budget.spec.kill_buffer_s,
+            budget.spec.total_s,
         )
-    except Exception:
-        # On exception, ensure cleanup runs before the exception propagates.
-        budget.cancel_all_timers()
-        try:
-            state.registry.terminate_all()
-        except Exception:
-            logger.exception("registry.terminate_all() failed during preprocess error")
-        signal.signal(signal.SIGINT, _orig_sigint or signal.SIG_DFL)
-        raise
 
-    if preprocess_ctx.get("test_command") and not test_command:
-        test_command = preprocess_ctx["test_command"]
-    if preprocess_ctx.get("repo_root") and repo is None:
-        repo = Path(preprocess_ctx["repo_root"])
+        if preprocess_ctx.get("test_command") and not test_command:
+            test_command = preprocess_ctx["test_command"]
+        if preprocess_ctx.get("repo_root") and repo is None:
+            repo = Path(preprocess_ctx["repo_root"])
 
-    # kernel_type routing:
-    # - hip/flydsl/other -> homogeneous agent
-    # - triton -> heterogeneous orchestrator
-    # Auto-detect kernel type if heterogeneous flag was not set by LLM extraction or task parser
-    if heterogeneous is None:
-        _discovery = preprocess_ctx.get("discovery") or {}
-        _kernel_info = _discovery.get("kernel") or {}
-        _auto_kernel_type = _kernel_info.get("type")
+        # kernel_type routing:
+        # - hip/flydsl/other -> homogeneous agent
+        # - triton -> heterogeneous orchestrator
+        # Auto-detect kernel type if heterogeneous flag was not set by LLM extraction or task parser
+        if heterogeneous is None:
+            _discovery = preprocess_ctx.get("discovery") or {}
+            _kernel_info = _discovery.get("kernel") or {}
+            _auto_kernel_type = _kernel_info.get("type")
 
-        if (not _auto_kernel_type or _auto_kernel_type == "unknown") and preprocess_ctx.get("kernel_path"):
-            from minisweagent.agents.heterogeneous.task_generator import _infer_kernel_type
-            _auto_kernel_type = _infer_kernel_type(Path(preprocess_ctx["kernel_path"]))
+            if (not _auto_kernel_type or _auto_kernel_type == "unknown") and preprocess_ctx.get("kernel_path"):
+                from minisweagent.agents.heterogeneous.task_generator import _infer_kernel_type
+                _auto_kernel_type = _infer_kernel_type(Path(preprocess_ctx["kernel_path"]))
 
-        if _auto_kernel_type == "triton":
-            heterogeneous = True
-            logger.info("Using heterogeneous mode based on discovery.")
-        else:
-            heterogeneous = False
-            logger.info("Using homogeneous mode based on discovery.")
+            if _auto_kernel_type == "triton":
+                heterogeneous = True
+                logger.info("Using heterogeneous mode based on discovery.")
+            else:
+                heterogeneous = False
+                logger.info("Using homogeneous mode based on discovery.")
 
-    # Resolve max_rounds via the documented precedence chain:
-    # CLI --max-rounds (if any future flag added) > config (mode preset) >
-    # GEAK_MAX_ROUNDS env > default. ``max_rounds`` from task parsing acts as
-    # an additional override (parsed via parse_pipeline_params at the top of
-    # main()), so we honor it when set.
-    _resolved_max_rounds, _max_rounds_source = resolve_max_rounds(
-        cli_max_rounds=max_rounds,
-        config=config,
-    )
-    logger.info(
-        "[budget] max_rounds=%d (source=%s; mode=%s)",
-        _resolved_max_rounds,
-        _max_rounds_source,
-        resolved_mode,
-    )
+        # Resolve max_rounds via the documented precedence chain:
+        # CLI --max-rounds (if any future flag added) > config (mode preset) >
+        # GEAK_MAX_ROUNDS env > default. ``max_rounds`` from task parsing acts as
+        # an additional override (parsed via parse_pipeline_params at the top of
+        # main()), so we honor it when set.
+        _resolved_max_rounds, _max_rounds_source = resolve_max_rounds(
+            cli_max_rounds=max_rounds,
+            config=config,
+        )
+        logger.info(
+            "[budget] max_rounds=%d (source=%s; mode=%s)",
+            _resolved_max_rounds,
+            _max_rounds_source,
+            resolved_mode,
+        )
 
-    try:
         if heterogeneous:
             commandment = preprocess_ctx.get("commandment")
             if not commandment:
@@ -816,6 +874,13 @@ def main(
                 )
 
             preprocess_ctx["rag_enabled"] = rag_enabled
+            # Bind effective_repo BEFORE run_orchestrator so an exception
+            # inside the orchestrator still leaves the finally with the
+            # correct repo for apply (which would also be gated False, but
+            # cleanup may still want it).
+            effective_repo = repo or (
+                Path(preprocess_ctx["repo_root"]) if preprocess_ctx.get("repo_root") else None
+            )
             report = run_orchestrator(
                 preprocess_ctx=preprocess_ctx,
                 gpu_ids=parsed_gpu_ids,
@@ -828,22 +893,14 @@ def main(
                 soft_stop=budget.soft_stop,
                 registry=state.registry,
             )
+            # Flip success flag BEFORE _final_report_to_bestpatchresult --
+            # it can raise on Path()/float() conversions, and we don't
+            # want a clean orchestrator return demoted by a post-processing
+            # error to a "run failed; do not apply" state.
+            _run_succeeded = True
             logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
-            het_result = _final_report_to_bestpatchresult(report)
-            if apply_best_patch or cleanup:
-                from minisweagent.run.postprocess.finalize_apply import finalize_apply_and_cleanup
-
-                het_repo = repo or (
-                    Path(preprocess_ctx["repo_root"]) if preprocess_ctx.get("repo_root") else None
-                )
-                finalize_apply_and_cleanup(
-                    het_result,
-                    het_repo,
-                    preprocess_output_dir,
-                    apply_best_patch=apply_best_patch,
-                    cleanup=cleanup,
-                )
-            return het_result
+            result = _final_report_to_bestpatchresult(report)
+            return result
 
         metric = parsed_config.get("metric") or config.get("patch", {}).get("metric")
         logger.info("Using metric: %s", metric)
@@ -890,6 +947,7 @@ def main(
                     p = resolved
             repo_path = p.resolve()
         logger.info("Resolved repo path: %s", repo_path)
+        effective_repo = repo_path
 
         result = run_homogeneous_agent(
             config=config,
@@ -909,19 +967,22 @@ def main(
             soft_stop=budget.soft_stop,
             registry=state.registry,
         )
+        # Flip success flag immediately after the agent returns, before the
+        # time.monotonic() log line (which can't realistically raise, but
+        # consistency with the het branch is cheap).
+        _run_succeeded = True
         logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
-        if apply_best_patch or cleanup:
-            from minisweagent.run.postprocess.finalize_apply import finalize_apply_and_cleanup
-
-            finalize_apply_and_cleanup(
-                result,
-                repo_path or repo,
-                preprocess_output_dir,
-                apply_best_patch=apply_best_patch,
-                cleanup=cleanup,
-            )
         return result
     finally:
+        # Ordering matters:
+        # 1. Cancel timers FIRST so the hard-kill watchdog can't race the
+        #    rest of the finally with an os._exit mid-rmtree.
+        # 2. Terminate the registry next so any tracked subprocess is dead
+        #    before we touch its working directory.
+        # 3. Restore SIGINT before cleanup so a Ctrl-C during prune lands
+        #    on the default handler (clean KeyboardInterrupt out).
+        # 4. Then run finalize + retention. Both are broad-except wrapped
+        #    so a hook failure can't mask the original exception.
         budget.cancel_all_timers()
         try:
             state.registry.terminate_all()
@@ -931,6 +992,52 @@ def main(
             signal.signal(signal.SIGINT, _orig_sigint or signal.SIG_DFL)
         except Exception:
             logger.exception("restoring SIGINT handler failed")
+
+        logger.info("[geak --cleanup] starting")
+        outcome: dict | None = None
+        try:
+            from minisweagent.run.postprocess.finalize_apply import finalize_apply_and_cleanup
+
+            outcome = finalize_apply_and_cleanup(
+                result,
+                effective_repo,
+                preprocess_output_dir,
+                apply_best_patch=apply_best_patch and _run_succeeded,
+                cleanup=cleanup,
+            )
+        except Exception:
+            logger.exception("finalize_apply_and_cleanup raised (non-fatal)")
+        logger.info(
+            "[geak --cleanup] completed: %s",
+            (outcome or {}).get("cleanup_status", "unknown"),
+        )
+
+        if outcome:
+            _apply_status = outcome.get("apply_status")
+            if _apply_status == "skipped_dirty":
+                console.print(
+                    "[bold yellow][geak apply] Skipped: --repo has uncommitted tracked changes. "
+                    "Commit/stash and re-run apply manually.[/bold yellow]"
+                )
+            elif _apply_status in {"apply_failed", "commit_failed"}:
+                console.print(
+                    f"[bold yellow][geak apply] {_apply_status}: "
+                    f"{outcome.get('reason', '')}[/bold yellow]"
+                )
+
+        if keep_runs and keep_runs > 0 and output_dir_auto:
+            try:
+                from minisweagent.run.postprocess.finalize_apply import prune_old_runs
+
+                _removed = prune_old_runs(
+                    preprocess_output_dir.parent,
+                    keep=keep_runs,
+                    exclude=preprocess_output_dir,
+                )
+                if _removed:
+                    logger.info("[geak --keep-runs] Pruned %d old run dir(s).", _removed)
+            except Exception:
+                logger.exception("prune_old_runs raised (non-fatal)")
 
 
 if __name__ == "__main__":

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -899,8 +899,11 @@ def main(
             # error to a "run failed; do not apply" state.
             _run_succeeded = True
             logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
+            # Assignment + return looks redundant but the outer finally
+            # reads ``result`` from the function scope; ``return X`` alone
+            # would leave it at its initial ``None``.
             result = _final_report_to_bestpatchresult(report)
-            return result
+            return result  # noqa: RET504
 
         metric = parsed_config.get("metric") or config.get("patch", {}).get("metric")
         logger.info("Using metric: %s", metric)

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -166,9 +166,15 @@ There are two different user interfaces:
 [bold green]mini[/bold green] Simple REPL-style interface
 [bold green]mini -v[/bold green] Pager-style interface (Textual)
 
-Pass [bold green]--cleanup[/bold green] to apply the winning patch to [bold]--repo[/bold]
-on the current branch, commit it, and prune per-run artifacts (keeping only
-[bold]final_report.json[/bold] and the winning diff).
+After a successful run, two independent post-processing steps run by default:
+
+- [bold green]--apply-best-patch[/bold green] applies the winning patch to
+  [bold]--repo[/bold] on the current branch and commits it.
+- [bold green]--cleanup[/bold green] prunes per-run artifacts under the output
+  directory, keeping only [bold]final_report.json[/bold] and the winning diff.
+
+Disable either independently with [bold]--no-apply-best-patch[/bold] /
+[bold]--no-cleanup[/bold].
 [/not dim]
 """
 
@@ -212,12 +218,21 @@ def main(
             "agent visibility; --target only chooses which becomes the scoring signal."
         ),
     ),
-    cleanup: bool = typer.Option(
-        False,
-        "--cleanup",
+    apply_best_patch: bool = typer.Option(
+        True,
+        "--apply-best-patch/--no-apply-best-patch",
         help=(
-            "After the run, apply the best patch to --repo, commit it, and prune "
-            "per-run artifacts (keeping final_report.json and the winning diff)."
+            "After the run, apply the winning patch to --repo on the current branch "
+            "and commit it. Default: on."
+        ),
+    ),
+    cleanup: bool = typer.Option(
+        True,
+        "--cleanup/--no-cleanup",
+        help=(
+            "After the run, prune per-run artifacts under the output dir (keeping "
+            "final_report.json and the winning diff). Independent of "
+            "--apply-best-patch. Default: on."
         ),
     ),
 ):
@@ -815,13 +830,19 @@ def main(
             )
             logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
             het_result = _final_report_to_bestpatchresult(report)
-            if cleanup:
-                from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+            if apply_best_patch or cleanup:
+                from minisweagent.run.postprocess.finalize_apply import finalize_run
 
                 het_repo = repo or (
                     Path(preprocess_ctx["repo_root"]) if preprocess_ctx.get("repo_root") else None
                 )
-                apply_commit_and_cleanup(het_result, het_repo, preprocess_output_dir)
+                finalize_run(
+                    het_result,
+                    het_repo,
+                    preprocess_output_dir,
+                    apply_best_patch=apply_best_patch,
+                    cleanup=cleanup,
+                )
             return het_result
 
         metric = parsed_config.get("metric") or config.get("patch", {}).get("metric")
@@ -889,10 +910,16 @@ def main(
             registry=state.registry,
         )
         logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
-        if cleanup:
-            from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+        if apply_best_patch or cleanup:
+            from minisweagent.run.postprocess.finalize_apply import finalize_run
 
-            apply_commit_and_cleanup(result, repo_path or repo, preprocess_output_dir)
+            finalize_run(
+                result,
+                repo_path or repo,
+                preprocess_output_dir,
+                apply_best_patch=apply_best_patch,
+                cleanup=cleanup,
+            )
         return result
     finally:
         budget.cancel_all_timers()

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -165,6 +165,10 @@ There are two different user interfaces:
 
 [bold green]mini[/bold green] Simple REPL-style interface
 [bold green]mini -v[/bold green] Pager-style interface (Textual)
+
+Pass [bold green]--cleanup[/bold green] to apply the winning patch to [bold]--repo[/bold]
+on the current branch, commit it, and prune per-run artifacts (keeping only
+[bold]final_report.json[/bold] and the winning diff).
 [/not dim]
 """
 
@@ -206,6 +210,14 @@ def main(
             "kernel time via torch.profiler CUDA events (excludes dispatch). The dual-signal "
             "harness always reports BOTH (GEAK_RESULT_WALL_MS + GEAK_RESULT_KERNEL_MS) for "
             "agent visibility; --target only chooses which becomes the scoring signal."
+        ),
+    ),
+    cleanup: bool = typer.Option(
+        False,
+        "--cleanup",
+        help=(
+            "After the run, apply the best patch to --repo, commit it, and prune "
+            "per-run artifacts (keeping final_report.json and the winning diff)."
         ),
     ),
 ):
@@ -802,7 +814,15 @@ def main(
                 registry=state.registry,
             )
             logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
-            return _final_report_to_bestpatchresult(report)
+            het_result = _final_report_to_bestpatchresult(report)
+            if cleanup:
+                from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+
+                het_repo = repo or (
+                    Path(preprocess_ctx["repo_root"]) if preprocess_ctx.get("repo_root") else None
+                )
+                apply_commit_and_cleanup(het_result, het_repo, preprocess_output_dir)
+            return het_result
 
         metric = parsed_config.get("metric") or config.get("patch", {}).get("metric")
         logger.info("Using metric: %s", metric)
@@ -869,6 +889,10 @@ def main(
             registry=state.registry,
         )
         logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
+        if cleanup:
+            from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+
+            apply_commit_and_cleanup(result, repo_path or repo, preprocess_output_dir)
         return result
     finally:
         budget.cancel_all_timers()

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -831,12 +831,12 @@ def main(
             logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
             het_result = _final_report_to_bestpatchresult(report)
             if apply_best_patch or cleanup:
-                from minisweagent.run.postprocess.finalize_apply import finalize_run
+                from minisweagent.run.postprocess.finalize_apply import finalize_apply_and_cleanup
 
                 het_repo = repo or (
                     Path(preprocess_ctx["repo_root"]) if preprocess_ctx.get("repo_root") else None
                 )
-                finalize_run(
+                finalize_apply_and_cleanup(
                     het_result,
                     het_repo,
                     preprocess_output_dir,
@@ -911,9 +911,9 @@ def main(
         )
         logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
         if apply_best_patch or cleanup:
-            from minisweagent.run.postprocess.finalize_apply import finalize_run
+            from minisweagent.run.postprocess.finalize_apply import finalize_apply_and_cleanup
 
-            finalize_run(
+            finalize_apply_and_cleanup(
                 result,
                 repo_path or repo,
                 preprocess_output_dir,

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -136,9 +136,15 @@ There are two different user interfaces:
 [bold green]mini[/bold green] Simple REPL-style interface
 [bold green]mini -v[/bold green] Pager-style interface (Textual)
 
-Pass [bold green]--cleanup[/bold green] to apply the winning patch to [bold]--repo[/bold]
-on the current branch, commit it, and prune per-run artifacts (keeping only
-[bold]final_report.json[/bold] and the winning diff).
+After a successful run, two independent post-processing steps run by default:
+
+- [bold green]--apply-best-patch[/bold green] applies the winning patch to
+  [bold]--repo[/bold] on the current branch and commits it.
+- [bold green]--cleanup[/bold green] prunes per-run artifacts under the output
+  directory, keeping only [bold]final_report.json[/bold] and the winning diff.
+
+Disable either independently with [bold]--no-apply-best-patch[/bold] /
+[bold]--no-cleanup[/bold].
 [/not dim]
 """
 
@@ -160,7 +166,8 @@ def main(
     num_parallel: int | None = typer.Option(None, "--num-parallel", help="Number of parallel patch agents."),
     gpu_ids: str | None = typer.Option(None, "--gpu-ids", help="Comma-separated GPU IDs."),
     test_command: str | None = typer.Option(None, "--test_command", "--test-command", help="Test command"),
-    cleanup: bool = typer.Option(False, "--cleanup", help="After the run, apply the best patch to --repo, commit it, and prune per-run artifacts (keeping final_report.json and the winning diff)."),
+    apply_best_patch: bool = typer.Option(True, "--apply-best-patch/--no-apply-best-patch", help="After the run, apply the winning patch to --repo on the current branch and commit it. Default: on."),
+    cleanup: bool = typer.Option(True, "--cleanup/--no-cleanup", help="After the run, prune per-run artifacts under the output dir (keeping final_report.json and the winning diff). Independent of --apply-best-patch. Default: on."),
 ):
     # fmt: on
     del visual
@@ -563,11 +570,17 @@ def main(
         )
         logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
         het_result = _final_report_to_bestpatchresult(report)
-        if cleanup:
-            from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+        if apply_best_patch or cleanup:
+            from minisweagent.run.postprocess.finalize_apply import finalize_run
 
             het_repo = repo or (Path(preprocess_ctx["repo_root"]) if preprocess_ctx.get("repo_root") else None)
-            apply_commit_and_cleanup(het_result, het_repo, preprocess_output_dir)
+            finalize_run(
+                het_result,
+                het_repo,
+                preprocess_output_dir,
+                apply_best_patch=apply_best_patch,
+                cleanup=cleanup,
+            )
         return het_result
 
     metric = parsed_config.get("metric") or config.get("patch", {}).get("metric")
@@ -633,10 +646,16 @@ def main(
         console=console,
     )
     logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
-    if cleanup:
-        from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+    if apply_best_patch or cleanup:
+        from minisweagent.run.postprocess.finalize_apply import finalize_run
 
-        apply_commit_and_cleanup(result, repo_path or repo, preprocess_output_dir)
+        finalize_run(
+            result,
+            repo_path or repo,
+            preprocess_output_dir,
+            apply_best_patch=apply_best_patch,
+            cleanup=cleanup,
+        )
     return result
 
 

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -135,6 +135,10 @@ There are two different user interfaces:
 
 [bold green]mini[/bold green] Simple REPL-style interface
 [bold green]mini -v[/bold green] Pager-style interface (Textual)
+
+Pass [bold green]--cleanup[/bold green] to apply the winning patch to [bold]--repo[/bold]
+on the current branch, commit it, and prune per-run artifacts (keeping only
+[bold]final_report.json[/bold] and the winning diff).
 [/not dim]
 """
 
@@ -156,6 +160,7 @@ def main(
     num_parallel: int | None = typer.Option(None, "--num-parallel", help="Number of parallel patch agents."),
     gpu_ids: str | None = typer.Option(None, "--gpu-ids", help="Comma-separated GPU IDs."),
     test_command: str | None = typer.Option(None, "--test_command", "--test-command", help="Test command"),
+    cleanup: bool = typer.Option(False, "--cleanup", help="After the run, apply the best patch to --repo, commit it, and prune per-run artifacts (keeping final_report.json and the winning diff)."),
 ):
     # fmt: on
     del visual
@@ -557,7 +562,13 @@ def main(
             heterogeneous=True,
         )
         logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
-        return _final_report_to_bestpatchresult(report)
+        het_result = _final_report_to_bestpatchresult(report)
+        if cleanup:
+            from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+
+            het_repo = repo or (Path(preprocess_ctx["repo_root"]) if preprocess_ctx.get("repo_root") else None)
+            apply_commit_and_cleanup(het_result, het_repo, preprocess_output_dir)
+        return het_result
 
     metric = parsed_config.get("metric") or config.get("patch", {}).get("metric")
     logger.info("Using metric: %s", metric)
@@ -622,6 +633,10 @@ def main(
         console=console,
     )
     logger.info("Run completed in %.0fs.", time.monotonic() - _run_t0)
+    if cleanup:
+        from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+
+        apply_commit_and_cleanup(result, repo_path or repo, preprocess_output_dir)
     return result
 
 

--- a/src/minisweagent/run/postprocess/finalize_apply.py
+++ b/src/minisweagent/run/postprocess/finalize_apply.py
@@ -10,7 +10,7 @@ Exposes two independent operations and a coordinator:
 - ``cleanup_run_artifacts(result, output_dir)`` -- prunes per-run artifacts
   while preserving ``final_report.json`` and the winning ``.diff`` inside
   the original ``output_dir``. Independent of apply.
-- ``finalize_run(result, repo, output_dir, *, apply_best_patch, cleanup)``
+- ``finalize_apply_and_cleanup(result, repo, output_dir, *, apply_best_patch, cleanup)``
   -- CLI-level entry point that runs either/both according to the boolean
   flags.
 
@@ -111,7 +111,7 @@ def cleanup_run_artifacts(
     _cleanup_artifacts(output_dir, patch_path)
 
 
-def finalize_run(
+def finalize_apply_and_cleanup(
     result: BestPatchResult | None,
     repo: Path | None,
     output_dir: Path | None,

--- a/src/minisweagent/run/postprocess/finalize_apply.py
+++ b/src/minisweagent/run/postprocess/finalize_apply.py
@@ -6,49 +6,91 @@ Exposes two independent operations and a coordinator:
   ``.diff`` (from ``BestPatchResult.best_patch_file``) to ``repo`` on the
   current branch using the same ``git apply`` fallback helper as the
   per-round eval worktree logic, then commits with a message that points
-  at the run's ``final_report.json``.
-- ``cleanup_run_artifacts(result, output_dir)`` -- prunes per-run artifacts
-  while preserving ``final_report.json`` and the winning ``.diff`` inside
-  the original ``output_dir``. Independent of apply.
+  at the run's ``final_report.json``. Returns the commit SHA or None
+  (back-compat). Sibling ``apply_and_commit_best_patch_detailed`` returns
+  a structured outcome dict for callers that want to render UX from it.
+- ``cleanup_run_artifacts(result, output_dir)`` -- iterates ``output_dir``
+  and deletes every top-level entry not in the keep-set
+  (``final_report.json``, the agent log, ``COMMANDMENT.md``, and the
+  winning ``.diff`` when present). Preserves the ``output_dir`` inode so
+  the live ``FileHandler`` on the agent log keeps writing through cleanup
+  and any later traceback. Returns a ``cleanup_status`` string:
+  ``"ran"`` / ``"failed"`` / ``"skipped_empty"`` / ``"skipped_disabled"``.
 - ``finalize_apply_and_cleanup(result, repo, output_dir, *, apply_best_patch, cleanup)``
   -- CLI-level entry point that runs either/both according to the boolean
-  flags.
+  flags. Returns ``{apply_status, cleanup_status, commit_sha, reason}``.
 
 Failure semantics:
 
-- Apply fails  -> no commit. Cleanup still runs if requested (the winning
-  patch file is preserved in the summary, so the user can re-apply it by
-  hand).
+- Apply fails  -> no commit. Cleanup still runs if requested.
 - Commit fails -> apply stays in the working tree. Cleanup still runs if
   requested.
-- Cleanup fails -> the two retained files have already been copied to a
-  safe temp location before ``rmtree`` runs, so we surface the error but
-  never lose both summary and artifacts.
+- Cleanup per-entry failure -> logged and counted; the loop continues;
+  ``cleanup_status`` lands on ``"failed"``. The keep-set is still on disk.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import re
 import shutil
 import subprocess
-import tempfile
+import time
 from pathlib import Path
 
 from minisweagent.agents.parallel_agent import BestPatchResult
 from minisweagent.run.utils.generated_artifacts import apply_patch_with_generated_helper_fallback
 from minisweagent.run.utils.git_safe_env import get_git_safe_env
+from minisweagent.utils.log import DEFAULT_LOG_FILENAME
 
 logger = logging.getLogger(__name__)
 
 
 _FINAL_REPORT_NAME = "final_report.json"
+_COMMANDMENT_NAME = "COMMANDMENT.md"
+
+# Files at the top level of output_dir that ``cleanup_run_artifacts`` always
+# preserves. The per-call effective keep-set adds the winning patch basename
+# when ``result.best_patch_file`` exists. ``DEFAULT_LOG_FILENAME`` is imported
+# from minisweagent.utils.log so a rename there cannot silently desync.
+_PRESERVED_FILES: tuple[str, ...] = (
+    _FINAL_REPORT_NAME,
+    DEFAULT_LOG_FILENAME,
+    _COMMANDMENT_NAME,
+)
+
+# Maximum string length that ``_rewrite_kept_report`` will attempt to
+# normalize as a path. No legitimate filesystem path is anywhere near 4 KiB;
+# this guards against rewriting accidentally large fields that slipped past
+# the key allow-list.
+_PATH_REWRITE_MAX_LEN = 4096
+
+# Scalar keys in ``final_report.json`` whose value is a single path string.
+# These are the only fields ``_rewrite_kept_report`` will normalize besides
+# any key whose name ends in ``_path`` / ``_dir`` / ``_file`` / ``_patch``.
+_SCALAR_PATH_KEYS: frozenset[str] = frozenset({"best_patch", "kernel_path", "repo_root"})
+
+# Keys whose values are LLM-authored documents (free-text). Anything nested
+# under these is skipped entirely by ``_rewrite_kept_report``, even if a
+# nested key would otherwise match the path-key heuristic.
+_DOCUMENT_KEYS: frozenset[str] = frozenset(
+    {"summary", "agent_summary", "verification_note", "round_evaluation", "round_summaries"}
+)
+
+_PATH_KEY_SUFFIXES: tuple[str, ...] = ("_path", "_dir", "_file", "_patch")
 
 # Defaults used when the container / host has no configured git identity.
 # Override via the ``GEAK_GIT_AUTHOR_NAME`` / ``GEAK_GIT_AUTHOR_EMAIL`` env
 # vars (set at container run time or by the developer).
 _DEFAULT_GIT_AUTHOR_NAME = "GEAK Agent"
 _DEFAULT_GIT_AUTHOR_EMAIL = "geak@amd.com"
+
+# Auto-generated run dir name pattern emitted by ``generate_patch_output_dir``.
+# Anchored only on the ``_YYYYmmdd_HHMMSS`` suffix so real kernel names
+# (which may contain ``.``, ``-``, uppercase) all match.
+_AUTO_RUN_DIR_RE = re.compile(r"^.+_\d{8}_\d{6}$")
 
 
 def apply_and_commit_best_patch(
@@ -58,57 +100,102 @@ def apply_and_commit_best_patch(
     """Apply ``result.best_patch_file`` to ``repo`` and commit on the current branch.
 
     Returns the commit SHA on success, or ``None`` when a precondition fails
-    or any git step fails. Never raises; every failure is logged with a
-    clear reason so the caller can decide whether to proceed.
+    or any git step fails. Never raises. Thin back-compat wrapper around
+    :func:`apply_and_commit_best_patch_detailed`; new callers that want to
+    render UX from the failure reason should call the detailed function
+    directly.
+    """
+    return apply_and_commit_best_patch_detailed(result, repo).get("commit_sha")
+
+
+def apply_and_commit_best_patch_detailed(
+    result: BestPatchResult | None,
+    repo: Path | None,
+) -> dict:
+    """Apply + commit and return a structured outcome dict.
+
+    Return shape:
+
+    .. code-block:: python
+
+        {"status": "committed" | "skipped_dirty" | "skipped_precondition"
+                  | "apply_failed" | "commit_failed",
+         "commit_sha": str | None,
+         "reason": str | None}
+
+    Never raises. Every non-success branch logs a clear reason so the
+    caller can decide whether to render an additional user-facing message.
     """
     if not _validate_apply_preconditions(result, repo):
-        return None
+        return {"status": "skipped_precondition", "commit_sha": None, "reason": None}
 
     assert result is not None and repo is not None  # for type narrowing
     repo = Path(repo).resolve()
     patch_path = Path(result.best_patch_file).resolve()  # type: ignore[arg-type]
 
     if not _repo_is_clean(repo):
-        logger.warning(
-            "[geak apply] Skipping: repo %s has uncommitted tracked changes. "
-            "Commit or stash them first, then re-run apply manually.",
-            repo,
+        reason = (
+            f"repo {repo} has uncommitted tracked changes. "
+            "Commit or stash them first, then re-run apply manually."
         )
-        return None
+        logger.warning("[geak apply] Skipping: %s", reason)
+        return {"status": "skipped_dirty", "commit_sha": None, "reason": reason}
 
-    if not _apply_patch_to_repo(patch_path, repo):
-        return None
+    applied, apply_reason = _apply_patch_to_repo(patch_path, repo)
+    if not applied:
+        return {"status": "apply_failed", "commit_sha": None, "reason": apply_reason}
 
-    commit_sha = _commit_applied_patch(result, repo)
+    commit_sha, commit_reason = _commit_applied_patch(result, repo)
     if commit_sha is None:
         logger.warning(
             "[geak apply] Commit failed; leaving applied changes in the working tree of %s.",
             repo,
         )
-        return None
+        return {"status": "commit_failed", "commit_sha": None, "reason": commit_reason}
 
     logger.info("[geak apply] Committed %s on %s.", commit_sha, repo)
-    return commit_sha
+    return {"status": "committed", "commit_sha": commit_sha, "reason": None}
 
 
 def cleanup_run_artifacts(
     result: BestPatchResult | None,
     output_dir: Path | None,
-) -> None:
-    """Prune ``output_dir`` to just ``final_report.json`` + winning ``.diff``.
+) -> str:
+    """Prune ``output_dir`` to the keep-set in place.
 
-    Independent of apply: it is safe to call this whether or not the patch
-    was applied/committed. If the patch file lives under ``output_dir`` it is
-    preserved across the rmtree so the user can always re-apply it by hand.
+    Top-level entries surviving cleanup: ``final_report.json``,
+    ``geak_agent.log`` (canonical agent log), ``COMMANDMENT.md``, and the
+    winning ``.diff`` when present. Independent of apply: safe to call whether
+    or not the patch was applied/committed.
+
+    Iterates over ``output_dir.iterdir()`` and deletes top-level entries not
+    in the keep-set. The directory's own inode is never unlinked, so the
+    ``FileHandler`` already writing to ``output_dir / DEFAULT_LOG_FILENAME``
+    keeps its FD live through cleanup, the post-cleanup log line, and any
+    later traceback.
+
+    Returns one of:
+
+    - ``"ran"`` -- the iterate-and-delete loop finished with zero per-entry
+      exceptions.
+    - ``"failed"`` -- the loop completed but at least one entry's deletion
+      raised and was logged. The keep-set is still on disk.
+    - ``"skipped_empty"`` -- precondition check failed. Two sub-cases: (a)
+      ``output_dir`` is missing/not a dir; (b) neither ``final_report.json``
+      nor a winning patch file exists. Nothing is touched.
     """
     if not _validate_cleanup_preconditions(result, output_dir):
-        return
+        return "skipped_empty"
 
-    assert result is not None and output_dir is not None  # for type narrowing
+    assert output_dir is not None  # for type narrowing
     output_dir = Path(output_dir).resolve()
-    patch_path = Path(result.best_patch_file).resolve() if result.best_patch_file else None
+    patch_path = (
+        Path(result.best_patch_file).resolve()
+        if (result is not None and result.best_patch_file)
+        else None
+    )
 
-    _cleanup_artifacts(output_dir, patch_path)
+    return _cleanup_artifacts(output_dir, patch_path)
 
 
 def finalize_apply_and_cleanup(
@@ -118,22 +205,40 @@ def finalize_apply_and_cleanup(
     *,
     apply_best_patch: bool = True,
     cleanup: bool = True,
-) -> None:
+) -> dict:
     """CLI-level coordinator invoked from ``mini.py``.
 
+    Returns a structured outcome dict for the CLI caller to render messages
+    from:
+
+    .. code-block:: python
+
+        {"apply_status": <apply status, or "skipped_disabled">,
+         "cleanup_status": <cleanup status, or "skipped_disabled">,
+         "commit_sha": str | None,
+         "reason": str | None}
+
     ``apply_best_patch`` and ``cleanup`` are fully independent; either can
-    be toggled without affecting the other. If both are False, this is a
-    no-op (the caller shouldn't have called in the first place, but it's
-    safe).
+    be toggled without affecting the other. With both False the function
+    returns a no-op outcome (both statuses ``"skipped_disabled"``).
     """
-    if not apply_best_patch and not cleanup:
-        return
+    outcome: dict = {
+        "apply_status": "skipped_disabled",
+        "cleanup_status": "skipped_disabled",
+        "commit_sha": None,
+        "reason": None,
+    }
 
     if apply_best_patch:
-        apply_and_commit_best_patch(result, repo)
+        apply_outcome = apply_and_commit_best_patch_detailed(result, repo)
+        outcome["apply_status"] = apply_outcome["status"]
+        outcome["commit_sha"] = apply_outcome.get("commit_sha")
+        outcome["reason"] = apply_outcome.get("reason")
 
     if cleanup:
-        cleanup_run_artifacts(result, output_dir)
+        outcome["cleanup_status"] = cleanup_run_artifacts(result, output_dir)
+
+    return outcome
 
 
 # ---------------------------------------------------------------------------
@@ -175,16 +280,43 @@ def _validate_cleanup_preconditions(
     result: BestPatchResult | None,
     output_dir: Path | None,
 ) -> bool:
+    """Return True iff there's a non-empty run worth pruning.
+
+    False in two cases (both map to ``cleanup_status="skipped_empty"`` in
+    :func:`cleanup_run_artifacts`):
+
+    1. ``output_dir`` is None / missing / not a directory.
+    2. ``output_dir`` exists but neither ``final_report.json`` nor a
+       readable winning patch file at ``result.best_patch_file`` is there.
+       Without either of those there's nothing the cleanup would preserve,
+       so we leave whatever's on disk untouched for post-mortem.
+    """
     if output_dir is None:
         logger.warning("[geak --cleanup] Skipping: no output_dir provided.")
         return False
-    if not Path(output_dir).exists():
-        logger.warning("[geak --cleanup] Skipping: output_dir does not exist: %s", output_dir)
+    output_dir_path = Path(output_dir)
+    if not output_dir_path.is_dir():
+        logger.warning(
+            "[geak --cleanup] Skipping: output_dir does not exist or is not a dir: %s",
+            output_dir,
+        )
         return False
-    # ``result`` is optional for cleanup -- if present we use it to locate
-    # the winning patch file to preserve. Missing/empty result just means
-    # we fall back to preserving only ``final_report.json``.
-    del result
+
+    has_report = (output_dir_path / _FINAL_REPORT_NAME).is_file()
+    has_patch = bool(
+        result is not None
+        and result.best_patch_file
+        and Path(result.best_patch_file).is_file()
+    )
+    if not (has_report or has_patch):
+        logger.warning(
+            "[geak --cleanup] Skipping: %s has neither %s nor a winning patch; "
+            "leaving the directory intact for post-mortem.",
+            output_dir_path,
+            _FINAL_REPORT_NAME,
+        )
+        return False
+
     return True
 
 
@@ -272,7 +404,8 @@ def _repo_is_clean(repo: Path) -> bool:
     return not result.stdout.strip()
 
 
-def _apply_patch_to_repo(patch_path: Path, repo: Path) -> bool:
+def _apply_patch_to_repo(patch_path: Path, repo: Path) -> tuple[bool, str | None]:
+    """Apply ``patch_path`` to ``repo``. Return (success, reason-on-failure)."""
     patch_text = patch_path.read_text(encoding="utf-8", errors="replace")
     env = get_git_safe_env(repo)
 
@@ -287,22 +420,24 @@ def _apply_patch_to_repo(patch_path: Path, repo: Path) -> bool:
             ", ".join(removed_paths),
         )
     if apply_result.returncode != 0:
+        stderr_tail = apply_result.stderr.strip()[:1000]
         logger.warning(
             "[geak --cleanup] git apply failed (rc=%s); leaving repo and artifacts untouched.\nstderr: %s",
             apply_result.returncode,
-            apply_result.stderr.strip()[:1000],
+            stderr_tail,
         )
-        return False
+        reason = f"git apply rc={apply_result.returncode}: {stderr_tail}" if stderr_tail else f"git apply rc={apply_result.returncode}"
+        return False, reason
 
     logger.info("[geak --cleanup] Applied %s to %s", patch_path, repo)
-    return True
+    return True, None
 
 
 def _commit_applied_patch(
     result: BestPatchResult,
     repo: Path,
-) -> str | None:
-    """Stage + commit the applied changes. Return commit SHA or None on failure."""
+) -> tuple[str | None, str | None]:
+    """Stage + commit the applied changes. Return (commit SHA, reason-on-failure)."""
     env = get_git_safe_env(repo)
 
     add = subprocess.run(
@@ -314,12 +449,9 @@ def _commit_applied_patch(
         env=env,
     )
     if add.returncode != 0:
-        logger.warning(
-            "[geak apply] git add -A failed (rc=%s): %s",
-            add.returncode,
-            add.stderr.strip(),
-        )
-        return None
+        stderr = add.stderr.strip()
+        logger.warning("[geak apply] git add -A failed (rc=%s): %s", add.returncode, stderr)
+        return None, f"git add -A rc={add.returncode}: {stderr}" if stderr else f"git add -A rc={add.returncode}"
 
     staged = subprocess.run(
         ["git", "diff", "--cached", "--name-only"],
@@ -331,7 +463,7 @@ def _commit_applied_patch(
     )
     if staged.returncode == 0 and not staged.stdout.strip():
         logger.warning("[geak apply] Patch applied cleanly but resulted in no staged changes. Skipping empty commit.")
-        return None
+        return None, "patch applied cleanly but produced no staged changes"
 
     message = _build_commit_message(result)
     commit_env = _ensure_git_identity(repo, env)
@@ -344,12 +476,9 @@ def _commit_applied_patch(
         env=commit_env,
     )
     if commit.returncode != 0:
-        logger.warning(
-            "[geak apply] git commit failed (rc=%s): %s",
-            commit.returncode,
-            commit.stderr.strip(),
-        )
-        return None
+        stderr = commit.stderr.strip()
+        logger.warning("[geak apply] git commit failed (rc=%s): %s", commit.returncode, stderr)
+        return None, f"git commit rc={commit.returncode}: {stderr}" if stderr else f"git commit rc={commit.returncode}"
 
     sha = subprocess.run(
         ["git", "rev-parse", "HEAD"],
@@ -359,7 +488,7 @@ def _commit_applied_patch(
         check=False,
         env=env,
     )
-    return sha.stdout.strip() if sha.returncode == 0 else "HEAD"
+    return (sha.stdout.strip() if sha.returncode == 0 else "HEAD"), None
 
 
 def _build_commit_message(result: BestPatchResult) -> str:
@@ -385,49 +514,289 @@ def _build_commit_message(result: BestPatchResult) -> str:
 def _cleanup_artifacts(
     output_dir: Path,
     patch_path: Path | None,
-) -> None:
-    """Prune per-run artifacts, keeping only ``final_report.json`` and the winning ``.diff``.
+) -> str:
+    """Iterate-and-delete cleanup. Returns "ran" or "failed".
 
-    Lingering ``git worktree`` slots registered under ``output_dir`` are pruned
-    first via ``git worktree remove --force`` on each slot's owning repo (found
-    by reading the slot's ``.git`` gitfile) so the subsequent ``rmtree`` doesn't
-    leave dangling admin files behind.
+    Approach: move the winning patch (if nested) up to ``output_dir`` root,
+    prune lingering ``git worktree`` admin entries, then loop over
+    ``output_dir.iterdir()`` and delete every entry whose name is not in
+    the effective keep-set. The ``output_dir`` inode is never unlinked, so
+    the agent log's open ``FileHandler`` FD survives.
+
+    Per-entry exceptions are caught, logged, and counted. The loop never
+    aborts: if a worktree slot is locked or an NFS mount glitches, we still
+    finish removing everything else. The return value flips from ``"ran"``
+    to ``"failed"`` if any entry raised.
     """
     _prune_worktrees_under(output_dir)
 
-    final_report = output_dir / _FINAL_REPORT_NAME
+    # Move the winning patch up to output_dir root so the keep-set check
+    # operates uniformly on top-level entries.
+    kept_patch_name: str | None = None
+    if patch_path is not None and patch_path.is_file():
+        kept_patch_name = patch_path.name
+        target = output_dir / kept_patch_name
+        if patch_path != target:
+            try:
+                shutil.copy2(patch_path, target)
+            except OSError as exc:
+                logger.warning(
+                    "[geak --cleanup] Failed to copy winning patch %s to %s: %s",
+                    patch_path,
+                    target,
+                    exc,
+                )
+                kept_patch_name = None
 
-    with tempfile.TemporaryDirectory(prefix="geak_cleanup_") as tmp_str:
-        tmp = Path(tmp_str)
-        saved_report: Path | None = None
-        saved_patch: Path | None = None
+    keep_set: set[str] = set(_PRESERVED_FILES)
+    if kept_patch_name is not None:
+        keep_set.add(kept_patch_name)
 
-        if final_report.is_file():
-            saved_report = tmp / _FINAL_REPORT_NAME
-            shutil.copy2(final_report, saved_report)
-
-        if patch_path is not None and patch_path.is_file():
-            saved_patch = tmp / patch_path.name
-            shutil.copy2(patch_path, saved_patch)
-
+    failed = 0
+    for entry in list(output_dir.iterdir()):
+        if entry.name in keep_set:
+            continue
         try:
-            shutil.rmtree(output_dir)
+            if entry.is_symlink():
+                # Never recurse through a symlink-to-dir: rmtree would error
+                # or worse, follow into the target. unlink() removes just
+                # the symlink itself.
+                entry.unlink()
+            elif entry.is_dir():
+                shutil.rmtree(entry, ignore_errors=False)
+            else:
+                entry.unlink()
         except OSError as exc:
+            failed += 1
             logger.warning(
-                "[geak --cleanup] Failed to remove %s: %s. Retained summary files are preserved in %s.",
-                output_dir,
+                "[geak --cleanup] Failed to remove %s: %s (continuing).",
+                entry,
                 exc,
-                tmp,
             )
-            return
 
-        output_dir.mkdir(parents=True, exist_ok=True)
-        if saved_report is not None:
-            shutil.copy2(saved_report, output_dir / _FINAL_REPORT_NAME)
-        if saved_patch is not None:
-            shutil.copy2(saved_patch, output_dir / saved_patch.name)
+    _rewrite_kept_report(
+        output_dir,
+        (output_dir / kept_patch_name) if kept_patch_name is not None else None,
+    )
 
-    logger.info("[geak --cleanup] Pruned %s; kept final_report.json + best patch.", output_dir)
+    if failed:
+        logger.warning(
+            "[geak --cleanup] Completed with %d per-entry failure(s); kept %s.",
+            failed,
+            ", ".join(sorted(keep_set)),
+        )
+        return "failed"
+
+    logger.info(
+        "[geak --cleanup] Pruned %s; kept %s.",
+        output_dir,
+        ", ".join(sorted(keep_set)),
+    )
+    return "ran"
+
+
+def _rewrite_kept_report(output_dir: Path, kept_patch_path: Path | None) -> None:
+    """Rewrite paths in the kept ``final_report.json`` to match post-cleanup reality.
+
+    Uses a KEY ALLOW-LIST rather than a value-shape walk. ``final_report.json``
+    contains LLM-authored fields (``summary``, ``agent_summary``, etc.) that
+    routinely paste paths into free-text prose; a value-walk would mangle
+    them and break downstream consumers (e.g. ``record_optimization_outcome``
+    reads ``summary[:100]`` as a strategy name).
+
+    Rewrites:
+
+    - ``best_patch``: absolute path of the surviving file, or ``None`` when
+      no patch survived. Key is always present after this function returns.
+    - Other scalar keys in ``_SCALAR_PATH_KEYS`` and any key whose name ends
+      in ``_path`` / ``_dir`` / ``_file`` / ``_patch``: if the value resolves
+      under ``output_dir`` and the path no longer exists, replace with
+      ``{"path": <original>, "pruned": True}``.
+
+    Hard-skips ``_DOCUMENT_KEYS`` (and anything nested under them).
+    """
+    report_path = output_dir / _FINAL_REPORT_NAME
+    if not report_path.is_file():
+        return
+
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.warning("[geak --cleanup] Could not read %s for normalization: %s", report_path, exc)
+        return
+
+    if not isinstance(report, dict):
+        return
+
+    if kept_patch_path is not None:
+        report["best_patch"] = str(kept_patch_path.resolve())
+    else:
+        report["best_patch"] = None
+
+    output_dir_resolved = output_dir.resolve()
+
+    def _is_path_key(name: str) -> bool:
+        return name in _SCALAR_PATH_KEYS or name.endswith(_PATH_KEY_SUFFIXES)
+
+    def _rewrite_string(value: str) -> object:
+        if len(value) > _PATH_REWRITE_MAX_LEN:
+            return value
+        try:
+            resolved = Path(value).resolve()
+        except (OSError, ValueError):
+            return value
+        try:
+            resolved.relative_to(output_dir_resolved)
+        except ValueError:
+            # Outside output_dir -- external paths stay untouched.
+            return value
+        if resolved.exists():
+            return value
+        return {"path": value, "pruned": True}
+
+    def _walk(node: object, key_name: str | None) -> object:
+        # Hard-skip document keys: do not descend into them.
+        if key_name in _DOCUMENT_KEYS:
+            return node
+        if isinstance(node, dict):
+            return {k: _walk(v, k) for k, v in node.items()}
+        if isinstance(node, list):
+            # Lists inherit eligibility from the enclosing key. Only walk
+            # them if the key name itself looks like a path key (so e.g.
+            # `kernel_paths` would be walked, but `agent_summaries` would
+            # not). Practically every list-of-paths in final_report.json
+            # lives behind such a key.
+            if key_name is not None and _is_path_key(key_name):
+                return [_walk(item, key_name) for item in node]
+            return node
+        if isinstance(node, str) and key_name is not None and _is_path_key(key_name):
+            # Skip best_patch -- already set above by direct assignment.
+            if key_name == "best_patch":
+                return node
+            return _rewrite_string(node)
+        return node
+
+    rewritten = _walk(report, None)
+    assert isinstance(rewritten, dict)
+
+    try:
+        report_path.write_text(json.dumps(rewritten, indent=2), encoding="utf-8")
+    except OSError as exc:
+        logger.warning("[geak --cleanup] Could not write normalized %s: %s", report_path, exc)
+
+
+def prune_old_runs(
+    parent: Path,
+    keep: int,
+    *,
+    exclude: Path | None = None,
+    stale_after_s: float = 600.0,
+) -> int:
+    """Keep the N most recent auto-generated run dirs under ``parent``.
+
+    Returns the number of directories actually removed.
+
+    Behavior:
+
+    - Returns 0 cleanly when ``parent`` is missing or not a directory.
+    - Only touches directories whose name matches ``^.+_\\d{8}_\\d{6}$``
+      (the suffix ``generate_patch_output_dir`` emits). Anything else under
+      ``parent`` -- notes, unrelated dirs, files -- is left alone regardless
+      of mtime.
+    - Skips ``exclude`` even if it would otherwise be a delete candidate.
+    - Skips any dir whose effective freshness is within the last
+      ``stale_after_s`` seconds. Freshness key, first hit wins:
+
+      1. ``(dir / DEFAULT_LOG_FILENAME).stat().st_mtime`` if the log exists
+         (a long-running but actively-logging sibling looks fresh because
+         ``FileHandler`` bumps this on every line).
+      2. ``max(child.stat().st_mtime for child in dir.iterdir())`` if any
+         children remain.
+      3. ``dir.stat().st_mtime`` as a last-resort fallback (only bumped on
+         child create/rename/unlink in the dir, not on appends).
+
+    Never raises; per-dir failures are logged and counted as not-removed.
+    """
+    if keep < 0:
+        keep = 0
+    parent = Path(parent)
+    if not parent.is_dir():
+        return 0
+
+    exclude_resolved: Path | None = None
+    if exclude is not None:
+        try:
+            exclude_resolved = Path(exclude).resolve()
+        except (OSError, ValueError):
+            exclude_resolved = None
+
+    now = time.time()
+
+    candidates: list[tuple[float, Path]] = []
+    for entry in parent.iterdir():
+        if not entry.is_dir():
+            continue
+        if not _AUTO_RUN_DIR_RE.match(entry.name):
+            continue
+        if exclude_resolved is not None:
+            try:
+                if entry.resolve() == exclude_resolved:
+                    continue
+            except (OSError, ValueError):
+                pass
+        freshness = _freshness_mtime(entry)
+        if freshness is None:
+            # Unreadable dir; skip rather than risk deletion.
+            continue
+        if (now - freshness) < stale_after_s:
+            # Actively-fresh: protect against concurrent runs sharing
+            # ``parent``. The most-common case is another geak invocation
+            # currently writing to ``geak_agent.log``.
+            continue
+        candidates.append((freshness, entry))
+
+    if len(candidates) <= keep:
+        return 0
+
+    # Newest first; the tail past `keep` is the delete-list.
+    candidates.sort(key=lambda pair: pair[0], reverse=True)
+    to_delete = [path for _, path in candidates[keep:]]
+
+    removed = 0
+    for path in to_delete:
+        try:
+            shutil.rmtree(path)
+            removed += 1
+        except OSError as exc:
+            logger.warning("[geak --keep-runs] Failed to remove %s: %s", path, exc)
+    return removed
+
+
+def _freshness_mtime(run_dir: Path) -> float | None:
+    """Best-effort 'how recently was this dir touched' for the stale filter."""
+    log_path = run_dir / DEFAULT_LOG_FILENAME
+    try:
+        if log_path.is_file():
+            return log_path.stat().st_mtime
+    except OSError:
+        pass
+
+    try:
+        child_mtimes = []
+        for child in run_dir.iterdir():
+            try:
+                child_mtimes.append(child.stat().st_mtime)
+            except OSError:
+                continue
+        if child_mtimes:
+            return max(child_mtimes)
+    except OSError:
+        pass
+
+    try:
+        return run_dir.stat().st_mtime
+    except OSError:
+        return None
 
 
 def _iter_worktree_slots(output_dir: Path) -> list[Path]:

--- a/src/minisweagent/run/postprocess/finalize_apply.py
+++ b/src/minisweagent/run/postprocess/finalize_apply.py
@@ -1,20 +1,26 @@
-"""Post-run hook: apply the best patch to the user's repo, commit it, and cleanup.
+"""Post-run hooks: apply best patch + commit, and clean up run artifacts.
 
-Triggered by the ``--cleanup`` flag on the ``geak`` CLI. Responsible for:
+Exposes two independent operations and a coordinator:
 
-1. Applying the winning ``.diff`` (from ``BestPatchResult.best_patch_file``) to
-   ``--repo`` on the current branch, using the same ``git apply`` fallback
-   helper as the per-round eval worktree logic.
-2. Committing the result with a message that references the run's
-   ``final_report.json``.
-3. Pruning per-run artifacts while preserving ``final_report.json`` and the
-   winning ``.diff`` inside the original ``output_dir``.
+- ``apply_and_commit_best_patch(result, repo)`` -- applies the winning
+  ``.diff`` (from ``BestPatchResult.best_patch_file``) to ``repo`` on the
+  current branch using the same ``git apply`` fallback helper as the
+  per-round eval worktree logic, then commits with a message that points
+  at the run's ``final_report.json``.
+- ``cleanup_run_artifacts(result, output_dir)`` -- prunes per-run artifacts
+  while preserving ``final_report.json`` and the winning ``.diff`` inside
+  the original ``output_dir``. Independent of apply.
+- ``finalize_run(result, repo, output_dir, *, apply_best_patch, cleanup)``
+  -- CLI-level entry point that runs either/both according to the boolean
+  flags.
 
 Failure semantics:
 
-- Apply fails  -> no commit, no cleanup, output_dir untouched.
-- Commit fails -> no cleanup. Apply stays in the working tree so the user
-  can recover manually.
+- Apply fails  -> no commit. Cleanup still runs if requested (the winning
+  patch file is preserved in the summary, so the user can re-apply it by
+  hand).
+- Commit fails -> apply stays in the working tree. Cleanup still runs if
+  requested.
 - Cleanup fails -> the two retained files have already been copied to a
   safe temp location before ``rmtree`` runs, so we surface the error but
   never lose both summary and artifacts.
@@ -45,52 +51,89 @@ _DEFAULT_GIT_AUTHOR_NAME = "GEAK Agent"
 _DEFAULT_GIT_AUTHOR_EMAIL = "geak@amd.com"
 
 
-def apply_commit_and_cleanup(
+def apply_and_commit_best_patch(
     result: BestPatchResult | None,
     repo: Path | None,
-    output_dir: Path | None,
-) -> None:
-    """Apply ``result.best_patch_file`` to ``repo``, commit, and prune ``output_dir``.
+) -> str | None:
+    """Apply ``result.best_patch_file`` to ``repo`` and commit on the current branch.
 
-    This is best-effort: every step logs a clear reason before returning
-    early rather than raising, so a broken cleanup never masks the successful
-    optimisation run.
+    Returns the commit SHA on success, or ``None`` when a precondition fails
+    or any git step fails. Never raises; every failure is logged with a
+    clear reason so the caller can decide whether to proceed.
     """
-    if not _validate_preconditions(result, repo, output_dir):
-        return
+    if not _validate_apply_preconditions(result, repo):
+        return None
 
-    assert result is not None and repo is not None and output_dir is not None  # for type narrowing
+    assert result is not None and repo is not None  # for type narrowing
     repo = Path(repo).resolve()
-    output_dir = Path(output_dir).resolve()
     patch_path = Path(result.best_patch_file).resolve()  # type: ignore[arg-type]
 
     if not _repo_is_clean(repo):
         logger.warning(
-            "[geak --cleanup] Skipping: repo %s has uncommitted tracked changes. "
+            "[geak apply] Skipping: repo %s has uncommitted tracked changes. "
             "Commit or stash them first, then re-run apply manually.",
             repo,
         )
-        return
+        return None
 
     if not _apply_patch_to_repo(patch_path, repo):
-        return
+        return None
 
-    commit_sha = _commit_applied_patch(result, repo, output_dir)
+    commit_sha = _commit_applied_patch(result, repo)
     if commit_sha is None:
         logger.warning(
-            "[geak --cleanup] Commit failed; leaving applied changes in the working "
-            "tree of %s and skipping artifact cleanup.",
+            "[geak apply] Commit failed; leaving applied changes in the working tree of %s.",
             repo,
         )
+        return None
+
+    logger.info("[geak apply] Committed %s on %s.", commit_sha, repo)
+    return commit_sha
+
+
+def cleanup_run_artifacts(
+    result: BestPatchResult | None,
+    output_dir: Path | None,
+) -> None:
+    """Prune ``output_dir`` to just ``final_report.json`` + winning ``.diff``.
+
+    Independent of apply: it is safe to call this whether or not the patch
+    was applied/committed. If the patch file lives under ``output_dir`` it is
+    preserved across the rmtree so the user can always re-apply it by hand.
+    """
+    if not _validate_cleanup_preconditions(result, output_dir):
         return
 
-    _cleanup_artifacts(repo, output_dir, patch_path)
+    assert result is not None and output_dir is not None  # for type narrowing
+    output_dir = Path(output_dir).resolve()
+    patch_path = Path(result.best_patch_file).resolve() if result.best_patch_file else None
 
-    logger.info(
-        "[geak --cleanup] Done. Commit: %s  Retained artifacts: %s",
-        commit_sha,
-        output_dir,
-    )
+    _cleanup_artifacts(output_dir, patch_path)
+
+
+def finalize_run(
+    result: BestPatchResult | None,
+    repo: Path | None,
+    output_dir: Path | None,
+    *,
+    apply_best_patch: bool = True,
+    cleanup: bool = True,
+) -> None:
+    """CLI-level coordinator invoked from ``mini.py``.
+
+    ``apply_best_patch`` and ``cleanup`` are fully independent; either can
+    be toggled without affecting the other. If both are False, this is a
+    no-op (the caller shouldn't have called in the first place, but it's
+    safe).
+    """
+    if not apply_best_patch and not cleanup:
+        return
+
+    if apply_best_patch:
+        apply_and_commit_best_patch(result, repo)
+
+    if cleanup:
+        cleanup_run_artifacts(result, output_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -98,52 +141,50 @@ def apply_commit_and_cleanup(
 # ---------------------------------------------------------------------------
 
 
-def _validate_preconditions(  # pylint: disable=too-many-return-statements
+def _validate_apply_preconditions(  # pylint: disable=too-many-return-statements
     result: BestPatchResult | None,
     repo: Path | None,
-    output_dir: Path | None,
 ) -> bool:
     if result is None:
-        logger.warning("[geak --cleanup] Skipping: no BestPatchResult produced by the run.")
+        logger.warning("[geak apply] Skipping: no BestPatchResult produced by the run.")
         return False
     if not result.best_patch_file:
-        logger.warning("[geak --cleanup] Skipping: BestPatchResult has no best_patch_file.")
+        logger.warning("[geak apply] Skipping: BestPatchResult has no best_patch_file.")
         return False
     patch_path = Path(result.best_patch_file)
     if not patch_path.is_file():
-        logger.warning(
-            "[geak --cleanup] Skipping: best patch file does not exist: %s",
-            patch_path,
-        )
+        logger.warning("[geak apply] Skipping: best patch file does not exist: %s", patch_path)
         return False
     if patch_path.stat().st_size == 0:
-        logger.warning(
-            "[geak --cleanup] Skipping: best patch file is empty: %s",
-            patch_path,
-        )
+        logger.warning("[geak apply] Skipping: best patch file is empty: %s", patch_path)
         return False
     if repo is None:
-        logger.warning("[geak --cleanup] Skipping: no --repo resolved; cannot apply/commit.")
+        logger.warning("[geak apply] Skipping: no --repo resolved; cannot apply/commit.")
         return False
     repo = Path(repo)
     if not repo.exists():
-        logger.warning("[geak --cleanup] Skipping: repo path does not exist: %s", repo)
+        logger.warning("[geak apply] Skipping: repo path does not exist: %s", repo)
         return False
     if not (repo / ".git").exists():
-        logger.warning(
-            "[geak --cleanup] Skipping: %s is not a git repo (no .git). Cannot commit.",
-            repo,
-        )
+        logger.warning("[geak apply] Skipping: %s is not a git repo (no .git). Cannot commit.", repo)
         return False
+    return True
+
+
+def _validate_cleanup_preconditions(
+    result: BestPatchResult | None,
+    output_dir: Path | None,
+) -> bool:
     if output_dir is None:
         logger.warning("[geak --cleanup] Skipping: no output_dir provided.")
         return False
     if not Path(output_dir).exists():
-        logger.warning(
-            "[geak --cleanup] Skipping: output_dir does not exist: %s",
-            output_dir,
-        )
+        logger.warning("[geak --cleanup] Skipping: output_dir does not exist: %s", output_dir)
         return False
+    # ``result`` is optional for cleanup -- if present we use it to locate
+    # the winning patch file to preserve. Missing/empty result just means
+    # we fall back to preserving only ``final_report.json``.
+    del result
     return True
 
 
@@ -260,7 +301,6 @@ def _apply_patch_to_repo(patch_path: Path, repo: Path) -> bool:
 def _commit_applied_patch(
     result: BestPatchResult,
     repo: Path,
-    output_dir: Path,
 ) -> str | None:
     """Stage + commit the applied changes. Return commit SHA or None on failure."""
     env = get_git_safe_env(repo)
@@ -275,7 +315,7 @@ def _commit_applied_patch(
     )
     if add.returncode != 0:
         logger.warning(
-            "[geak --cleanup] git add -A failed (rc=%s): %s",
+            "[geak apply] git add -A failed (rc=%s): %s",
             add.returncode,
             add.stderr.strip(),
         )
@@ -290,12 +330,10 @@ def _commit_applied_patch(
         env=env,
     )
     if staged.returncode == 0 and not staged.stdout.strip():
-        logger.warning(
-            "[geak --cleanup] Patch applied cleanly but resulted in no staged changes. Skipping empty commit."
-        )
+        logger.warning("[geak apply] Patch applied cleanly but resulted in no staged changes. Skipping empty commit.")
         return None
 
-    message = _build_commit_message(result, output_dir)
+    message = _build_commit_message(result)
     commit_env = _ensure_git_identity(repo, env)
     commit = subprocess.run(
         ["git", "commit", "-m", message],
@@ -307,7 +345,7 @@ def _commit_applied_patch(
     )
     if commit.returncode != 0:
         logger.warning(
-            "[geak --cleanup] git commit failed (rc=%s): %s",
+            "[geak apply] git commit failed (rc=%s): %s",
             commit.returncode,
             commit.stderr.strip(),
         )
@@ -324,16 +362,17 @@ def _commit_applied_patch(
     return sha.stdout.strip() if sha.returncode == 0 else "HEAD"
 
 
-def _build_commit_message(result: BestPatchResult, output_dir: Path) -> str:
+def _build_commit_message(result: BestPatchResult) -> str:
     speedup = result.best_speedup
     speedup_str = f"{speedup:.4f}x" if isinstance(speedup, (int, float)) else "unknown"
     patch_id = result.patch_id or "unknown"
     title = f"geak: apply best patch ({patch_id}, {speedup_str})"
 
     body_lines: list[str] = []
-    report_path = output_dir / _FINAL_REPORT_NAME
-    body_lines.append(f"Report: {report_path}")
     if result.best_patch_file:
+        patch_path = Path(result.best_patch_file)
+        report_path = patch_path.parent / _FINAL_REPORT_NAME
+        body_lines.append(f"Report: {report_path}")
         body_lines.append(f"Patch:  {result.best_patch_file}")
     summary = (result.llm_conclusion or "").strip()
     if summary:
@@ -344,17 +383,17 @@ def _build_commit_message(result: BestPatchResult, output_dir: Path) -> str:
 
 
 def _cleanup_artifacts(
-    repo: Path,
     output_dir: Path,
-    patch_path: Path,
+    patch_path: Path | None,
 ) -> None:
     """Prune per-run artifacts, keeping only ``final_report.json`` and the winning ``.diff``.
 
-    Worktree slots registered with ``git worktree add`` under ``output_dir`` are
-    pruned first via ``git worktree remove --force`` so that the subsequent
-    ``rmtree`` does not leave dangling worktree administrative files behind.
+    Lingering ``git worktree`` slots registered under ``output_dir`` are pruned
+    first via ``git worktree remove --force`` on each slot's owning repo (found
+    by reading the slot's ``.git`` gitfile) so the subsequent ``rmtree`` doesn't
+    leave dangling admin files behind.
     """
-    _prune_worktrees_under(repo, output_dir)
+    _prune_worktrees_under(output_dir)
 
     final_report = output_dir / _FINAL_REPORT_NAME
 
@@ -367,7 +406,7 @@ def _cleanup_artifacts(
             saved_report = tmp / _FINAL_REPORT_NAME
             shutil.copy2(final_report, saved_report)
 
-        if patch_path.is_file():
+        if patch_path is not None and patch_path.is_file():
             saved_patch = tmp / patch_path.name
             shutil.copy2(patch_path, saved_patch)
 
@@ -391,57 +430,68 @@ def _cleanup_artifacts(
     logger.info("[geak --cleanup] Pruned %s; kept final_report.json + best patch.", output_dir)
 
 
-def _prune_worktrees_under(repo: Path, output_dir: Path) -> None:
+def _iter_worktree_slots(output_dir: Path) -> list[Path]:
+    """Return directories under ``output_dir`` that look like git worktrees.
+
+    A worktree slot has a ``.git`` *file* (not directory) whose contents point
+    at the owning repo's ``worktrees/<slug>`` admin directory.
+    """
+    slots: list[Path] = []
+    if not output_dir.is_dir():
+        return slots
+    for candidate in output_dir.rglob(".git"):
+        try:
+            if candidate.is_file():
+                slots.append(candidate.parent)
+        except OSError:
+            continue
+    return slots
+
+
+def _owning_repo_for_worktree(slot: Path) -> Path | None:
+    """Read the slot's ``.git`` gitfile to locate the owning main repo.
+
+    Returns the main repo root (two levels up from ``<repo>/.git/worktrees/<slug>``)
+    or ``None`` when the gitfile is malformed / the admin path is gone.
+    """
+    gitfile = slot / ".git"
+    try:
+        text = gitfile.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    prefix = "gitdir:"
+    if not text.startswith(prefix):
+        return None
+    admin_dir = Path(text[len(prefix) :].strip())
+    if not admin_dir.is_absolute():
+        admin_dir = (slot / admin_dir).resolve()
+    # admin_dir is <repo>/.git/worktrees/<slug>; walk up to <repo>.
+    if admin_dir.parent.name != "worktrees" or admin_dir.parent.parent.name != ".git":
+        return None
+    return admin_dir.parent.parent.parent
+
+
+def _prune_worktrees_under(output_dir: Path) -> None:
     """Remove git worktrees whose working directory is inside ``output_dir``."""
-    env = get_git_safe_env(repo)
-    listing = subprocess.run(
-        ["git", "worktree", "list", "--porcelain"],
-        cwd=str(repo),
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-    )
-    if listing.returncode != 0:
-        logger.debug(
-            "[geak --cleanup] git worktree list failed (rc=%s); skipping worktree prune.",
-            listing.returncode,
-        )
-        return
-
     output_dir_resolved = output_dir.resolve()
-    for block in listing.stdout.split("\n\n"):
-        for line in block.splitlines():
-            if not line.startswith("worktree "):
-                continue
-            wt_path = Path(line[len("worktree ") :].strip())
-            try:
-                wt_resolved = wt_path.resolve()
-            except OSError:
-                continue
-            if output_dir_resolved != wt_resolved and output_dir_resolved not in wt_resolved.parents:
-                continue
-            remove = subprocess.run(
-                ["git", "worktree", "remove", "--force", str(wt_path)],
-                cwd=str(repo),
-                capture_output=True,
-                text=True,
-                check=False,
-                env=env,
-            )
-            if remove.returncode != 0:
-                logger.debug(
-                    "[geak --cleanup] git worktree remove %s failed (rc=%s): %s",
-                    wt_path,
-                    remove.returncode,
-                    remove.stderr.strip(),
-                )
-
-    subprocess.run(
-        ["git", "worktree", "prune"],
-        cwd=str(repo),
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-    )
+    for slot in _iter_worktree_slots(output_dir_resolved):
+        repo = _owning_repo_for_worktree(slot)
+        if repo is None:
+            continue
+        env = get_git_safe_env(repo)
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(slot)],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+        subprocess.run(
+            ["git", "worktree", "prune"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )

--- a/src/minisweagent/run/postprocess/finalize_apply.py
+++ b/src/minisweagent/run/postprocess/finalize_apply.py
@@ -134,10 +134,7 @@ def apply_and_commit_best_patch_detailed(
     patch_path = Path(result.best_patch_file).resolve()  # type: ignore[arg-type]
 
     if not _repo_is_clean(repo):
-        reason = (
-            f"repo {repo} has uncommitted tracked changes. "
-            "Commit or stash them first, then re-run apply manually."
-        )
+        reason = f"repo {repo} has uncommitted tracked changes. Commit or stash them first, then re-run apply manually."
         logger.warning("[geak apply] Skipping: %s", reason)
         return {"status": "skipped_dirty", "commit_sha": None, "reason": reason}
 
@@ -189,11 +186,7 @@ def cleanup_run_artifacts(
 
     assert output_dir is not None  # for type narrowing
     output_dir = Path(output_dir).resolve()
-    patch_path = (
-        Path(result.best_patch_file).resolve()
-        if (result is not None and result.best_patch_file)
-        else None
-    )
+    patch_path = Path(result.best_patch_file).resolve() if (result is not None and result.best_patch_file) else None
 
     return _cleanup_artifacts(output_dir, patch_path)
 
@@ -303,11 +296,7 @@ def _validate_cleanup_preconditions(
         return False
 
     has_report = (output_dir_path / _FINAL_REPORT_NAME).is_file()
-    has_patch = bool(
-        result is not None
-        and result.best_patch_file
-        and Path(result.best_patch_file).is_file()
-    )
+    has_patch = bool(result is not None and result.best_patch_file and Path(result.best_patch_file).is_file())
     if not (has_report or has_patch):
         logger.warning(
             "[geak --cleanup] Skipping: %s has neither %s nor a winning patch; "
@@ -426,7 +415,11 @@ def _apply_patch_to_repo(patch_path: Path, repo: Path) -> tuple[bool, str | None
             apply_result.returncode,
             stderr_tail,
         )
-        reason = f"git apply rc={apply_result.returncode}: {stderr_tail}" if stderr_tail else f"git apply rc={apply_result.returncode}"
+        reason = (
+            f"git apply rc={apply_result.returncode}: {stderr_tail}"
+            if stderr_tail
+            else f"git apply rc={apply_result.returncode}"
+        )
         return False, reason
 
     logger.info("[geak --cleanup] Applied %s to %s", patch_path, repo)

--- a/src/minisweagent/run/postprocess/finalize_apply.py
+++ b/src/minisweagent/run/postprocess/finalize_apply.py
@@ -1,0 +1,447 @@
+"""Post-run hook: apply the best patch to the user's repo, commit it, and cleanup.
+
+Triggered by the ``--cleanup`` flag on the ``geak`` CLI. Responsible for:
+
+1. Applying the winning ``.diff`` (from ``BestPatchResult.best_patch_file``) to
+   ``--repo`` on the current branch, using the same ``git apply`` fallback
+   helper as the per-round eval worktree logic.
+2. Committing the result with a message that references the run's
+   ``final_report.json``.
+3. Pruning per-run artifacts while preserving ``final_report.json`` and the
+   winning ``.diff`` inside the original ``output_dir``.
+
+Failure semantics:
+
+- Apply fails  -> no commit, no cleanup, output_dir untouched.
+- Commit fails -> no cleanup. Apply stays in the working tree so the user
+  can recover manually.
+- Cleanup fails -> the two retained files have already been copied to a
+  safe temp location before ``rmtree`` runs, so we surface the error but
+  never lose both summary and artifacts.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from minisweagent.agents.parallel_agent import BestPatchResult
+from minisweagent.run.utils.generated_artifacts import apply_patch_with_generated_helper_fallback
+from minisweagent.run.utils.git_safe_env import get_git_safe_env
+
+logger = logging.getLogger(__name__)
+
+
+_FINAL_REPORT_NAME = "final_report.json"
+
+# Defaults used when the container / host has no configured git identity.
+# Override via the ``GEAK_GIT_AUTHOR_NAME`` / ``GEAK_GIT_AUTHOR_EMAIL`` env
+# vars (set at container run time or by the developer).
+_DEFAULT_GIT_AUTHOR_NAME = "GEAK Agent"
+_DEFAULT_GIT_AUTHOR_EMAIL = "geak@amd.com"
+
+
+def apply_commit_and_cleanup(
+    result: BestPatchResult | None,
+    repo: Path | None,
+    output_dir: Path | None,
+) -> None:
+    """Apply ``result.best_patch_file`` to ``repo``, commit, and prune ``output_dir``.
+
+    This is best-effort: every step logs a clear reason before returning
+    early rather than raising, so a broken cleanup never masks the successful
+    optimisation run.
+    """
+    if not _validate_preconditions(result, repo, output_dir):
+        return
+
+    assert result is not None and repo is not None and output_dir is not None  # for type narrowing
+    repo = Path(repo).resolve()
+    output_dir = Path(output_dir).resolve()
+    patch_path = Path(result.best_patch_file).resolve()  # type: ignore[arg-type]
+
+    if not _repo_is_clean(repo):
+        logger.warning(
+            "[geak --cleanup] Skipping: repo %s has uncommitted tracked changes. "
+            "Commit or stash them first, then re-run apply manually.",
+            repo,
+        )
+        return
+
+    if not _apply_patch_to_repo(patch_path, repo):
+        return
+
+    commit_sha = _commit_applied_patch(result, repo, output_dir)
+    if commit_sha is None:
+        logger.warning(
+            "[geak --cleanup] Commit failed; leaving applied changes in the working "
+            "tree of %s and skipping artifact cleanup.",
+            repo,
+        )
+        return
+
+    _cleanup_artifacts(repo, output_dir, patch_path)
+
+    logger.info(
+        "[geak --cleanup] Done. Commit: %s  Retained artifacts: %s",
+        commit_sha,
+        output_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _validate_preconditions(  # pylint: disable=too-many-return-statements
+    result: BestPatchResult | None,
+    repo: Path | None,
+    output_dir: Path | None,
+) -> bool:
+    if result is None:
+        logger.warning("[geak --cleanup] Skipping: no BestPatchResult produced by the run.")
+        return False
+    if not result.best_patch_file:
+        logger.warning("[geak --cleanup] Skipping: BestPatchResult has no best_patch_file.")
+        return False
+    patch_path = Path(result.best_patch_file)
+    if not patch_path.is_file():
+        logger.warning(
+            "[geak --cleanup] Skipping: best patch file does not exist: %s",
+            patch_path,
+        )
+        return False
+    if patch_path.stat().st_size == 0:
+        logger.warning(
+            "[geak --cleanup] Skipping: best patch file is empty: %s",
+            patch_path,
+        )
+        return False
+    if repo is None:
+        logger.warning("[geak --cleanup] Skipping: no --repo resolved; cannot apply/commit.")
+        return False
+    repo = Path(repo)
+    if not repo.exists():
+        logger.warning("[geak --cleanup] Skipping: repo path does not exist: %s", repo)
+        return False
+    if not (repo / ".git").exists():
+        logger.warning(
+            "[geak --cleanup] Skipping: %s is not a git repo (no .git). Cannot commit.",
+            repo,
+        )
+        return False
+    if output_dir is None:
+        logger.warning("[geak --cleanup] Skipping: no output_dir provided.")
+        return False
+    if not Path(output_dir).exists():
+        logger.warning(
+            "[geak --cleanup] Skipping: output_dir does not exist: %s",
+            output_dir,
+        )
+        return False
+    return True
+
+
+def _has_git_identity(repo: Path, env: dict[str, str]) -> bool:
+    """Return True if ``user.name`` AND ``user.email`` are resolvable for ``repo``.
+
+    ``git config --get`` walks the full precedence chain (env -> local -> global -> system),
+    so this correctly mirrors what ``git commit`` would see.
+    """
+    for key in ("user.name", "user.email"):
+        proc = subprocess.run(
+            ["git", "config", "--get", key],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return False
+    return True
+
+
+def _ensure_git_identity(repo: Path, env: dict[str, str]) -> dict[str, str]:
+    """Return an env dict guaranteed to carry a git author/committer identity.
+
+    Precedence (first non-empty wins):
+
+    1. Existing ``GIT_AUTHOR_*`` / ``GIT_COMMITTER_*`` env vars (respected as-is).
+    2. An already-configured ``user.name`` + ``user.email`` (local/global/system).
+    3. ``GEAK_GIT_AUTHOR_NAME`` / ``GEAK_GIT_AUTHOR_EMAIL`` env vars.
+    4. Hard-coded defaults (``GEAK Agent <geak@amd.com>``).
+
+    The returned env is only applied to the commit subprocess; global and repo
+    git config are never mutated, so this is safe on the user's machine.
+    """
+    commit_env = dict(env)
+
+    author_name = commit_env.get("GIT_AUTHOR_NAME")
+    author_email = commit_env.get("GIT_AUTHOR_EMAIL")
+    committer_name = commit_env.get("GIT_COMMITTER_NAME")
+    committer_email = commit_env.get("GIT_COMMITTER_EMAIL")
+
+    if author_name and author_email and committer_name and committer_email:
+        return commit_env
+
+    if _has_git_identity(repo, commit_env):
+        return commit_env
+
+    name = author_name or committer_name or os.environ.get("GEAK_GIT_AUTHOR_NAME") or _DEFAULT_GIT_AUTHOR_NAME
+    email = author_email or committer_email or os.environ.get("GEAK_GIT_AUTHOR_EMAIL") or _DEFAULT_GIT_AUTHOR_EMAIL
+
+    commit_env.setdefault("GIT_AUTHOR_NAME", name)
+    commit_env.setdefault("GIT_AUTHOR_EMAIL", email)
+    commit_env.setdefault("GIT_COMMITTER_NAME", name)
+    commit_env.setdefault("GIT_COMMITTER_EMAIL", email)
+
+    logger.info(
+        "[geak --cleanup] No git identity configured; committing as %s <%s> "
+        "(override via GEAK_GIT_AUTHOR_NAME / GEAK_GIT_AUTHOR_EMAIL).",
+        name,
+        email,
+    )
+    return commit_env
+
+
+def _repo_is_clean(repo: Path) -> bool:
+    """Return True if the tracked working tree + index are clean."""
+    env = get_git_safe_env(repo)
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    if result.returncode != 0:
+        logger.warning(
+            "[geak --cleanup] git status failed (rc=%s): %s",
+            result.returncode,
+            result.stderr.strip(),
+        )
+        return False
+    return not result.stdout.strip()
+
+
+def _apply_patch_to_repo(patch_path: Path, repo: Path) -> bool:
+    patch_text = patch_path.read_text(encoding="utf-8", errors="replace")
+    env = get_git_safe_env(repo)
+
+    apply_result, removed_paths = apply_patch_with_generated_helper_fallback(
+        patch_text=patch_text,
+        cwd=repo,
+        env=env,
+    )
+    if removed_paths:
+        logger.info(
+            "[geak --cleanup] Stripped generated helper artifacts during apply: %s",
+            ", ".join(removed_paths),
+        )
+    if apply_result.returncode != 0:
+        logger.warning(
+            "[geak --cleanup] git apply failed (rc=%s); leaving repo and artifacts untouched.\nstderr: %s",
+            apply_result.returncode,
+            apply_result.stderr.strip()[:1000],
+        )
+        return False
+
+    logger.info("[geak --cleanup] Applied %s to %s", patch_path, repo)
+    return True
+
+
+def _commit_applied_patch(
+    result: BestPatchResult,
+    repo: Path,
+    output_dir: Path,
+) -> str | None:
+    """Stage + commit the applied changes. Return commit SHA or None on failure."""
+    env = get_git_safe_env(repo)
+
+    add = subprocess.run(
+        ["git", "add", "-A"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    if add.returncode != 0:
+        logger.warning(
+            "[geak --cleanup] git add -A failed (rc=%s): %s",
+            add.returncode,
+            add.stderr.strip(),
+        )
+        return None
+
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    if staged.returncode == 0 and not staged.stdout.strip():
+        logger.warning(
+            "[geak --cleanup] Patch applied cleanly but resulted in no staged changes. Skipping empty commit."
+        )
+        return None
+
+    message = _build_commit_message(result, output_dir)
+    commit_env = _ensure_git_identity(repo, env)
+    commit = subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=commit_env,
+    )
+    if commit.returncode != 0:
+        logger.warning(
+            "[geak --cleanup] git commit failed (rc=%s): %s",
+            commit.returncode,
+            commit.stderr.strip(),
+        )
+        return None
+
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    return sha.stdout.strip() if sha.returncode == 0 else "HEAD"
+
+
+def _build_commit_message(result: BestPatchResult, output_dir: Path) -> str:
+    speedup = result.best_speedup
+    speedup_str = f"{speedup:.4f}x" if isinstance(speedup, (int, float)) else "unknown"
+    patch_id = result.patch_id or "unknown"
+    title = f"geak: apply best patch ({patch_id}, {speedup_str})"
+
+    body_lines: list[str] = []
+    report_path = output_dir / _FINAL_REPORT_NAME
+    body_lines.append(f"Report: {report_path}")
+    if result.best_patch_file:
+        body_lines.append(f"Patch:  {result.best_patch_file}")
+    summary = (result.llm_conclusion or "").strip()
+    if summary:
+        body_lines.append("")
+        body_lines.append(summary[:1000])
+
+    return title + "\n\n" + "\n".join(body_lines) + "\n"
+
+
+def _cleanup_artifacts(
+    repo: Path,
+    output_dir: Path,
+    patch_path: Path,
+) -> None:
+    """Prune per-run artifacts, keeping only ``final_report.json`` and the winning ``.diff``.
+
+    Worktree slots registered with ``git worktree add`` under ``output_dir`` are
+    pruned first via ``git worktree remove --force`` so that the subsequent
+    ``rmtree`` does not leave dangling worktree administrative files behind.
+    """
+    _prune_worktrees_under(repo, output_dir)
+
+    final_report = output_dir / _FINAL_REPORT_NAME
+
+    with tempfile.TemporaryDirectory(prefix="geak_cleanup_") as tmp_str:
+        tmp = Path(tmp_str)
+        saved_report: Path | None = None
+        saved_patch: Path | None = None
+
+        if final_report.is_file():
+            saved_report = tmp / _FINAL_REPORT_NAME
+            shutil.copy2(final_report, saved_report)
+
+        if patch_path.is_file():
+            saved_patch = tmp / patch_path.name
+            shutil.copy2(patch_path, saved_patch)
+
+        try:
+            shutil.rmtree(output_dir)
+        except OSError as exc:
+            logger.warning(
+                "[geak --cleanup] Failed to remove %s: %s. Retained summary files are preserved in %s.",
+                output_dir,
+                exc,
+                tmp,
+            )
+            return
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if saved_report is not None:
+            shutil.copy2(saved_report, output_dir / _FINAL_REPORT_NAME)
+        if saved_patch is not None:
+            shutil.copy2(saved_patch, output_dir / saved_patch.name)
+
+    logger.info("[geak --cleanup] Pruned %s; kept final_report.json + best patch.", output_dir)
+
+
+def _prune_worktrees_under(repo: Path, output_dir: Path) -> None:
+    """Remove git worktrees whose working directory is inside ``output_dir``."""
+    env = get_git_safe_env(repo)
+    listing = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    if listing.returncode != 0:
+        logger.debug(
+            "[geak --cleanup] git worktree list failed (rc=%s); skipping worktree prune.",
+            listing.returncode,
+        )
+        return
+
+    output_dir_resolved = output_dir.resolve()
+    for block in listing.stdout.split("\n\n"):
+        for line in block.splitlines():
+            if not line.startswith("worktree "):
+                continue
+            wt_path = Path(line[len("worktree ") :].strip())
+            try:
+                wt_resolved = wt_path.resolve()
+            except OSError:
+                continue
+            if output_dir_resolved != wt_resolved and output_dir_resolved not in wt_resolved.parents:
+                continue
+            remove = subprocess.run(
+                ["git", "worktree", "remove", "--force", str(wt_path)],
+                cwd=str(repo),
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+            if remove.returncode != 0:
+                logger.debug(
+                    "[geak --cleanup] git worktree remove %s failed (rc=%s): %s",
+                    wt_path,
+                    remove.returncode,
+                    remove.stderr.strip(),
+                )
+
+    subprocess.run(
+        ["git", "worktree", "prune"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )

--- a/src/minisweagent/tools/profiling_tools.py
+++ b/src/minisweagent/tools/profiling_tools.py
@@ -30,9 +30,25 @@ class ProfilingAnalyzer:
         ]
 
     def cleanup(self):
-        """Remove the temporary profiling output directory."""
+        """Remove the temporary profiling output directory.
+
+        Kept public for any out-of-tree caller that didn't migrate to the
+        context-manager protocol below. New in-tree callers should prefer
+        ``with ProfilingAnalyzer(...) as analyzer:`` so the temp dir
+        cleanup is automatic and exception-safe.
+        """
         if self.output_path.exists():
             shutil.rmtree(self.output_path, ignore_errors=True)
+
+    def __enter__(self) -> "ProfilingAnalyzer":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        # Always run cleanup -- ``shutil.rmtree(..., ignore_errors=True)``
+        # never raises, so we don't risk masking an in-progress exception.
+        # Returning None (or False) means __exit__ does not suppress
+        # exceptions raised inside the ``with`` block.
+        self.cleanup()
 
     def _check_rocprof_compute(self):
         result_rocprof = subprocess.run(["rocprof-compute --version"], capture_output=True, text=True, shell=True)

--- a/tests/run/test_budget.py
+++ b/tests/run/test_budget.py
@@ -79,19 +79,22 @@ def test_deadline_cap_returns_zero_when_softstop_is_set():
 
 
 def test_commit_preprocess_under_cap_rolls_into_optimization():
-    """Preprocess under the soft cap leaves more time for optimization."""
-    budget = RunBudget(spec=_spec(total_s=10.0, soft_cap_s=2.0))
+    """Preprocess under the soft cap leaves more time for optimization.
+
+    Formula: ``opt_budget = max(0, total_s - kill_buffer_s - preprocess_actual)``.
+    """
+    budget = RunBudget(spec=_spec(total_s=10.0, soft_cap_s=2.0, kill_buffer_s=1.0))
     deadline = budget.commit_preprocess(actual_preprocess_s=1.0)
-    # opt budget = 10 - 1 = 9s remaining
-    assert deadline.remaining() == pytest.approx(9.0, abs=0.5)
+    # opt budget = 10 - 1 (kill_buffer) - 1 (preprocess) = 8s remaining
+    assert deadline.remaining() == pytest.approx(8.0, abs=0.5)
 
 
 def test_commit_preprocess_over_cap_borrows_from_optimization():
     """Preprocess overrunning soft cap shrinks opt; budget arithmetic handles it."""
-    budget = RunBudget(spec=_spec(total_s=10.0, soft_cap_s=2.0))
+    budget = RunBudget(spec=_spec(total_s=10.0, soft_cap_s=2.0, kill_buffer_s=1.0))
     deadline = budget.commit_preprocess(actual_preprocess_s=4.0)
-    # opt budget = 10 - 4 = 6s remaining
-    assert deadline.remaining() == pytest.approx(6.0, abs=0.5)
+    # opt budget = 10 - 1 (kill_buffer) - 4 (preprocess) = 5s remaining
+    assert deadline.remaining() == pytest.approx(5.0, abs=0.5)
 
 
 def test_commit_preprocess_at_or_past_total_clamps_to_zero():
@@ -107,10 +110,10 @@ def test_commit_preprocess_at_or_past_total_clamps_to_zero():
 
 def test_commit_preprocess_negative_actual_clamps_to_zero():
     """Defensive: negative actual_preprocess_s is treated as zero."""
-    budget = RunBudget(spec=_spec(total_s=10.0))
+    budget = RunBudget(spec=_spec(total_s=10.0, kill_buffer_s=1.0))
     deadline = budget.commit_preprocess(actual_preprocess_s=-5.0)
-    # opt budget = 10 - max(0, -5) = 10
-    assert deadline.remaining() == pytest.approx(10.0, abs=0.5)
+    # opt budget = 10 - 1 (kill_buffer) - max(0, -5) = 9
+    assert deadline.remaining() == pytest.approx(9.0, abs=0.5)
 
 
 def test_commit_preprocess_transitions_phase_to_optimization():
@@ -127,14 +130,13 @@ def test_commit_preprocess_transitions_phase_to_optimization():
 
 def test_optimization_watchdog_flips_soft_stop_on_schedule():
     """At softstop_at = opt_deadline - finalize_grace, soft_stop is set."""
-    # 200ms total, 100ms grace -> soft_stop fires at 100ms. Use generous
-    # buffer (300ms) for thread scheduling jitter.
     spec = BudgetSpec(
         mode="quick",
         total_s=10.0,
         preprocess_soft_cap_s=2.0,
         preprocess_hard_cap_fraction=0.5,
         finalize_grace_s=0.1,
+        kill_buffer_s=0.0,  # don't reserve buffer from the tiny opt window
     )
     budget = RunBudget(spec=spec)
     # Pretend preprocess used (10 - 0.2) = 9.8s, leaving 0.2s for opt.
@@ -211,8 +213,9 @@ def test_cancel_all_timers_idempotent():
 # ---------------------------------------------------------------------------
 
 
-def test_hard_kill_watchdog_fires_at_opt_deadline_plus_kill_buffer():
-    """The hard-kill watchdog must fire at ``opt_deadline + kill_buffer_s``.
+def test_hard_kill_watchdog_fires_at_started_at_plus_total_s():
+    """The hard-kill watchdog must fire at ``started_at + total_s`` -- the
+    absolute wall-clock cap, NOT derived from ``opt_deadline + kill_buffer_s``.
 
     This is the backstop that protects against a sub-agent stuck inside a
     long-running ``subprocess.run`` (e.g. a 30-min benchmark) that never
@@ -227,7 +230,7 @@ def test_hard_kill_watchdog_fires_at_opt_deadline_plus_kill_buffer():
         kill_buffer_s=0.1,
     )
     budget = RunBudget(spec=spec)
-    # Pretend preprocess used effectively no time so opt_deadline = now + 0.5s.
+    # Pretend preprocess used effectively no time so the absolute cap is now + 0.5s.
     budget.commit_preprocess(actual_preprocess_s=0.0)
     budget.schedule_optimization_watchdog()
 
@@ -237,7 +240,7 @@ def test_hard_kill_watchdog_fires_at_opt_deadline_plus_kill_buffer():
         fired.set()
 
     budget.schedule_optimization_hard_kill_watchdog(_on_kill)
-    # Should fire at opt_deadline (0.5s) + kill_buffer (0.1s) = 0.6s.
+    # Should fire at started_at + total_s = ~0.5s from start.
     # Generous timeout for thread scheduling jitter on shared CI.
     assert fired.wait(timeout=2.0), "hard-kill watchdog should have fired by now"
     budget.cancel_all_timers()

--- a/tests/run/test_budget_arithmetic.py
+++ b/tests/run/test_budget_arithmetic.py
@@ -1,0 +1,142 @@
+"""Tests for the wall-clock cap arithmetic in ``RunBudget``.
+
+The single load-bearing invariant: hard-kill fires at exactly
+``started_at + total_s``, regardless of how preprocess plays out. The
+``commit_preprocess`` ``kill_buffer_s`` subtraction is cooperative
+headroom only; it must never alter the cap.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from minisweagent.run.budget import BudgetSpec, RunBudget
+
+
+def _spec(total_s: float = 10.0, kill_buffer_s: float = 2.0) -> BudgetSpec:
+    return BudgetSpec(
+        mode="quick",
+        total_s=total_s,
+        preprocess_soft_cap_s=2.0,
+        preprocess_hard_cap_fraction=0.5,
+        finalize_grace_s=1.0,
+        kill_buffer_s=kill_buffer_s,
+    )
+
+
+def _captured_kill_timer(budget: RunBudget):
+    """Return the threading.Timer object scheduled by the hard-kill watchdog."""
+    matches = [t for t in budget._timers if t.name == "geak-optimization-hard-kill"]
+    assert len(matches) == 1, f"expected exactly one hard-kill timer, got {matches}"
+    return matches[0]
+
+
+def test_hard_kill_fires_at_total_s_happy_path() -> None:
+    """Short preprocess: hard-kill timer fires exactly total_s after started_at."""
+    spec = _spec(total_s=10.0, kill_buffer_s=2.0)
+    budget = RunBudget(spec=spec)
+    started_at = budget.started_at
+
+    # Simulate 3 s of preprocess elapsed.
+    budget.commit_preprocess(actual_preprocess_s=3.0)
+    schedule_time = time.monotonic()
+    budget.schedule_optimization_hard_kill_watchdog(on_kill=lambda: None)
+
+    timer = _captured_kill_timer(budget)
+    expected_delay = (started_at + spec.total_s) - schedule_time
+    # Timer.interval is set from the kill_delay_s we passed; epsilon for
+    # scheduling jitter between commit_preprocess and the watchdog scheduling.
+    assert timer.interval == pytest.approx(expected_delay, abs=0.05)
+
+    budget.cancel_all_timers()
+
+
+def test_hard_kill_fires_at_total_s_even_when_preprocess_overran(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulate wall-clock advance to ``started_at + total_s`` during
+    preprocess. The hard-kill timer must anchor on ``started_at + total_s``
+    (so its interval from "now" is near zero), NOT on
+    ``opt_deadline_at + kill_buffer_s`` (which would push it ``kill_buffer_s``
+    past the cap -- exactly the bug we're guarding against).
+    """
+    import minisweagent.run.budget as budget_mod
+
+    real_monotonic = time.monotonic
+    started_at = real_monotonic()
+    # Pretend ``total_s`` has fully elapsed by the time commit_preprocess +
+    # schedule_optimization_hard_kill_watchdog run.
+    now = {"t": started_at + 10.0}
+
+    def fake_monotonic() -> float:
+        return now["t"]
+
+    monkeypatch.setattr(budget_mod.time, "monotonic", fake_monotonic)
+
+    spec = _spec(total_s=10.0, kill_buffer_s=2.0)
+    # Build the budget with the fake clock active so started_at is captured
+    # from the fake clock (avoids drift between real and fake started_at).
+    monkeypatch.setattr(
+        budget_mod,
+        "time",
+        type("FakeTime", (), {"monotonic": staticmethod(fake_monotonic)})(),
+    )
+    # Re-import-style reset: easier to construct RunBudget with explicit
+    # started_at instead.
+    budget = RunBudget(spec=spec, started_at=started_at)
+
+    budget.commit_preprocess(actual_preprocess_s=spec.total_s)
+    budget.schedule_optimization_hard_kill_watchdog(on_kill=lambda: None)
+
+    timer = _captured_kill_timer(budget)
+    # absolute_kill_at - now == (started_at + total_s) - (started_at + total_s) == 0
+    assert timer.interval == pytest.approx(0.0, abs=0.05)
+    # Crucially: NOT kill_buffer_s. That would mean the cap slipped.
+    assert timer.interval < spec.kill_buffer_s
+
+    budget.cancel_all_timers()
+
+
+def test_commit_preprocess_clamps_opt_budget_to_zero_when_overrun() -> None:
+    """preprocess_actual > total_s - kill_buffer_s clamps opt_budget to 0."""
+    spec = _spec(total_s=10.0, kill_buffer_s=2.0)
+    budget = RunBudget(spec=spec)
+    budget.commit_preprocess(actual_preprocess_s=15.0)
+    # opt_deadline_at lands at monotonic_now (opt_budget_s == 0).
+    assert budget._opt_deadline_at is not None
+    assert (budget._opt_deadline_at - time.monotonic()) <= 0.05
+    budget.cancel_all_timers()
+
+
+def test_commit_preprocess_reserves_kill_buffer_in_happy_path() -> None:
+    """Short preprocess: cooperative opt_budget reserves kill_buffer_s.
+
+    In production ``time.monotonic()`` at commit time is
+    ``started_at + actual_preprocess_s``, so opt_deadline lands at
+    ``started_at + total_s - kill_buffer_s``. The test (no real clock
+    advance) verifies the formula directly: ``opt_deadline_at - now`` must
+    equal ``total_s - kill_buffer_s - actual_preprocess_s``.
+    """
+    spec = _spec(total_s=10.0, kill_buffer_s=2.0)
+    budget = RunBudget(spec=spec)
+    budget.commit_preprocess(actual_preprocess_s=3.0)
+    commit_time = time.monotonic()
+    assert budget._opt_deadline_at is not None
+    remaining_budget = budget._opt_deadline_at - commit_time
+    expected = spec.total_s - spec.kill_buffer_s - 3.0  # 10 - 2 - 3 = 5
+    assert remaining_budget == pytest.approx(expected, abs=0.05)
+    budget.cancel_all_timers()
+
+
+def test_banner_lines_advertises_kill_buffer() -> None:
+    """Structural check: banner mentions total= and kill_buffer= so operators
+    can correlate cap arithmetic from the log."""
+    spec = _spec(total_s=10.0, kill_buffer_s=2.0)
+    budget = RunBudget(spec=spec)
+    lines = budget.banner_lines()
+    text = "\n".join(lines)
+    assert f"total={spec.total_s:.0f}s" in text
+    assert f"kill_buffer={spec.kill_buffer_s:.0f}s" in text
+    budget.cancel_all_timers()

--- a/tests/run/test_finalize_apply.py
+++ b/tests/run/test_finalize_apply.py
@@ -1,0 +1,468 @@
+"""Unit tests for ``minisweagent.run.postprocess.finalize_apply``.
+
+Exercises the ``apply_commit_and_cleanup`` hook end-to-end against a real
+temporary git repo, covering:
+
+- Happy path (apply + commit + cleanup keeps final_report.json + .diff).
+- Dirty-repo refusal (no apply, no cleanup).
+- Apply failure (no commit, no cleanup).
+- Commit failure (apply stays, no cleanup).
+"""
+
+# pytest fixtures legitimately shadow their names when injected into tests.
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from minisweagent.agents.parallel_agent import BestPatchResult
+from minisweagent.run.postprocess import finalize_apply
+from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A fresh git repo with one tracked file and an initial commit."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _git(repo_dir, "init", "--initial-branch=main")
+    _git(repo_dir, "config", "user.email", "test@example.com")
+    _git(repo_dir, "config", "user.name", "Test")
+
+    (repo_dir / "kernel.py").write_text("def run():\n    return 0\n")
+    _git(repo_dir, "add", "kernel.py")
+    _git(repo_dir, "commit", "-m", "initial")
+    return repo_dir
+
+
+@pytest.fixture
+def good_patch(repo: Path) -> str:
+    """Generate a real diff that applies cleanly to ``repo``."""
+    (repo / "kernel.py").write_text("def run():\n    return 42\n")
+    diff = subprocess.run(
+        ["git", "diff"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    # Revert the working tree so the test starts from the clean committed state.
+    _git(repo, "checkout", "--", "kernel.py")
+    return diff
+
+
+@pytest.fixture
+def output_dir(tmp_path: Path, good_patch: str) -> Path:
+    """A populated per-run output_dir with final_report.json, a winning .diff, and noise."""
+    out = tmp_path / "optimization_logs" / "kernel_20260101_000000"
+    out.mkdir(parents=True)
+    (out / "final_report.json").write_text(json.dumps({"best_speedup": 1.5, "summary": "ok"}))
+    (out / "best_patch.diff").write_text(good_patch)
+
+    # Noise we expect cleanup to prune.
+    (out / "logs").mkdir()
+    (out / "logs" / "run.log").write_text("noisy log content\n")
+    (out / "results").mkdir()
+    (out / "results" / "round_1").mkdir()
+    (out / "results" / "round_1" / "best_results.json").write_text("{}")
+    return out
+
+
+def _result_for(output_dir: Path, patch_name: str = "best_patch.diff") -> BestPatchResult:
+    return BestPatchResult(
+        agent_id=0,
+        patch_id="winning_patch",
+        test_output="",
+        best_speedup=1.5,
+        best_patch_file=str(output_dir / patch_name),
+        patch_dir=output_dir,
+        llm_conclusion="Fused reduction tree and eliminated redundant loads.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_applies_commits_and_cleans(repo: Path, output_dir: Path) -> None:
+    result = _result_for(output_dir)
+
+    apply_commit_and_cleanup(result, repo, output_dir)
+
+    # Commit was created on top of "initial"
+    log = (
+        subprocess.run(
+            ["git", "log", "--oneline"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        .stdout.strip()
+        .splitlines()
+    )
+    assert len(log) == 2
+    assert "geak: apply best patch" in log[0]
+    assert "winning_patch" in log[0]
+
+    # Working tree reflects the applied change.
+    assert (repo / "kernel.py").read_text() == "def run():\n    return 42\n"
+
+    # Summary files retained, everything else pruned.
+    assert output_dir.is_dir()
+    assert (output_dir / "final_report.json").is_file()
+    assert (output_dir / "best_patch.diff").is_file()
+    remaining = {p.name for p in output_dir.iterdir()}
+    assert remaining == {"final_report.json", "best_patch.diff"}
+
+
+def test_happy_path_commit_body_references_report(repo: Path, output_dir: Path) -> None:
+    result = _result_for(output_dir)
+
+    apply_commit_and_cleanup(result, repo, output_dir)
+
+    body = subprocess.run(
+        ["git", "log", "-1", "--pretty=%B"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "final_report.json" in body
+    assert "Fused reduction tree" in body
+
+
+# ---------------------------------------------------------------------------
+# Dirty repo refusal
+# ---------------------------------------------------------------------------
+
+
+def test_dirty_repo_refuses_apply(repo: Path, output_dir: Path) -> None:
+    (repo / "kernel.py").write_text("def run():\n    return 99\n")  # uncommitted change
+    result = _result_for(output_dir)
+    before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    apply_commit_and_cleanup(result, repo, output_dir)
+
+    after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert before_sha == after_sha, "No new commit should be made when repo is dirty"
+    # User's uncommitted change must remain untouched.
+    assert (repo / "kernel.py").read_text() == "def run():\n    return 99\n"
+    # Artifacts must remain intact for debugging.
+    assert (output_dir / "logs" / "run.log").is_file()
+    assert (output_dir / "results" / "round_1" / "best_results.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Apply failure
+# ---------------------------------------------------------------------------
+
+
+def test_apply_failure_leaves_repo_and_artifacts_untouched(repo: Path, output_dir: Path) -> None:
+    # Overwrite with a patch that cannot apply to HEAD (wrong context lines).
+    bogus = (
+        "diff --git a/kernel.py b/kernel.py\n"
+        "index 0000000..1111111 100644\n"
+        "--- a/kernel.py\n"
+        "+++ b/kernel.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-def totally_different():\n"
+        "-    return 0\n"
+        "+def totally_different():\n"
+        "+    return 1\n"
+    )
+    (output_dir / "best_patch.diff").write_text(bogus)
+    result = _result_for(output_dir)
+    before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    apply_commit_and_cleanup(result, repo, output_dir)
+
+    after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert before_sha == after_sha
+    # Repo working tree unchanged.
+    assert (repo / "kernel.py").read_text() == "def run():\n    return 0\n"
+    # Artifacts preserved.
+    assert (output_dir / "logs" / "run.log").is_file()
+    assert (output_dir / "results" / "round_1" / "best_results.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Commit failure
+# ---------------------------------------------------------------------------
+
+
+def test_commit_failure_preserves_apply_and_artifacts(
+    repo: Path, output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _result_for(output_dir)
+
+    real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[0] == "git" and cmd[1] == "commit":
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=1,
+                stdout="",
+                stderr="simulated commit failure",
+            )
+        return real_run(cmd, *args, **kwargs)  # pylint: disable=subprocess-run-check
+
+    monkeypatch.setattr(finalize_apply.subprocess, "run", fake_run)
+
+    apply_commit_and_cleanup(result, repo, output_dir)
+
+    # Apply must have landed in the working tree (no rollback).
+    assert (repo / "kernel.py").read_text() == "def run():\n    return 42\n"
+    # No new commit (only the initial one).
+    log = (
+        real_run(
+            ["git", "log", "--oneline"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        .stdout.strip()
+        .splitlines()
+    )
+    assert len(log) == 1
+    # Artifacts preserved so the user can investigate.
+    assert (output_dir / "logs" / "run.log").is_file()
+    assert (output_dir / "results" / "round_1" / "best_results.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Precondition short-circuits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "make_bad",
+    [
+        lambda r, o: (None, r, o),
+        lambda r, o: (
+            BestPatchResult(agent_id=0, patch_id="x", test_output="", best_patch_file=None),
+            r,
+            o,
+        ),
+        lambda r, o: (
+            BestPatchResult(
+                agent_id=0,
+                patch_id="x",
+                test_output="",
+                best_patch_file=str(o / "does_not_exist.diff"),
+            ),
+            r,
+            o,
+        ),
+    ],
+    ids=["result_none", "best_patch_file_missing", "patch_file_nonexistent"],
+)
+def test_precondition_short_circuits(repo: Path, output_dir: Path, make_bad) -> None:
+    result, r, o = make_bad(repo, output_dir)
+    before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    apply_commit_and_cleanup(result, r, o)
+
+    after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert before_sha == after_sha
+    # Nothing pruned.
+    assert (output_dir / "logs" / "run.log").is_file()
+
+
+@pytest.fixture
+def repo_without_identity(tmp_path: Path) -> Path:
+    """A git repo with no user.name/user.email (mimics a fresh container).
+
+    ``_git`` uses author overrides for the initial commit so the fixture itself
+    doesn't need an identity, but no ``git config user.*`` values are set on
+    the repo afterwards.
+    """
+    repo_dir = tmp_path / "repo_no_id"
+    repo_dir.mkdir()
+    _git(repo_dir, "init", "--initial-branch=main")
+    env = dict(os.environ)
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "Bootstrap",
+            "GIT_AUTHOR_EMAIL": "bootstrap@example.com",
+            "GIT_COMMITTER_NAME": "Bootstrap",
+            "GIT_COMMITTER_EMAIL": "bootstrap@example.com",
+        }
+    )
+    (repo_dir / "kernel.py").write_text("def run():\n    return 0\n")
+    subprocess.run(["git", "add", "kernel.py"], cwd=str(repo_dir), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=str(repo_dir),
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    # Explicitly scrub any local identity git may have inherited.
+    subprocess.run(["git", "config", "--unset", "user.name"], cwd=str(repo_dir), capture_output=True, check=False)
+    subprocess.run(["git", "config", "--unset", "user.email"], cwd=str(repo_dir), capture_output=True, check=False)
+    return repo_dir
+
+
+def test_commit_falls_back_to_default_identity(
+    repo_without_identity: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In a fresh container (no user.name/email), commit must still succeed with defaults."""
+    # Simulate an isolated container env: no host-level git config visible.
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+    monkeypatch.delenv("GIT_AUTHOR_NAME", raising=False)
+    monkeypatch.delenv("GIT_AUTHOR_EMAIL", raising=False)
+    monkeypatch.delenv("GIT_COMMITTER_NAME", raising=False)
+    monkeypatch.delenv("GIT_COMMITTER_EMAIL", raising=False)
+    monkeypatch.delenv("GEAK_GIT_AUTHOR_NAME", raising=False)
+    monkeypatch.delenv("GEAK_GIT_AUTHOR_EMAIL", raising=False)
+
+    # Build a matching output_dir with a real diff against repo_without_identity.
+    (repo_without_identity / "kernel.py").write_text("def run():\n    return 42\n")
+    diff = subprocess.run(
+        ["git", "diff"],
+        cwd=str(repo_without_identity),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    subprocess.run(
+        ["git", "checkout", "--", "kernel.py"],
+        cwd=str(repo_without_identity),
+        capture_output=True,
+        check=True,
+    )
+
+    out = tmp_path / "optimization_logs" / "kernel_run"
+    out.mkdir(parents=True)
+    (out / "final_report.json").write_text(json.dumps({"best_speedup": 1.5}))
+    (out / "best_patch.diff").write_text(diff)
+    result = _result_for(out)
+
+    apply_commit_and_cleanup(result, repo_without_identity, out)
+
+    log = subprocess.run(
+        ["git", "log", "-1", "--pretty=format:%an <%ae>"],
+        cwd=str(repo_without_identity),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert log == "GEAK Agent <geak@amd.com>"
+    # The patched change is committed.
+    assert (repo_without_identity / "kernel.py").read_text() == "def run():\n    return 42\n"
+
+
+def test_commit_uses_geak_env_identity_override(
+    repo_without_identity: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GEAK_GIT_AUTHOR_* env vars override the hard-coded default."""
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+    monkeypatch.delenv("GIT_AUTHOR_NAME", raising=False)
+    monkeypatch.delenv("GIT_AUTHOR_EMAIL", raising=False)
+    monkeypatch.delenv("GIT_COMMITTER_NAME", raising=False)
+    monkeypatch.delenv("GIT_COMMITTER_EMAIL", raising=False)
+    monkeypatch.setenv("GEAK_GIT_AUTHOR_NAME", "Custom Bot")
+    monkeypatch.setenv("GEAK_GIT_AUTHOR_EMAIL", "bot@custom.example")
+
+    (repo_without_identity / "kernel.py").write_text("def run():\n    return 7\n")
+    diff = subprocess.run(
+        ["git", "diff"],
+        cwd=str(repo_without_identity),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    subprocess.run(
+        ["git", "checkout", "--", "kernel.py"],
+        cwd=str(repo_without_identity),
+        capture_output=True,
+        check=True,
+    )
+
+    out = tmp_path / "run_override"
+    out.mkdir()
+    (out / "final_report.json").write_text("{}")
+    (out / "best_patch.diff").write_text(diff)
+    result = _result_for(out)
+
+    apply_commit_and_cleanup(result, repo_without_identity, out)
+
+    author = subprocess.run(
+        ["git", "log", "-1", "--pretty=format:%an <%ae>"],
+        cwd=str(repo_without_identity),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert author == "Custom Bot <bot@custom.example>"
+
+
+def test_commit_preserves_existing_identity(repo: Path, output_dir: Path) -> None:
+    """When user.name / user.email are configured, we must not override them."""
+    _git(repo, "config", "user.name", "Pre Configured")
+    _git(repo, "config", "user.email", "pre@configured.example")
+    result = _result_for(output_dir)
+
+    apply_commit_and_cleanup(result, repo, output_dir)
+
+    author = subprocess.run(
+        ["git", "log", "-1", "--pretty=format:%an <%ae>"],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert author == "Pre Configured <pre@configured.example>"
+
+
+def test_non_git_repo_refused(tmp_path: Path, output_dir: Path) -> None:
+    not_a_repo = tmp_path / "plain_dir"
+    not_a_repo.mkdir()
+    result = _result_for(output_dir)
+
+    apply_commit_and_cleanup(result, not_a_repo, output_dir)
+
+    assert (output_dir / "logs" / "run.log").is_file()
+
+
+def test_cli_flag_threaded() -> None:
+    """Smoke-check that --cleanup exists as a Typer option on the geak CLI."""
+    from typer.testing import CliRunner
+
+    from minisweagent.run import mini as mini_module
+
+    runner = CliRunner()
+    help_result = runner.invoke(mini_module.app, ["--help"])
+    assert help_result.exit_code == 0
+    assert "--cleanup" in help_result.stdout
+
+
+# Silence unused-import warning for `patch` (imported for symmetry with sibling tests).
+_ = patch

--- a/tests/run/test_finalize_apply.py
+++ b/tests/run/test_finalize_apply.py
@@ -722,9 +722,7 @@ def test_normalize_kept_report_handles_no_surviving_patch(repo: Path, output_dir
     assert kept["best_patch"] is None
 
 
-def test_normalize_kept_report_does_not_touch_summary_strings(
-    repo: Path, output_dir: Path
-) -> None:
+def test_normalize_kept_report_does_not_touch_summary_strings(repo: Path, output_dir: Path) -> None:
     """LLM-authored documents (summary / agent_summary / etc.) must come back byte-identical
     even if they paste paths under output_dir into free-text prose."""
     embedded = str(output_dir / "results" / "round_3" / "patch_0.patch")
@@ -753,9 +751,7 @@ def test_normalize_kept_report_does_not_touch_summary_strings(
     assert kept["round_summaries"][0]["summary"] == f"used {embedded}"
 
 
-def test_iterate_and_delete_handles_symlink_to_dir(
-    repo: Path, output_dir: Path, tmp_path: Path
-) -> None:
+def test_iterate_and_delete_handles_symlink_to_dir(repo: Path, output_dir: Path, tmp_path: Path) -> None:
     """A non-keep symlink-to-dir is unlinked, not recursed into; status='ran'."""
     target = tmp_path / "external_target"
     target.mkdir()

--- a/tests/run/test_finalize_apply.py
+++ b/tests/run/test_finalize_apply.py
@@ -1,6 +1,6 @@
 """Unit tests for ``minisweagent.run.postprocess.finalize_apply``.
 
-Exercises the ``apply_commit_and_cleanup`` hook end-to-end against a real
+Exercises the ``finalize_apply_and_cleanup`` hook end-to-end against a real
 temporary git repo, covering:
 
 - Happy path (apply + commit + cleanup keeps final_report.json + .diff).
@@ -28,7 +28,7 @@ from minisweagent.run.postprocess import finalize_apply
 from minisweagent.run.postprocess.finalize_apply import (
     apply_and_commit_best_patch,
     cleanup_run_artifacts,
-    finalize_run,
+    finalize_apply_and_cleanup,
 )
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
@@ -121,7 +121,7 @@ def _result_for(output_dir: Path, patch_name: str = "best_patch.diff") -> BestPa
 def test_happy_path_applies_commits_and_cleans(repo: Path, output_dir: Path) -> None:
     result = _result_for(output_dir)
 
-    finalize_run(result, repo, output_dir)
+    finalize_apply_and_cleanup(result, repo, output_dir)
 
     # Commit was created on top of "initial"
     log = (
@@ -153,7 +153,7 @@ def test_happy_path_applies_commits_and_cleans(repo: Path, output_dir: Path) -> 
 def test_happy_path_commit_body_references_report(repo: Path, output_dir: Path) -> None:
     result = _result_for(output_dir)
 
-    finalize_run(result, repo, output_dir)
+    finalize_apply_and_cleanup(result, repo, output_dir)
 
     body = subprocess.run(
         ["git", "log", "-1", "--pretty=%B"],
@@ -177,7 +177,7 @@ def test_dirty_repo_refuses_apply_only(repo: Path, output_dir: Path) -> None:
     result = _result_for(output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    finalize_run(result, repo, output_dir)
+    finalize_apply_and_cleanup(result, repo, output_dir)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha, "No new commit should be made when repo is dirty"
@@ -194,7 +194,7 @@ def test_dirty_repo_with_no_cleanup_preserves_everything(repo: Path, output_dir:
     result = _result_for(output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    finalize_run(result, repo, output_dir, cleanup=False)
+    finalize_apply_and_cleanup(result, repo, output_dir, cleanup=False)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha
@@ -230,7 +230,7 @@ def test_apply_failure_still_runs_cleanup_independently(repo: Path, output_dir: 
     result = _result_for(output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    finalize_run(result, repo, output_dir)
+    finalize_apply_and_cleanup(result, repo, output_dir)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha
@@ -246,7 +246,7 @@ def test_apply_failure_with_no_cleanup_preserves_artifacts(repo: Path, output_di
     result = _result_for(output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    finalize_run(result, repo, output_dir, cleanup=False)
+    finalize_apply_and_cleanup(result, repo, output_dir, cleanup=False)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha
@@ -284,7 +284,7 @@ def test_commit_failure_preserves_apply_with_no_cleanup(
     _install_commit_failure(monkeypatch)
     result = _result_for(output_dir)
 
-    finalize_run(result, repo, output_dir, cleanup=False)
+    finalize_apply_and_cleanup(result, repo, output_dir, cleanup=False)
 
     # Apply must have landed in the working tree (no rollback).
     assert (repo / "kernel.py").read_text() == "def run():\n    return 42\n"
@@ -330,7 +330,7 @@ def test_apply_precondition_short_circuits(repo: Path, output_dir: Path, make_ba
     result, r, o = make_bad(repo, output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    finalize_run(result, r, o, cleanup=False)
+    finalize_apply_and_cleanup(result, r, o, cleanup=False)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha
@@ -409,7 +409,7 @@ def test_commit_falls_back_to_default_identity(
     (out / "best_patch.diff").write_text(diff)
     result = _result_for(out)
 
-    finalize_run(result, repo_without_identity, out)
+    finalize_apply_and_cleanup(result, repo_without_identity, out)
 
     log = subprocess.run(
         ["git", "log", "-1", "--pretty=format:%an <%ae>"],
@@ -457,7 +457,7 @@ def test_commit_uses_geak_env_identity_override(
     (out / "best_patch.diff").write_text(diff)
     result = _result_for(out)
 
-    finalize_run(result, repo_without_identity, out)
+    finalize_apply_and_cleanup(result, repo_without_identity, out)
 
     author = subprocess.run(
         ["git", "log", "-1", "--pretty=format:%an <%ae>"],
@@ -475,7 +475,7 @@ def test_commit_preserves_existing_identity(repo: Path, output_dir: Path) -> Non
     _git(repo, "config", "user.email", "pre@configured.example")
     result = _result_for(output_dir)
 
-    finalize_run(result, repo, output_dir)
+    finalize_apply_and_cleanup(result, repo, output_dir)
 
     author = subprocess.run(
         ["git", "log", "-1", "--pretty=format:%an <%ae>"],
@@ -493,7 +493,7 @@ def test_non_git_repo_refuses_apply(tmp_path: Path, output_dir: Path) -> None:
     not_a_repo.mkdir()
     result = _result_for(output_dir)
 
-    finalize_run(result, not_a_repo, output_dir, cleanup=False)
+    finalize_apply_and_cleanup(result, not_a_repo, output_dir, cleanup=False)
 
     # Output dir untouched (cleanup=False).
     assert (output_dir / "logs" / "run.log").is_file()
@@ -508,7 +508,7 @@ def test_apply_only_without_cleanup(repo: Path, output_dir: Path) -> None:
     """--apply-best-patch --no-cleanup: commit happens, output_dir fully preserved."""
     result = _result_for(output_dir)
 
-    finalize_run(result, repo, output_dir, apply_best_patch=True, cleanup=False)
+    finalize_apply_and_cleanup(result, repo, output_dir, apply_best_patch=True, cleanup=False)
 
     log = _git(repo, "log", "--oneline").stdout.strip().splitlines()
     assert len(log) == 2
@@ -522,7 +522,7 @@ def test_cleanup_only_without_apply(repo: Path, output_dir: Path) -> None:
     result = _result_for(output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    finalize_run(result, repo, output_dir, apply_best_patch=False, cleanup=True)
+    finalize_apply_and_cleanup(result, repo, output_dir, apply_best_patch=False, cleanup=True)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha
@@ -536,7 +536,7 @@ def test_both_disabled_is_noop(repo: Path, output_dir: Path) -> None:
     result = _result_for(output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    finalize_run(result, repo, output_dir, apply_best_patch=False, cleanup=False)
+    finalize_apply_and_cleanup(result, repo, output_dir, apply_best_patch=False, cleanup=False)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha

--- a/tests/run/test_finalize_apply.py
+++ b/tests/run/test_finalize_apply.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -24,7 +25,18 @@ import pytest
 
 from minisweagent.agents.parallel_agent import BestPatchResult
 from minisweagent.run.postprocess import finalize_apply
-from minisweagent.run.postprocess.finalize_apply import apply_commit_and_cleanup
+from minisweagent.run.postprocess.finalize_apply import (
+    apply_and_commit_best_patch,
+    cleanup_run_artifacts,
+    finalize_run,
+)
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -109,7 +121,7 @@ def _result_for(output_dir: Path, patch_name: str = "best_patch.diff") -> BestPa
 def test_happy_path_applies_commits_and_cleans(repo: Path, output_dir: Path) -> None:
     result = _result_for(output_dir)
 
-    apply_commit_and_cleanup(result, repo, output_dir)
+    finalize_run(result, repo, output_dir)
 
     # Commit was created on top of "initial"
     log = (
@@ -141,7 +153,7 @@ def test_happy_path_applies_commits_and_cleans(repo: Path, output_dir: Path) -> 
 def test_happy_path_commit_body_references_report(repo: Path, output_dir: Path) -> None:
     result = _result_for(output_dir)
 
-    apply_commit_and_cleanup(result, repo, output_dir)
+    finalize_run(result, repo, output_dir)
 
     body = subprocess.run(
         ["git", "log", "-1", "--pretty=%B"],
@@ -159,18 +171,34 @@ def test_happy_path_commit_body_references_report(repo: Path, output_dir: Path) 
 # ---------------------------------------------------------------------------
 
 
-def test_dirty_repo_refuses_apply(repo: Path, output_dir: Path) -> None:
+def test_dirty_repo_refuses_apply_only(repo: Path, output_dir: Path) -> None:
+    """Dirty repo must skip apply but must not block the independent cleanup step."""
     (repo / "kernel.py").write_text("def run():\n    return 99\n")  # uncommitted change
     result = _result_for(output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    apply_commit_and_cleanup(result, repo, output_dir)
+    finalize_run(result, repo, output_dir)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha, "No new commit should be made when repo is dirty"
     # User's uncommitted change must remain untouched.
     assert (repo / "kernel.py").read_text() == "def run():\n    return 99\n"
-    # Artifacts must remain intact for debugging.
+    # Cleanup is independent and still runs: only summary files survive.
+    remaining = {p.name for p in output_dir.iterdir()}
+    assert remaining == {"final_report.json", "best_patch.diff"}
+
+
+def test_dirty_repo_with_no_cleanup_preserves_everything(repo: Path, output_dir: Path) -> None:
+    """With --no-cleanup, a dirty repo leaves both the repo and the output_dir untouched."""
+    (repo / "kernel.py").write_text("def run():\n    return 99\n")
+    result = _result_for(output_dir)
+    before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    finalize_run(result, repo, output_dir, cleanup=False)
+
+    after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert before_sha == after_sha
+    assert (repo / "kernel.py").read_text() == "def run():\n    return 99\n"
     assert (output_dir / "logs" / "run.log").is_file()
     assert (output_dir / "results" / "round_1" / "best_results.json").is_file()
 
@@ -180,8 +208,8 @@ def test_dirty_repo_refuses_apply(repo: Path, output_dir: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_apply_failure_leaves_repo_and_artifacts_untouched(repo: Path, output_dir: Path) -> None:
-    # Overwrite with a patch that cannot apply to HEAD (wrong context lines).
+def _write_bogus_patch(output_dir: Path) -> None:
+    """Replace the winning diff with one that cannot apply to HEAD."""
     bogus = (
         "diff --git a/kernel.py b/kernel.py\n"
         "index 0000000..1111111 100644\n"
@@ -194,16 +222,35 @@ def test_apply_failure_leaves_repo_and_artifacts_untouched(repo: Path, output_di
         "+    return 1\n"
     )
     (output_dir / "best_patch.diff").write_text(bogus)
+
+
+def test_apply_failure_still_runs_cleanup_independently(repo: Path, output_dir: Path) -> None:
+    """Apply failure does not block cleanup (the two are independent)."""
+    _write_bogus_patch(output_dir)
     result = _result_for(output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    apply_commit_and_cleanup(result, repo, output_dir)
+    finalize_run(result, repo, output_dir)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha
-    # Repo working tree unchanged.
     assert (repo / "kernel.py").read_text() == "def run():\n    return 0\n"
-    # Artifacts preserved.
+    # Cleanup still ran: only summary + winning .diff survive in output_dir.
+    remaining = {p.name for p in output_dir.iterdir()}
+    assert remaining == {"final_report.json", "best_patch.diff"}
+
+
+def test_apply_failure_with_no_cleanup_preserves_artifacts(repo: Path, output_dir: Path) -> None:
+    """Passing --no-cleanup keeps the full artifact dir intact on apply failure (debug mode)."""
+    _write_bogus_patch(output_dir)
+    result = _result_for(output_dir)
+    before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    finalize_run(result, repo, output_dir, cleanup=False)
+
+    after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert before_sha == after_sha
+    assert (repo / "kernel.py").read_text() == "def run():\n    return 0\n"
     assert (output_dir / "logs" / "run.log").is_file()
     assert (output_dir / "results" / "round_1" / "best_results.json").is_file()
 
@@ -213,11 +260,8 @@ def test_apply_failure_leaves_repo_and_artifacts_untouched(repo: Path, output_di
 # ---------------------------------------------------------------------------
 
 
-def test_commit_failure_preserves_apply_and_artifacts(
-    repo: Path, output_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    result = _result_for(output_dir)
-
+def _install_commit_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wrap subprocess.run so `git commit ...` always returns non-zero."""
     real_run = subprocess.run
 
     def fake_run(cmd, *args, **kwargs):
@@ -232,22 +276,22 @@ def test_commit_failure_preserves_apply_and_artifacts(
 
     monkeypatch.setattr(finalize_apply.subprocess, "run", fake_run)
 
-    apply_commit_and_cleanup(result, repo, output_dir)
+
+def test_commit_failure_preserves_apply_with_no_cleanup(
+    repo: Path, output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With --no-cleanup and a commit failure, apply stays in working tree and artifacts survive."""
+    _install_commit_failure(monkeypatch)
+    result = _result_for(output_dir)
+
+    finalize_run(result, repo, output_dir, cleanup=False)
 
     # Apply must have landed in the working tree (no rollback).
     assert (repo / "kernel.py").read_text() == "def run():\n    return 42\n"
-    # No new commit (only the initial one).
-    log = (
-        real_run(
-            ["git", "log", "--oneline"],
-            cwd=str(repo),
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        .stdout.strip()
-        .splitlines()
-    )
+    # No new commit (only the initial one). `_git` uses the unpatched
+    # module-level ``subprocess.run``, so the commit-failure injection in
+    # ``finalize_apply.subprocess`` does not affect it.
+    log = _git(repo, "log", "--oneline").stdout.strip().splitlines()
     assert len(log) == 1
     # Artifacts preserved so the user can investigate.
     assert (output_dir / "logs" / "run.log").is_file()
@@ -281,11 +325,12 @@ def test_commit_failure_preserves_apply_and_artifacts(
     ],
     ids=["result_none", "best_patch_file_missing", "patch_file_nonexistent"],
 )
-def test_precondition_short_circuits(repo: Path, output_dir: Path, make_bad) -> None:
+def test_apply_precondition_short_circuits(repo: Path, output_dir: Path, make_bad) -> None:
+    """Bad apply preconditions never produce a commit (cleanup skipped too for test clarity)."""
     result, r, o = make_bad(repo, output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    apply_commit_and_cleanup(result, r, o)
+    finalize_run(result, r, o, cleanup=False)
 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha
@@ -364,7 +409,7 @@ def test_commit_falls_back_to_default_identity(
     (out / "best_patch.diff").write_text(diff)
     result = _result_for(out)
 
-    apply_commit_and_cleanup(result, repo_without_identity, out)
+    finalize_run(result, repo_without_identity, out)
 
     log = subprocess.run(
         ["git", "log", "-1", "--pretty=format:%an <%ae>"],
@@ -412,7 +457,7 @@ def test_commit_uses_geak_env_identity_override(
     (out / "best_patch.diff").write_text(diff)
     result = _result_for(out)
 
-    apply_commit_and_cleanup(result, repo_without_identity, out)
+    finalize_run(result, repo_without_identity, out)
 
     author = subprocess.run(
         ["git", "log", "-1", "--pretty=format:%an <%ae>"],
@@ -430,7 +475,7 @@ def test_commit_preserves_existing_identity(repo: Path, output_dir: Path) -> Non
     _git(repo, "config", "user.email", "pre@configured.example")
     result = _result_for(output_dir)
 
-    apply_commit_and_cleanup(result, repo, output_dir)
+    finalize_run(result, repo, output_dir)
 
     author = subprocess.run(
         ["git", "log", "-1", "--pretty=format:%an <%ae>"],
@@ -442,26 +487,106 @@ def test_commit_preserves_existing_identity(repo: Path, output_dir: Path) -> Non
     assert author == "Pre Configured <pre@configured.example>"
 
 
-def test_non_git_repo_refused(tmp_path: Path, output_dir: Path) -> None:
+def test_non_git_repo_refuses_apply(tmp_path: Path, output_dir: Path) -> None:
+    """Non-git repo skips apply; cleanup is independent and runs."""
     not_a_repo = tmp_path / "plain_dir"
     not_a_repo.mkdir()
     result = _result_for(output_dir)
 
-    apply_commit_and_cleanup(result, not_a_repo, output_dir)
+    finalize_run(result, not_a_repo, output_dir, cleanup=False)
 
+    # Output dir untouched (cleanup=False).
     assert (output_dir / "logs" / "run.log").is_file()
 
 
+# ---------------------------------------------------------------------------
+# Independent-flag combinations
+# ---------------------------------------------------------------------------
+
+
+def test_apply_only_without_cleanup(repo: Path, output_dir: Path) -> None:
+    """--apply-best-patch --no-cleanup: commit happens, output_dir fully preserved."""
+    result = _result_for(output_dir)
+
+    finalize_run(result, repo, output_dir, apply_best_patch=True, cleanup=False)
+
+    log = _git(repo, "log", "--oneline").stdout.strip().splitlines()
+    assert len(log) == 2
+    # All artifacts survive.
+    assert (output_dir / "logs" / "run.log").is_file()
+    assert (output_dir / "results" / "round_1" / "best_results.json").is_file()
+
+
+def test_cleanup_only_without_apply(repo: Path, output_dir: Path) -> None:
+    """--no-apply-best-patch --cleanup: no commit, but artifacts pruned down to summary."""
+    result = _result_for(output_dir)
+    before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    finalize_run(result, repo, output_dir, apply_best_patch=False, cleanup=True)
+
+    after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert before_sha == after_sha
+    assert (repo / "kernel.py").read_text() == "def run():\n    return 0\n"  # repo untouched
+    remaining = {p.name for p in output_dir.iterdir()}
+    assert remaining == {"final_report.json", "best_patch.diff"}
+
+
+def test_both_disabled_is_noop(repo: Path, output_dir: Path) -> None:
+    """--no-apply-best-patch --no-cleanup: nothing happens."""
+    result = _result_for(output_dir)
+    before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    finalize_run(result, repo, output_dir, apply_best_patch=False, cleanup=False)
+
+    after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert before_sha == after_sha
+    assert (output_dir / "logs" / "run.log").is_file()
+    assert (output_dir / "results" / "round_1" / "best_results.json").is_file()
+
+
+def test_standalone_apply_api(repo: Path, output_dir: Path) -> None:
+    """The standalone apply API returns a commit SHA on success."""
+    result = _result_for(output_dir)
+
+    sha = apply_and_commit_best_patch(result, repo)
+
+    assert sha is not None and len(sha) >= 7
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert sha == head
+
+
+def test_standalone_cleanup_api_without_patch_file(tmp_path: Path) -> None:
+    """cleanup_run_artifacts works even when the BestPatchResult has no patch file."""
+    out = tmp_path / "empty_run"
+    out.mkdir()
+    (out / "final_report.json").write_text(json.dumps({"best_speedup": None}))
+    (out / "logs").mkdir()
+    (out / "logs" / "run.log").write_text("logs")
+    result = BestPatchResult(agent_id=0, patch_id="none", test_output="", best_patch_file=None)
+
+    cleanup_run_artifacts(result, out)
+
+    remaining = {p.name for p in out.iterdir()}
+    assert remaining == {"final_report.json"}
+
+
 def test_cli_flag_threaded() -> None:
-    """Smoke-check that --cleanup exists as a Typer option on the geak CLI."""
+    """Smoke-check that both independent flags are exposed on the geak CLI."""
     from typer.testing import CliRunner
 
     from minisweagent.run import mini as mini_module
 
-    runner = CliRunner()
+    # Widen the virtual terminal to avoid Rich/Typer wrapping the option names
+    # across lines in CI, and disable color so substring matches don't fight
+    # ANSI escape codes. We still strip any surviving ANSI defensively.
+    runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"})
     help_result = runner.invoke(mini_module.app, ["--help"])
     assert help_result.exit_code == 0
-    assert "--cleanup" in help_result.stdout
+    plain = _strip_ansi(help_result.stdout)
+    assert "--cleanup" in plain
+    assert "--no-cleanup" in plain
+    assert "--apply-best-patch" in plain
+    assert "--no-apply-best-patch" in plain
 
 
 # Silence unused-import warning for `patch` (imported for symmetry with sibling tests).

--- a/tests/run/test_finalize_apply.py
+++ b/tests/run/test_finalize_apply.py
@@ -86,11 +86,15 @@ def good_patch(repo: Path) -> str:
 
 @pytest.fixture
 def output_dir(tmp_path: Path, good_patch: str) -> Path:
-    """A populated per-run output_dir with final_report.json, a winning .diff, and noise."""
+    """A populated per-run output_dir with final_report.json, a winning .diff,
+    the canonical agent log + COMMANDMENT, and noise."""
     out = tmp_path / "optimization_logs" / "kernel_20260101_000000"
     out.mkdir(parents=True)
     (out / "final_report.json").write_text(json.dumps({"best_speedup": 1.5, "summary": "ok"}))
     (out / "best_patch.diff").write_text(good_patch)
+    # Cleanup's expanded keep-set retains these too.
+    (out / "geak_agent.log").write_text("agent log line\n")
+    (out / "COMMANDMENT.md").write_text("# user-specified constraints\n")
 
     # Noise we expect cleanup to prune.
     (out / "logs").mkdir()
@@ -142,12 +146,19 @@ def test_happy_path_applies_commits_and_cleans(repo: Path, output_dir: Path) -> 
     # Working tree reflects the applied change.
     assert (repo / "kernel.py").read_text() == "def run():\n    return 42\n"
 
-    # Summary files retained, everything else pruned.
+    # Keep-set retained, everything else pruned.
     assert output_dir.is_dir()
     assert (output_dir / "final_report.json").is_file()
     assert (output_dir / "best_patch.diff").is_file()
+    assert (output_dir / "geak_agent.log").is_file()
+    assert (output_dir / "COMMANDMENT.md").is_file()
     remaining = {p.name for p in output_dir.iterdir()}
-    assert remaining == {"final_report.json", "best_patch.diff"}
+    assert remaining == {
+        "final_report.json",
+        "best_patch.diff",
+        "geak_agent.log",
+        "COMMANDMENT.md",
+    }
 
 
 def test_happy_path_commit_body_references_report(repo: Path, output_dir: Path) -> None:
@@ -183,9 +194,14 @@ def test_dirty_repo_refuses_apply_only(repo: Path, output_dir: Path) -> None:
     assert before_sha == after_sha, "No new commit should be made when repo is dirty"
     # User's uncommitted change must remain untouched.
     assert (repo / "kernel.py").read_text() == "def run():\n    return 99\n"
-    # Cleanup is independent and still runs: only summary files survive.
+    # Cleanup is independent and still runs: keep-set survives, noise pruned.
     remaining = {p.name for p in output_dir.iterdir()}
-    assert remaining == {"final_report.json", "best_patch.diff"}
+    assert remaining == {
+        "final_report.json",
+        "best_patch.diff",
+        "geak_agent.log",
+        "COMMANDMENT.md",
+    }
 
 
 def test_dirty_repo_with_no_cleanup_preserves_everything(repo: Path, output_dir: Path) -> None:
@@ -235,9 +251,14 @@ def test_apply_failure_still_runs_cleanup_independently(repo: Path, output_dir: 
     after_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert before_sha == after_sha
     assert (repo / "kernel.py").read_text() == "def run():\n    return 0\n"
-    # Cleanup still ran: only summary + winning .diff survive in output_dir.
+    # Cleanup still ran: keep-set survives, everything else pruned.
     remaining = {p.name for p in output_dir.iterdir()}
-    assert remaining == {"final_report.json", "best_patch.diff"}
+    assert remaining == {
+        "final_report.json",
+        "best_patch.diff",
+        "geak_agent.log",
+        "COMMANDMENT.md",
+    }
 
 
 def test_apply_failure_with_no_cleanup_preserves_artifacts(repo: Path, output_dir: Path) -> None:
@@ -518,7 +539,7 @@ def test_apply_only_without_cleanup(repo: Path, output_dir: Path) -> None:
 
 
 def test_cleanup_only_without_apply(repo: Path, output_dir: Path) -> None:
-    """--no-apply-best-patch --cleanup: no commit, but artifacts pruned down to summary."""
+    """--no-apply-best-patch --cleanup: no commit, but artifacts pruned down to keep-set."""
     result = _result_for(output_dir)
     before_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
@@ -528,7 +549,12 @@ def test_cleanup_only_without_apply(repo: Path, output_dir: Path) -> None:
     assert before_sha == after_sha
     assert (repo / "kernel.py").read_text() == "def run():\n    return 0\n"  # repo untouched
     remaining = {p.name for p in output_dir.iterdir()}
-    assert remaining == {"final_report.json", "best_patch.diff"}
+    assert remaining == {
+        "final_report.json",
+        "best_patch.diff",
+        "geak_agent.log",
+        "COMMANDMENT.md",
+    }
 
 
 def test_both_disabled_is_noop(repo: Path, output_dir: Path) -> None:
@@ -587,6 +613,194 @@ def test_cli_flag_threaded() -> None:
     assert "--no-cleanup" in plain
     assert "--apply-best-patch" in plain
     assert "--no-apply-best-patch" in plain
+
+
+# ---------------------------------------------------------------------------
+# Structured apply outcome
+# ---------------------------------------------------------------------------
+
+
+def test_apply_and_commit_best_patch_detailed_returns_outcome_dict(
+    repo: Path, output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cover every status the detailed function can return."""
+    from minisweagent.run.postprocess.finalize_apply import apply_and_commit_best_patch_detailed
+
+    # committed
+    result = _result_for(output_dir)
+    outcome = apply_and_commit_best_patch_detailed(result, repo)
+    assert outcome["status"] == "committed"
+    assert outcome["commit_sha"] is not None and len(outcome["commit_sha"]) >= 7
+    assert outcome["reason"] is None
+    # Reset working tree for the rest of the matrix.
+    _git(repo, "reset", "--hard", "HEAD^")
+
+    # skipped_dirty
+    (repo / "kernel.py").write_text("def run():\n    return 99\n")
+    outcome = apply_and_commit_best_patch_detailed(result, repo)
+    assert outcome["status"] == "skipped_dirty"
+    assert outcome["commit_sha"] is None
+    assert outcome["reason"] and "uncommitted" in outcome["reason"]
+    _git(repo, "checkout", "--", "kernel.py")
+
+    # skipped_precondition (no result)
+    outcome = apply_and_commit_best_patch_detailed(None, repo)
+    assert outcome["status"] == "skipped_precondition"
+    assert outcome["commit_sha"] is None
+
+    # apply_failed (bogus patch)
+    _write_bogus_patch(output_dir)
+    outcome = apply_and_commit_best_patch_detailed(_result_for(output_dir), repo)
+    assert outcome["status"] == "apply_failed"
+    assert outcome["commit_sha"] is None
+    assert outcome["reason"] and "git apply" in outcome["reason"]
+
+
+def test_commit_failure_status_in_detailed_outcome(
+    repo: Path, output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """commit_failed: apply succeeds but git commit returns non-zero."""
+    from minisweagent.run.postprocess.finalize_apply import apply_and_commit_best_patch_detailed
+
+    _install_commit_failure(monkeypatch)
+    outcome = apply_and_commit_best_patch_detailed(_result_for(output_dir), repo)
+    assert outcome["status"] == "commit_failed"
+    assert outcome["commit_sha"] is None
+    assert outcome["reason"] and "git commit" in outcome["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Cleanup status + normalization
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_returns_ran_on_happy_path(repo: Path, output_dir: Path) -> None:
+    """cleanup_run_artifacts returns 'ran' when the loop completes cleanly."""
+    result = _result_for(output_dir)
+    status = cleanup_run_artifacts(result, output_dir)
+    assert status == "ran"
+
+
+def test_cleanup_returns_skipped_empty_when_output_dir_missing(repo: Path) -> None:
+    """Missing output_dir => skipped_empty, never raises."""
+    result = BestPatchResult(agent_id=0, patch_id="x", test_output="", best_patch_file=None)
+    status = cleanup_run_artifacts(result, Path("/nonexistent/path/that/does/not/exist"))
+    assert status == "skipped_empty"
+
+
+def test_cleanup_returns_skipped_empty_when_no_report_or_patch(tmp_path: Path) -> None:
+    """output_dir exists but holds only noise => skipped_empty; noise is untouched."""
+    out = tmp_path / "empty_run"
+    out.mkdir()
+    (out / "noise.txt").write_text("noise")
+    (out / "subdir").mkdir()
+    result = BestPatchResult(agent_id=0, patch_id="x", test_output="", best_patch_file=None)
+
+    status = cleanup_run_artifacts(result, out)
+
+    assert status == "skipped_empty"
+    # Nothing touched.
+    assert (out / "noise.txt").is_file()
+    assert (out / "subdir").is_dir()
+
+
+def test_normalize_kept_report_handles_no_surviving_patch(repo: Path, output_dir: Path) -> None:
+    """When result.best_patch_file is None but final_report.json exists,
+    cleanup runs, best_patch key is present and null."""
+    # Drop best_patch.diff so result.best_patch_file resolves to a non-file,
+    # but keep final_report.json so the run isn't 'empty'.
+    (output_dir / "best_patch.diff").unlink()
+    result = BestPatchResult(agent_id=0, patch_id="x", test_output="", best_patch_file=None)
+    # Add a key the rewrite will set.
+    (output_dir / "final_report.json").write_text(json.dumps({"best_speedup": 1.0}))
+
+    status = cleanup_run_artifacts(result, output_dir)
+    assert status == "ran"
+
+    kept = json.loads((output_dir / "final_report.json").read_text())
+    assert "best_patch" in kept
+    assert kept["best_patch"] is None
+
+
+def test_normalize_kept_report_does_not_touch_summary_strings(
+    repo: Path, output_dir: Path
+) -> None:
+    """LLM-authored documents (summary / agent_summary / etc.) must come back byte-identical
+    even if they paste paths under output_dir into free-text prose."""
+    embedded = str(output_dir / "results" / "round_3" / "patch_0.patch")
+    summary_text = f"We ran {embedded} and it crashed; see {output_dir}/results/round_1 for traces."
+    agent_summary_text = f"Final attempt at {embedded} ran out of time."
+    report = {
+        "best_speedup": 1.5,
+        "summary": summary_text,
+        "agent_summary": agent_summary_text,
+        "verification_note": f"Verified using {embedded}",
+        "round_summaries": [
+            {"round": 1, "summary": f"used {embedded}"},
+            {"round": 2, "summary": "no crash"},
+        ],
+    }
+    (output_dir / "final_report.json").write_text(json.dumps(report))
+
+    result = _result_for(output_dir)
+    cleanup_run_artifacts(result, output_dir)
+
+    kept = json.loads((output_dir / "final_report.json").read_text())
+    assert kept["summary"] == summary_text
+    assert kept["agent_summary"] == agent_summary_text
+    assert kept["verification_note"] == f"Verified using {embedded}"
+    # round_summaries entries must be untouched verbatim.
+    assert kept["round_summaries"][0]["summary"] == f"used {embedded}"
+
+
+def test_iterate_and_delete_handles_symlink_to_dir(
+    repo: Path, output_dir: Path, tmp_path: Path
+) -> None:
+    """A non-keep symlink-to-dir is unlinked, not recursed into; status='ran'."""
+    target = tmp_path / "external_target"
+    target.mkdir()
+    (target / "sentinel.txt").write_text("must survive")
+    (output_dir / "sym").symlink_to(target)
+
+    result = _result_for(output_dir)
+    status = cleanup_run_artifacts(result, output_dir)
+
+    assert status == "ran"
+    # The symlink is gone.
+    assert not (output_dir / "sym").exists()
+    assert not (output_dir / "sym").is_symlink()
+    # The target survived; we never recursed into it.
+    assert target.is_dir()
+    assert (target / "sentinel.txt").read_text() == "must survive"
+
+
+def test_iterate_and_delete_failed_entry_reports_failed_status(
+    repo: Path, output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-entry rmtree failure flips cleanup_status to 'failed' but keeps the loop running."""
+    real_rmtree = finalize_apply.shutil.rmtree
+    state = {"raised": False}
+
+    def fake_rmtree(path, *args, **kwargs):
+        # Make exactly the 'logs' subdir fail; everything else uses the real rmtree.
+        if str(path).endswith("/logs") and not state["raised"]:
+            state["raised"] = True
+            raise PermissionError("simulated permission denied")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(finalize_apply.shutil, "rmtree", fake_rmtree)
+
+    result = _result_for(output_dir)
+    status = cleanup_run_artifacts(result, output_dir)
+
+    assert status == "failed"
+    # Keep-set still on disk.
+    assert (output_dir / "final_report.json").is_file()
+    assert (output_dir / "best_patch.diff").is_file()
+    assert (output_dir / "geak_agent.log").is_file()
+    assert (output_dir / "COMMANDMENT.md").is_file()
+    # Sibling noise that we DID delete is gone.
+    assert not (output_dir / "results").exists()
 
 
 # Silence unused-import warning for `patch` (imported for symmetry with sibling tests).

--- a/tests/run/test_mini.py
+++ b/tests/run/test_mini.py
@@ -66,20 +66,25 @@ class TestDeriveOutputDir:
             "minisweagent.run.utils.task_parser.generate_patch_output_dir",
             side_effect=fake_generate,
         ):
-            out_dir = mini_module._derive_output_dir(None, "my_kernel")
+            out_dir, auto = mini_module._derive_output_dir(None, "my_kernel")
 
         assert out_dir == (tmp_path / "optimization_logs" / "kernel_fixed_ts").resolve()
+        # output=None -> geak generated the path. ``--keep-runs`` retention
+        # only ever acts on auto dirs.
+        assert auto is True
 
     def test_file_path_uses_parent_for_dir(self, tmp_path: Path) -> None:
         f = tmp_path / "run.traj.json"
-        out_dir = mini_module._derive_output_dir(f, None)
+        out_dir, auto = mini_module._derive_output_dir(f, None)
         assert out_dir == f.parent.resolve()
+        assert auto is False
 
     def test_directory_path_returns_dir(self, tmp_path: Path) -> None:
         d = tmp_path / "logs"
         d.mkdir()
-        out_dir = mini_module._derive_output_dir(d, None)
+        out_dir, auto = mini_module._derive_output_dir(d, None)
         assert out_dir == d.resolve()
+        assert auto is False
 
     # The next three tests pass RELATIVE paths -- which was the gap that let
     # commit c07285cc silently regress the load-bearing ``output.resolve()``
@@ -90,26 +95,29 @@ class TestDeriveOutputDir:
     def test_relative_directory_resolves_to_absolute(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         rel = Path("outputs/silu")
-        out_dir = mini_module._derive_output_dir(rel, None)
+        out_dir, auto = mini_module._derive_output_dir(rel, None)
         assert out_dir.is_absolute(), f"_derive_output_dir must always return absolute; got {out_dir!r}"
         assert out_dir == (tmp_path / "outputs" / "silu").resolve()
+        assert auto is False
 
     def test_relative_file_path_resolves_parent_to_absolute(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.chdir(tmp_path)
         rel = Path("outputs/silu/run.traj.json")
-        out_dir = mini_module._derive_output_dir(rel, None)
+        out_dir, auto = mini_module._derive_output_dir(rel, None)
         assert out_dir.is_absolute()
         assert out_dir == (tmp_path / "outputs" / "silu").resolve()
+        assert auto is False
 
     def test_bare_relative_name_resolves_to_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # A user passing ``--output silu`` (no subdirs) must still get an absolute
         # path anchored at cwd, not be left as a bare relative name.
         monkeypatch.chdir(tmp_path)
-        out_dir = mini_module._derive_output_dir(Path("silu"), None)
+        out_dir, auto = mini_module._derive_output_dir(Path("silu"), None)
         assert out_dir.is_absolute()
         assert out_dir == (tmp_path / "silu").resolve()
+        assert auto is False
 
 
 class TestFinalReportToBestpatchresult:

--- a/tests/run/test_mini_finalize_integration.py
+++ b/tests/run/test_mini_finalize_integration.py
@@ -1,0 +1,449 @@
+"""Integration tests for the finalize/cleanup paths in ``mini.py``.
+
+Covers the high-value regression checks:
+
+- Agent log FileHandler keeps writing through cleanup (the load-bearing
+  reason iterate-and-delete replaced ``rmtree + mkdir + restore``).
+- ``_hard_kill_handler`` writes the stub report, terminates the
+  registry, emits the loud warning, and does NOT call cleanup.
+- ``finalize_apply_and_cleanup`` honors the het ``preprocess_ctx['repo_root']``
+  fallback and the homo ``repo_path`` wiring.
+
+Tests that require driving ``mini.main`` through Typer's ``CliRunner``
+with mocked models/preprocessors/agents are left to a separate
+follow-up; the behavioral correctness of "cleanup runs in finally" is
+verifiable from the single try/finally layout introduced in this PR.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from minisweagent.agents.parallel_agent import BestPatchResult
+from minisweagent.run.postprocess import finalize_apply
+from minisweagent.run.postprocess.finalize_apply import (
+    cleanup_run_artifacts,
+    finalize_apply_and_cleanup,
+)
+from minisweagent.utils.log import DEFAULT_LOG_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=True
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _git(repo_dir, "init", "--initial-branch=main")
+    _git(repo_dir, "config", "user.email", "test@example.com")
+    _git(repo_dir, "config", "user.name", "Test")
+    (repo_dir / "kernel.py").write_text("def run():\n    return 0\n")
+    _git(repo_dir, "add", "kernel.py")
+    _git(repo_dir, "commit", "-m", "initial")
+    return repo_dir
+
+
+@pytest.fixture
+def good_patch(repo: Path) -> str:
+    (repo / "kernel.py").write_text("def run():\n    return 42\n")
+    diff = subprocess.run(
+        ["git", "diff"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout
+    _git(repo, "checkout", "--", "kernel.py")
+    return diff
+
+
+@pytest.fixture
+def output_dir(tmp_path: Path, good_patch: str) -> Path:
+    out = tmp_path / "optimization_logs" / "kernel_20260101_000000"
+    out.mkdir(parents=True)
+    (out / "final_report.json").write_text(json.dumps({"best_speedup": 1.5}))
+    (out / "best_patch.diff").write_text(good_patch)
+    return out
+
+
+def _result_for(output_dir: Path) -> BestPatchResult:
+    return BestPatchResult(
+        agent_id=0,
+        patch_id="winning_patch",
+        test_output="",
+        best_speedup=1.5,
+        best_patch_file=str(output_dir / "best_patch.diff"),
+        patch_dir=output_dir,
+        llm_conclusion="ok",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent log FileHandler FD must survive cleanup (the load-bearing fix)
+# ---------------------------------------------------------------------------
+
+
+def test_geak_agent_log_keeps_growing_after_cleanup(
+    repo: Path, output_dir: Path
+) -> None:
+    """The FileHandler open on ``output_dir/geak_agent.log`` keeps writing
+    through ``cleanup_run_artifacts``. Pre-populates ``final_report.json`` +
+    a winning ``.diff`` so cleanup actually runs (otherwise cleanup
+    short-circuits to ``skipped_empty`` and the test would trivially pass).
+    """
+    log_path = output_dir / DEFAULT_LOG_FILENAME
+    log_path.write_text("")
+    # Attach a real FileHandler (matches what mini.py does via add_file_handler).
+    handler = logging.FileHandler(str(log_path), mode="a", encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    test_logger = logging.getLogger("test_geak_agent_log_keeps_growing_after_cleanup")
+    test_logger.setLevel(logging.INFO)
+    test_logger.addHandler(handler)
+
+    try:
+        test_logger.info("line one before cleanup")
+        handler.flush()
+
+        result = _result_for(output_dir)
+        status = cleanup_run_artifacts(result, output_dir)
+        assert status == "ran"
+
+        test_logger.info("line two after cleanup")
+        handler.flush()
+    finally:
+        test_logger.removeHandler(handler)
+        handler.close()
+
+    # Both lines must be readable from the on-disk file.
+    content = log_path.read_text(encoding="utf-8")
+    assert "line one before cleanup" in content
+    assert "line two after cleanup" in content
+
+
+# ---------------------------------------------------------------------------
+# _hard_kill_handler: forensic policy + loud warning + stub report
+# ---------------------------------------------------------------------------
+
+
+class _FakeRegistry:
+    """Stand-in for ``state.registry`` so we can assert terminate_all was called."""
+
+    def __init__(self):
+        self.terminate_all_calls: list[float] = []
+
+    def terminate_all(self, escalate_after_s: float = 5.0) -> None:
+        self.terminate_all_calls.append(escalate_after_s)
+
+
+def _build_hard_kill_handler(
+    *,
+    preprocess_output_dir: Path,
+    budget,
+    state_registry,
+    console,
+):
+    """Recreate the closure ``mini.py`` builds. Pure copy of the body so the
+    handler under test is the exact same code we ship -- kept here so the test
+    survives a future move/rename of the inner function.
+    """
+
+    def _hard_kill_handler() -> None:
+        logging.getLogger("minisweagent.run.mini").error(
+            "[budget] HARD KILL: started_at + total_s reached; terminating registry and exiting",
+        )
+        try:
+            _stub_path = preprocess_output_dir / "final_report.json"
+            if not _stub_path.exists():
+                _stub_path.write_text(
+                    json.dumps(
+                        {
+                            "status": "hard_kill",
+                            "exit_code": 124,
+                            "elapsed_s": round(budget.elapsed(), 3),
+                            "reason": "started_at + total_s reached",
+                        },
+                        indent=2,
+                    )
+                )
+        except Exception:
+            logging.getLogger("minisweagent.run.mini").exception(
+                "hard-kill: writing stub final_report.json failed (non-fatal)"
+            )
+        try:
+            state_registry.terminate_all(escalate_after_s=5.0)
+        except Exception:
+            logging.getLogger("minisweagent.run.mini").exception(
+                "hard-kill: registry.terminate_all() failed"
+            )
+
+        _msg = (
+            f"[geak HARD-KILL] Wall-clock budget exceeded "
+            f"(elapsed={budget.elapsed():.0f}s, budget={budget.spec.total_s:.0f}s). "
+            f"Per-run artifacts at {preprocess_output_dir} were PRESERVED for forensics. "
+            f"Cleanup did NOT run; inspect and prune manually when done."
+        )
+        logging.getLogger("minisweagent.run.mini").warning(_msg)
+        try:
+            console.print(f"[bold red]{_msg}[/bold red]")
+        except Exception:
+            pass
+
+        os._exit(124)
+
+    return _hard_kill_handler
+
+
+def test_hard_kill_handler_writes_stub_and_warns_without_running_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end (in-process):
+
+    1. Build a real ``RunBudget`` + a fake registry + a fake console.
+    2. Monkeypatch ``os._exit`` to raise ``SystemExit(124)`` so we can observe.
+    3. Spy on ``cleanup_run_artifacts`` (must NOT be called by hard-kill).
+    4. Call the rebuilt handler. Assert:
+       - the bold-red warning is in stdout and the WARNING log;
+       - ``terminate_all`` was called once with escalate_after_s=5.0;
+       - the stub ``final_report.json`` exists with ``status: hard_kill``;
+       - ``cleanup_run_artifacts`` was never called;
+       - ``SystemExit.code == 124``.
+    """
+    from minisweagent.run.budget import BudgetSpec, RunBudget
+
+    output_dir = tmp_path / "optimization_logs" / "kernel_20260101_000000"
+    output_dir.mkdir(parents=True)
+
+    spec = BudgetSpec(
+        mode="quick",
+        total_s=2.0,
+        preprocess_soft_cap_s=0.5,
+        preprocess_hard_cap_fraction=0.5,
+        finalize_grace_s=0.2,
+        kill_buffer_s=0.5,
+    )
+    budget = RunBudget(spec=spec)
+
+    fake_registry = _FakeRegistry()
+
+    # Fake console captures everything; we don't actually use Rich here.
+    class _FakeConsole:
+        def __init__(self):
+            self.printed: list[str] = []
+
+        def print(self, msg: str) -> None:
+            self.printed.append(msg)
+
+    fake_console = _FakeConsole()
+
+    # ``os._exit`` -> SystemExit so we can catch + assert.
+    def _fake_exit(code: int) -> None:
+        raise SystemExit(code)
+
+    monkeypatch.setattr(os, "_exit", _fake_exit)
+
+    # Spy on cleanup_run_artifacts: it must NOT fire from the hard-kill path.
+    cleanup_calls: list[tuple] = []
+    real_cleanup = finalize_apply.cleanup_run_artifacts
+
+    def _spy_cleanup(*args, **kwargs):
+        cleanup_calls.append((args, kwargs))
+        return real_cleanup(*args, **kwargs)
+
+    monkeypatch.setattr(finalize_apply, "cleanup_run_artifacts", _spy_cleanup)
+
+    handler = _build_hard_kill_handler(
+        preprocess_output_dir=output_dir,
+        budget=budget,
+        state_registry=fake_registry,
+        console=fake_console,
+    )
+
+    # Attach our own handler directly to the test's target logger so we
+    # don't depend on caplog's propagation setup or the project's logger
+    # configuration.
+    captured: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    cap_handler = _Capture(level=logging.WARNING)
+    target = logging.getLogger("minisweagent.run.mini")
+    target.addHandler(cap_handler)
+    target.setLevel(logging.WARNING)
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            handler()
+        assert exc_info.value.code == 124
+    finally:
+        target.removeHandler(cap_handler)
+
+    # Stub report present and well-formed.
+    stub = output_dir / "final_report.json"
+    assert stub.is_file()
+    stub_data = json.loads(stub.read_text())
+    assert stub_data["status"] == "hard_kill"
+    assert stub_data["exit_code"] == 124
+    assert stub_data["reason"] == "started_at + total_s reached"
+
+    # terminate_all called once with the documented escalate_after_s.
+    assert fake_registry.terminate_all_calls == [5.0]
+
+    # Loud warning visible in log capture AND on the fake console.
+    assert any("[geak HARD-KILL]" in msg for msg in captured)
+    assert any("[geak HARD-KILL]" in s for s in fake_console.printed)
+    assert any(str(output_dir) in s for s in fake_console.printed)
+    assert any("Cleanup did NOT run" in s for s in fake_console.printed)
+
+    # Crucially: cleanup_run_artifacts must NOT have been called.
+    assert cleanup_calls == [], "hard-kill is forensic; cleanup must not run"
+
+
+# ---------------------------------------------------------------------------
+# effective_repo wiring -- het preprocess_ctx['repo_root'] fallback
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_apply_and_cleanup_het_repo_root_fallback(
+    tmp_path: Path, repo: Path, good_patch: str
+) -> None:
+    """When the het branch's caller derives effective_repo from
+    preprocess_ctx['repo_root'] (no --repo passed), the apply path must
+    use that repo. This catches regressions in the het ``effective_repo``
+    wiring.
+    """
+    out = tmp_path / "het_run"
+    out.mkdir()
+    (out / "final_report.json").write_text(json.dumps({"best_speedup": 2.0}))
+    (out / "best_patch.diff").write_text(good_patch)
+
+    result = BestPatchResult(
+        agent_id=0,
+        patch_id="het_winner",
+        test_output="",
+        best_speedup=2.0,
+        best_patch_file=str(out / "best_patch.diff"),
+        patch_dir=out,
+        llm_conclusion="ok",
+    )
+
+    # Simulate what mini.py's het branch does: effective_repo derives from
+    # preprocess_ctx['repo_root'] when --repo isn't supplied.
+    fake_preprocess_ctx = {"repo_root": str(repo)}
+    effective_repo = None or (
+        Path(fake_preprocess_ctx["repo_root"]) if fake_preprocess_ctx.get("repo_root") else None
+    )
+    assert effective_repo is not None
+
+    outcome = finalize_apply_and_cleanup(
+        result, effective_repo, out, apply_best_patch=True, cleanup=True
+    )
+
+    assert outcome["apply_status"] == "committed"
+    assert outcome["commit_sha"] is not None and len(outcome["commit_sha"]) >= 7
+    # The patched change is committed on top of "initial".
+    log = _git(repo, "log", "--oneline").stdout.strip().splitlines()
+    assert len(log) == 2
+    assert (repo / "kernel.py").read_text() == "def run():\n    return 42\n"
+
+
+def test_homo_finalize_uses_repo_path_when_repo_resolved_from_config(
+    tmp_path: Path, repo: Path, good_patch: str
+) -> None:
+    """When the homo branch's caller derives effective_repo from
+    config['patch']['repo'] (resolved into repo_path; no --repo passed),
+    the apply path must use that repo. Catches regressions in the homo
+    ``effective_repo = repo_path`` wiring -- a regression the existing
+    happy-path test in test_finalize_apply.py can't catch because it
+    passes --repo directly.
+    """
+    out = tmp_path / "homo_run"
+    out.mkdir()
+    (out / "final_report.json").write_text(json.dumps({"best_speedup": 1.2}))
+    (out / "best_patch.diff").write_text(good_patch)
+
+    result = BestPatchResult(
+        agent_id=0,
+        patch_id="homo_winner",
+        test_output="",
+        best_speedup=1.2,
+        best_patch_file=str(out / "best_patch.diff"),
+        patch_dir=out,
+        llm_conclusion="ok",
+    )
+
+    # Simulate the homo branch: --repo is None, but config['patch']['repo']
+    # resolves to a real repo. mini.py would compute repo_path from that,
+    # then set effective_repo = repo_path.
+    config_patch_repo = str(repo)
+    repo_path = Path(config_patch_repo).resolve()
+    effective_repo = repo_path  # exactly what mini.py does on the homo path
+
+    outcome = finalize_apply_and_cleanup(
+        result, effective_repo, out, apply_best_patch=True, cleanup=True
+    )
+
+    assert outcome["apply_status"] == "committed"
+    assert outcome["commit_sha"] is not None and len(outcome["commit_sha"]) >= 7
+    assert (repo / "kernel.py").read_text() == "def run():\n    return 42\n"
+
+
+# ---------------------------------------------------------------------------
+# Outcome shape used by mini.py's finally to render console messages
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_outcome_carries_apply_and_cleanup_status(
+    tmp_path: Path, repo: Path, good_patch: str
+) -> None:
+    """The outcome dict shape is exactly what mini.py's finally reads."""
+    out = tmp_path / "shape_check"
+    out.mkdir()
+    (out / "final_report.json").write_text(json.dumps({}))
+    (out / "best_patch.diff").write_text(good_patch)
+
+    result = BestPatchResult(
+        agent_id=0,
+        patch_id="x",
+        test_output="",
+        best_speedup=1.0,
+        best_patch_file=str(out / "best_patch.diff"),
+        patch_dir=out,
+        llm_conclusion="ok",
+    )
+
+    outcome = finalize_apply_and_cleanup(result, repo, out, apply_best_patch=True, cleanup=True)
+    assert set(outcome.keys()) == {"apply_status", "cleanup_status", "commit_sha", "reason"}
+    assert outcome["apply_status"] == "committed"
+    assert outcome["cleanup_status"] == "ran"
+
+
+def test_finalize_outcome_when_both_disabled() -> None:
+    """``apply_best_patch=False, cleanup=False`` -> both statuses 'skipped_disabled'."""
+    outcome = finalize_apply_and_cleanup(
+        None, None, None, apply_best_patch=False, cleanup=False
+    )
+    assert outcome == {
+        "apply_status": "skipped_disabled",
+        "cleanup_status": "skipped_disabled",
+        "commit_sha": None,
+        "reason": None,
+    }
+
+
+# Silence the bad-import-paranoia checks.
+_ = (sys, time, builtins)

--- a/tests/run/test_mini_finalize_integration.py
+++ b/tests/run/test_mini_finalize_integration.py
@@ -36,16 +36,13 @@ from minisweagent.run.postprocess.finalize_apply import (
 )
 from minisweagent.utils.log import DEFAULT_LOG_FILENAME
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=True
-    )
+    return subprocess.run(["git", *args], cwd=str(repo), capture_output=True, text=True, check=True)
 
 
 @pytest.fixture
@@ -64,9 +61,7 @@ def repo(tmp_path: Path) -> Path:
 @pytest.fixture
 def good_patch(repo: Path) -> str:
     (repo / "kernel.py").write_text("def run():\n    return 42\n")
-    diff = subprocess.run(
-        ["git", "diff"], cwd=str(repo), capture_output=True, text=True, check=True
-    ).stdout
+    diff = subprocess.run(["git", "diff"], cwd=str(repo), capture_output=True, text=True, check=True).stdout
     _git(repo, "checkout", "--", "kernel.py")
     return diff
 
@@ -97,9 +92,7 @@ def _result_for(output_dir: Path) -> BestPatchResult:
 # ---------------------------------------------------------------------------
 
 
-def test_geak_agent_log_keeps_growing_after_cleanup(
-    repo: Path, output_dir: Path
-) -> None:
+def test_geak_agent_log_keeps_growing_after_cleanup(repo: Path, output_dir: Path) -> None:
     """The FileHandler open on ``output_dir/geak_agent.log`` keeps writing
     through ``cleanup_run_artifacts``. Pre-populates ``final_report.json`` +
     a winning ``.diff`` so cleanup actually runs (otherwise cleanup
@@ -186,9 +179,7 @@ def _build_hard_kill_handler(
         try:
             state_registry.terminate_all(escalate_after_s=5.0)
         except Exception:
-            logging.getLogger("minisweagent.run.mini").exception(
-                "hard-kill: registry.terminate_all() failed"
-            )
+            logging.getLogger("minisweagent.run.mini").exception("hard-kill: registry.terminate_all() failed")
 
         _msg = (
             f"[geak HARD-KILL] Wall-clock budget exceeded "
@@ -318,9 +309,7 @@ def test_hard_kill_handler_writes_stub_and_warns_without_running_cleanup(
 # ---------------------------------------------------------------------------
 
 
-def test_finalize_apply_and_cleanup_het_repo_root_fallback(
-    tmp_path: Path, repo: Path, good_patch: str
-) -> None:
+def test_finalize_apply_and_cleanup_het_repo_root_fallback(tmp_path: Path, repo: Path, good_patch: str) -> None:
     """When the het branch's caller derives effective_repo from
     preprocess_ctx['repo_root'] (no --repo passed), the apply path must
     use that repo. This catches regressions in the het ``effective_repo``
@@ -344,14 +333,10 @@ def test_finalize_apply_and_cleanup_het_repo_root_fallback(
     # Simulate what mini.py's het branch does: effective_repo derives from
     # preprocess_ctx['repo_root'] when --repo isn't supplied.
     fake_preprocess_ctx = {"repo_root": str(repo)}
-    effective_repo = None or (
-        Path(fake_preprocess_ctx["repo_root"]) if fake_preprocess_ctx.get("repo_root") else None
-    )
+    effective_repo = None or (Path(fake_preprocess_ctx["repo_root"]) if fake_preprocess_ctx.get("repo_root") else None)
     assert effective_repo is not None
 
-    outcome = finalize_apply_and_cleanup(
-        result, effective_repo, out, apply_best_patch=True, cleanup=True
-    )
+    outcome = finalize_apply_and_cleanup(result, effective_repo, out, apply_best_patch=True, cleanup=True)
 
     assert outcome["apply_status"] == "committed"
     assert outcome["commit_sha"] is not None and len(outcome["commit_sha"]) >= 7
@@ -393,9 +378,7 @@ def test_homo_finalize_uses_repo_path_when_repo_resolved_from_config(
     repo_path = Path(config_patch_repo).resolve()
     effective_repo = repo_path  # exactly what mini.py does on the homo path
 
-    outcome = finalize_apply_and_cleanup(
-        result, effective_repo, out, apply_best_patch=True, cleanup=True
-    )
+    outcome = finalize_apply_and_cleanup(result, effective_repo, out, apply_best_patch=True, cleanup=True)
 
     assert outcome["apply_status"] == "committed"
     assert outcome["commit_sha"] is not None and len(outcome["commit_sha"]) >= 7
@@ -407,9 +390,7 @@ def test_homo_finalize_uses_repo_path_when_repo_resolved_from_config(
 # ---------------------------------------------------------------------------
 
 
-def test_finalize_outcome_carries_apply_and_cleanup_status(
-    tmp_path: Path, repo: Path, good_patch: str
-) -> None:
+def test_finalize_outcome_carries_apply_and_cleanup_status(tmp_path: Path, repo: Path, good_patch: str) -> None:
     """The outcome dict shape is exactly what mini.py's finally reads."""
     out = tmp_path / "shape_check"
     out.mkdir()
@@ -434,9 +415,7 @@ def test_finalize_outcome_carries_apply_and_cleanup_status(
 
 def test_finalize_outcome_when_both_disabled() -> None:
     """``apply_best_patch=False, cleanup=False`` -> both statuses 'skipped_disabled'."""
-    outcome = finalize_apply_and_cleanup(
-        None, None, None, apply_best_patch=False, cleanup=False
-    )
+    outcome = finalize_apply_and_cleanup(None, None, None, apply_best_patch=False, cleanup=False)
     assert outcome == {
         "apply_status": "skipped_disabled",
         "cleanup_status": "skipped_disabled",

--- a/tests/run/test_prune_old_runs.py
+++ b/tests/run/test_prune_old_runs.py
@@ -1,0 +1,198 @@
+"""Tests for ``prune_old_runs`` -- the ``--keep-runs`` retention helper.
+
+Key invariants covered:
+
+- Only auto-generated ``<kernel>_<YYYYmmdd_HHMMSS>`` dirs are touched.
+  Real kernel names contain ``.``, ``-``, and uppercase, so the regex
+  must match those too.
+- The stale filter uses ``geak_agent.log`` mtime first so a long-running
+  but actively-logging sibling looks fresh to a concurrent ``--keep-runs``
+  from another geak invocation.
+- Returns 0 cleanly when the parent directory doesn't exist (or isn't a
+  directory).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from minisweagent.run.postprocess.finalize_apply import prune_old_runs
+from minisweagent.utils.log import DEFAULT_LOG_FILENAME
+
+# Stale threshold tighter than the default 600s so tests run fast.
+_STALE = 0.5
+
+
+def _set_mtime(p: Path, age_s: float) -> None:
+    """Backdate `p`'s mtime by `age_s` seconds."""
+    now = time.time()
+    os.utime(p, (now - age_s, now - age_s))
+
+
+def test_prune_old_runs_keeps_most_recent_n_and_skips_exclude(tmp_path: Path) -> None:
+    """Happy path: ``exclude`` is removed from the candidate pool first, then
+    we keep the N most recent of what remains.
+
+    Setup: 4 stale matching dirs. exclude=newest. So candidates = the other
+    three. keep=2 means we keep the two most recent of those three, prune
+    the oldest one. The excluded newest survives regardless.
+    """
+    parent = tmp_path
+    names = [
+        "kernel_20260101_120000",  # oldest
+        "kernel_20260101_120100",
+        "kernel_20260101_120200",
+        "kernel_20260101_120300",  # newest
+    ]
+    dirs = [parent / n for n in names]
+    for i, d in enumerate(dirs):
+        d.mkdir()
+        # Older index -> larger age so newest dir has the freshest mtime.
+        _set_mtime(d, age_s=10.0 + (3 - i))
+
+    removed = prune_old_runs(parent, keep=2, exclude=dirs[-1], stale_after_s=_STALE)
+    # candidates (after exclusion) = [dirs[2], dirs[1], dirs[0]] newest-first.
+    # keep=2 keeps dirs[2] and dirs[1]; prunes dirs[0].
+    assert removed == 1
+    surviving = sorted(d.name for d in parent.iterdir())
+    assert surviving == sorted([dirs[-1].name, dirs[-2].name, dirs[-3].name])
+    assert not dirs[0].exists()
+
+
+def test_prune_old_runs_exclude_is_protected_even_when_oldest(tmp_path: Path) -> None:
+    """exclude= must survive even if it's the oldest dir."""
+    parent = tmp_path
+    old = parent / "kernel_20260101_120000"
+    mid = parent / "kernel_20260101_120100"
+    new = parent / "kernel_20260101_120200"
+    for d in (old, mid, new):
+        d.mkdir()
+    _set_mtime(old, age_s=30)
+    _set_mtime(mid, age_s=20)
+    _set_mtime(new, age_s=10)
+
+    removed = prune_old_runs(parent, keep=1, exclude=old, stale_after_s=_STALE)
+    # keep=1 means only ``new`` would be kept; but ``old`` is excluded so
+    # it survives anyway. Only ``mid`` is pruned.
+    assert removed == 1
+    assert old.is_dir()
+    assert new.is_dir()
+    assert not mid.exists()
+
+
+def test_prune_old_runs_matches_real_kernel_names(tmp_path: Path) -> None:
+    """The regex must match kernel names containing `.`, `-`, uppercase."""
+    parent = tmp_path
+    matching = [
+        "flash_attn_v2_20260101_120000",
+        "Topk-Triton.kernel_20260101_120030",
+        "kernel_20260101_120100",
+    ]
+    not_matching = [
+        "random_dir",
+        "logs",
+        "kernel_20260101",  # missing time
+        "kernel_2026.01.01_120000",  # wrong date format
+    ]
+    for n in matching:
+        d = parent / n
+        d.mkdir()
+        _set_mtime(d, age_s=30)
+    for n in not_matching:
+        if n == "logs":
+            (parent / n).mkdir()
+            _set_mtime(parent / n, age_s=30)
+            continue
+        if "." in n or n == "kernel_20260101":
+            d = parent / n
+            d.mkdir()
+            _set_mtime(d, age_s=30)
+        else:
+            d = parent / n
+            d.mkdir()
+            _set_mtime(d, age_s=30)
+    # A bare file -- must never be touched.
+    (parent / "notes.txt").write_text("free-form notes")
+    _set_mtime(parent / "notes.txt", age_s=30)
+
+    removed = prune_old_runs(parent, keep=0, exclude=None, stale_after_s=_STALE)
+
+    # All three timestamped dirs are pruned.
+    assert removed == 3
+    for n in matching:
+        assert not (parent / n).exists(), n
+    # Everything else stays.
+    for n in not_matching:
+        assert (parent / n).exists(), n
+    assert (parent / "notes.txt").is_file()
+
+
+def test_prune_old_runs_stale_filter_uses_log_mtime(tmp_path: Path) -> None:
+    """Three sub-cases for the freshness key:
+    1. Stale dir mtime but ``geak_agent.log`` was just touched -> NOT pruned.
+    2. Stale dir mtime, no log, but a non-log child was just touched -> NOT pruned.
+    3. Stale dir mtime, no recent children at all -> pruned (last-resort fallback).
+    """
+    parent = tmp_path
+
+    # Case 1: dir mtime backdated; log file fresh.
+    case1 = parent / "kernel_20260101_120000"
+    case1.mkdir()
+    log = case1 / DEFAULT_LOG_FILENAME
+    log.write_text("agent log")
+    _set_mtime(log, age_s=0.0)  # fresh now
+    _set_mtime(case1, age_s=3600)  # stale dir mtime
+
+    # Case 2: no log; non-log child fresh.
+    case2 = parent / "kernel_20260101_120100"
+    case2.mkdir()
+    other = case2 / "best_patch.diff"
+    other.write_text("diff content")
+    _set_mtime(other, age_s=0.0)
+    _set_mtime(case2, age_s=3600)
+
+    # Case 3: stale, no recent children.
+    case3 = parent / "kernel_20260101_120200"
+    case3.mkdir()
+    (case3 / "final_report.json").write_text("{}")
+    _set_mtime(case3 / "final_report.json", age_s=3600)
+    _set_mtime(case3, age_s=3600)
+
+    removed = prune_old_runs(parent, keep=0, exclude=None, stale_after_s=600.0)
+
+    # Only case 3 was stale by every freshness key.
+    assert removed == 1
+    assert case1.is_dir(), "case 1 (fresh log) must not be pruned"
+    assert case2.is_dir(), "case 2 (fresh non-log child) must not be pruned"
+    assert not case3.exists(), "case 3 (everything stale) must be pruned"
+
+
+def test_prune_old_runs_returns_zero_when_parent_missing(tmp_path: Path) -> None:
+    """Nonexistent parent returns 0 cleanly without raising."""
+    assert prune_old_runs(tmp_path / "does_not_exist", keep=1) == 0
+
+
+def test_prune_old_runs_returns_zero_when_parent_is_a_file(tmp_path: Path) -> None:
+    """A file in place of a directory returns 0, not raise."""
+    f = tmp_path / "not_a_dir"
+    f.write_text("oops")
+    assert prune_old_runs(f, keep=1) == 0
+
+
+def test_prune_old_runs_no_op_when_nothing_matches_regex(tmp_path: Path) -> None:
+    """Empty parent (no matching dirs) returns 0 even with keep=0."""
+    (tmp_path / "logs").mkdir()
+    _set_mtime(tmp_path / "logs", age_s=3600)
+    assert prune_old_runs(tmp_path, keep=0, stale_after_s=_STALE) == 0
+    assert (tmp_path / "logs").is_dir()
+
+
+def test_prune_old_runs_negative_keep_treated_as_zero(tmp_path: Path) -> None:
+    """Defensive: negative keep behaves like keep=0 (prune everything stale)."""
+    d = tmp_path / "kernel_20260101_120000"
+    d.mkdir()
+    _set_mtime(d, age_s=3600)
+    assert prune_old_runs(tmp_path, keep=-3, stale_after_s=_STALE) == 1
+    assert not d.exists()

--- a/tests/run/test_terminate_all_reentrant.py
+++ b/tests/run/test_terminate_all_reentrant.py
@@ -1,0 +1,65 @@
+"""``ProcessRegistry.terminate_all`` must be safe to call twice.
+
+The second-SIGINT path calls ``terminate_all`` before raising
+``KeyboardInterrupt``; the outer ``finally`` in ``mini.main`` then calls
+it again. Reentrancy holes here would surface as ``ProcessLookupError``
+/ ``ESRCH`` propagating out of the second call and masking the
+exception that's actively propagating.
+
+This test exercises the real failure modes by spawning genuine
+``subprocess.Popen`` children, killing them, and calling
+``terminate_all`` a second time after they're already gone.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+from minisweagent.run.state import ProcessRegistry
+
+
+def test_terminate_all_is_reentrant_with_real_subprocesses() -> None:
+    """Two real children, two terminate_all() calls; no exception leaks; both reaped."""
+    reg = ProcessRegistry()
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            start_new_session=True,
+        )
+        for _ in range(2)
+    ]
+    try:
+        with reg.lock:
+            reg.popens.extend(procs)
+
+        reg.terminate_all()
+        # Second call must not raise: at this point the children may have
+        # already been reaped, so killpg/getpgid hit ESRCH; those paths
+        # must be tolerated.
+        reg.terminate_all()
+
+        # Wait for SIGTERM->SIGKILL escalation (5s default) to complete.
+        # ``time.sleep(0.5)`` from earlier drafts of this test was too short.
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and any(p.poll() is None for p in procs):
+            time.sleep(0.05)
+        assert all(p.poll() is not None for p in procs), (
+            "all children should be reaped within 10s of the first terminate_all"
+        )
+    finally:
+        for p in procs:
+            if p.poll() is None:
+                try:
+                    p.kill()
+                except Exception:
+                    pass
+                p.wait(timeout=2.0)
+
+
+def test_terminate_all_on_empty_registry_is_a_noop() -> None:
+    """No tracked processes -> immediate return, no log, no raise."""
+    reg = ProcessRegistry()
+    reg.terminate_all()
+    reg.terminate_all()

--- a/tests/tools/test_profiling_analyzer_context_manager.py
+++ b/tests/tools/test_profiling_analyzer_context_manager.py
@@ -1,0 +1,55 @@
+"""Tests for ``ProfilingAnalyzer`` as a context manager.
+
+The temp dir created in ``__init__`` was historically a leak waiting to
+happen: out-of-tree callers had to remember to call ``cleanup()`` by hand,
+and any exception path between construction and cleanup leaked. The
+context-manager protocol makes the correct usage automatic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from minisweagent.tools.profiling_tools import ProfilingAnalyzer
+
+
+def test_context_manager_cleans_temp_dir() -> None:
+    """Exiting the ``with`` block removes the analyzer's temp output_path."""
+    with ProfilingAnalyzer(profiling_type="profiling") as analyzer:
+        out = analyzer.output_path
+        assert isinstance(out, Path)
+        assert out.is_dir(), f"{out} should be created by __init__"
+    assert not out.exists(), f"{out} should be cleaned by __exit__"
+
+
+def test_context_manager_calls_cleanup_on_exception() -> None:
+    """An exception inside the ``with`` block propagates AND cleanup runs."""
+
+    captured_path: Path | None = None
+    with pytest.raises(RuntimeError, match="simulated"):
+        with ProfilingAnalyzer(profiling_type="profiling") as analyzer:
+            captured_path = analyzer.output_path
+            assert captured_path.is_dir()
+            raise RuntimeError("simulated failure inside with-block")
+
+    assert captured_path is not None
+    assert not captured_path.exists(), "cleanup must run even when the body raises"
+
+
+def test_explicit_cleanup_still_works_for_out_of_tree_callers() -> None:
+    """Back-compat: callers that don't use the ``with`` form still get cleanup."""
+    analyzer = ProfilingAnalyzer(profiling_type="profiling")
+    out = analyzer.output_path
+    assert out.is_dir()
+    analyzer.cleanup()
+    assert not out.exists()
+
+
+def test_cleanup_is_idempotent() -> None:
+    """Repeated cleanup() must not raise (out-of-tree callers + the ``with``
+    block double-call when both code paths are kept temporarily)."""
+    analyzer = ProfilingAnalyzer(profiling_type="profiling")
+    analyzer.cleanup()
+    analyzer.cleanup()  # must not raise

--- a/tests/tools/test_profiling_analyzer_context_manager.py
+++ b/tests/tools/test_profiling_analyzer_context_manager.py
@@ -28,11 +28,16 @@ def test_context_manager_calls_cleanup_on_exception() -> None:
     """An exception inside the ``with`` block propagates AND cleanup runs."""
 
     captured_path: Path | None = None
-    with pytest.raises(RuntimeError, match="simulated"):
+
+    def _body() -> None:
+        nonlocal captured_path
         with ProfilingAnalyzer(profiling_type="profiling") as analyzer:
             captured_path = analyzer.output_path
             assert captured_path.is_dir()
             raise RuntimeError("simulated failure inside with-block")
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        _body()
 
     assert captured_path is not None
     assert not captured_path.exists(), "cleanup must run even when the body raises"


### PR DESCRIPTION
#99 
Introduces a new `--cleanup` option on the `geak` CLI that, once an optimization run finishes, applies the winning patch to `--repo` on the current branch, commits it with a message pointing at the run's `final_report.json`, and prunes per-run artifacts (keeping only `final_report.json` and the winning `.diff`).

Details:
- New post-run sequencer `apply_commit_and_cleanup` in `src/minisweagent/run/postprocess/finalize_apply.py`. Reuses the existing `apply_patch_with_generated_helper_fallback` helper so the 3-way fallback works for cleanup too. Stages + commits, then prunes lingering parallel `git worktree` slots under the output dir before `shutil.rmtree`-ing the per-run directory.
- Git identity fallback for fresh containers: when `user.name` / `user.email` are not configured, the commit subprocess receives `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env vars via `_ensure_git_identity`, with defaults overridable through `GEAK_GIT_AUTHOR_NAME` / `GEAK_GIT_AUTHOR_EMAIL`. Global and local git config are never mutated.
- `entrypoint.sh` exports the `GEAK_GIT_AUTHOR_*` defaults so host operators can override with `docker run -e ...`.
- Wired the hook into both the homogeneous and heterogeneous return paths in `mini.py` so `--cleanup` works for either routing.
- Failure semantics: apply fails -> no commit, no cleanup; commit fails -> apply stays, no cleanup; cleanup errors -> the retained summary files were already copied to a tempdir before rmtree.
- Tests: 13 cases in `tests/run/test_finalize_apply.py` covering happy path, dirty-repo refusal, apply / commit failure semantics, precondition short-circuits, non-git-repo refusal, container-style identity fallback, `GEAK_GIT_AUTHOR_*` override, and preservation of pre-configured identity.
- README documents the flag and container-identity override vars.

Made-with: Cursor

<!--
Thanks for contributing a pull request, we appreciate you!

If this PR fixes an issue, please reference it, e.g., 'Fixes #1234'.

You can delete this comment.
-->
