### PR TITLE
fix(docker): include scripts/ in image so make index works at runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !Makefile
 !src/
 !mcp_tools/
+!scripts/
 !skills/
 !docs/
 !knowledge-base/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN python3 -c "from profiler_mcp.server import profile_kernel; from metrix impo
 # Runtime assets (not needed for install; changes only rebuild cheap COPY layers)
 COPY skills/ skills/
 COPY docs/ docs/
+COPY scripts/ scripts/
 COPY entrypoint.sh ./
 
 RUN chmod +x /workspace/entrypoint.sh


### PR DESCRIPTION
Fix to get `make index` and RAG working with Docker.
