### PR TITLE
unify all timeout to GEAK_TEST_TIMEOUT and GEAK_PROFILE_TIMEOUT

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from jinja2 import StrictUndefined, Template
 
 from minisweagent import Environment, Model
-from minisweagent.skills.skill_runtime import SkillRuntime
 from minisweagent.run.utils.timeouts import GEAK_TEST_TIMEOUT
+from minisweagent.skills.skill_runtime import SkillRuntime
 from minisweagent.tools.tools_runtime import ToolRuntime
 
 logger = logging.getLogger(__name__)

--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -13,6 +13,7 @@ from jinja2 import StrictUndefined, Template
 
 from minisweagent import Environment, Model
 from minisweagent.skills.skill_runtime import SkillRuntime
+from minisweagent.run.utils.timeouts import GEAK_TEST_TIMEOUT
 from minisweagent.tools.tools_runtime import ToolRuntime
 
 logger = logging.getLogger(__name__)
@@ -208,7 +209,7 @@ class DefaultAgent:
         context = SaveAndTestContext(
             cwd=cwd,
             test_command=self.config.test_command,
-            timeout=getattr(self.env.config, "timeout", 3600),
+            timeout=getattr(self.env.config, "timeout", None) or GEAK_TEST_TIMEOUT,
             patch_output_dir=self.config.patch_output_dir,
             env_vars=getattr(self.env.config, "env", None),
             base_repo_path=self.base_repo_path,

--- a/src/minisweagent/config/geak.yaml
+++ b/src/minisweagent/config/geak.yaml
@@ -28,4 +28,5 @@ model:
 tools:
   profiling: false
   profiling_type: profiling
+  profile_timeout: 3600
   rag: false

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -18,8 +18,6 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-
-from minisweagent.run.utils.timeouts import GEAK_PROFILE_TIMEOUT, GEAK_TEST_TIMEOUT
 from typing import Any
 
 from minisweagent.run.postprocess.benchmark_parsing import (
@@ -32,6 +30,7 @@ from minisweagent.run.utils.generated_artifacts import (
     apply_patch_with_generated_helper_fallback,
 )
 from minisweagent.run.utils.git_safe_env import get_git_safe_env
+from minisweagent.run.utils.timeouts import GEAK_PROFILE_TIMEOUT, GEAK_TEST_TIMEOUT
 
 logger = logging.getLogger(__name__)
 

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -18,6 +18,8 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+
+from minisweagent.run.utils.timeouts import GEAK_PROFILE_TIMEOUT, GEAK_TEST_TIMEOUT
 from typing import Any
 
 from minisweagent.run.postprocess.benchmark_parsing import (
@@ -247,7 +249,7 @@ def run_correctness_and_benchmark(
                 ["bash", correctness_script],
                 capture_output=True,
                 text=True,
-                timeout=600,
+                timeout=GEAK_TEST_TIMEOUT,
                 cwd=str(eval_worktree),
                 env=eval_env,
             )
@@ -295,7 +297,7 @@ def run_correctness_and_benchmark(
                 ["bash", benchmark_script],
                 capture_output=True,
                 text=True,
-                timeout=1800,
+                timeout=GEAK_TEST_TIMEOUT,
                 cwd=str(eval_worktree),
                 env=eval_env,
             )
@@ -415,7 +417,7 @@ def run_profile(
             ["bash", profile_script],
             capture_output=True,
             text=True,
-            timeout=1800,
+            timeout=GEAK_PROFILE_TIMEOUT,
             cwd=str(eval_worktree),
             env=eval_env,
         )

--- a/src/minisweagent/run/preprocess/commandment.py
+++ b/src/minisweagent/run/preprocess/commandment.py
@@ -319,7 +319,8 @@ def _auto_fix(content: str, errors: list[str]) -> str:
         m = re.search(r"Command starts with shell built-in ['\"](\w+)['\"].*?['\"](.+?)['\"]", error)
         if m:
             original_cmd = m.group(2)
-            fixed_cmd = f'bash -c "{original_cmd}"'
+            escaped = original_cmd.replace("'", "'\\''")
+            fixed_cmd = f"bash -c '{escaped}'"
             content = content.replace(original_cmd, fixed_cmd)
 
         # Fix: inline env var prefix -> wrap in bash -c
@@ -327,7 +328,8 @@ def _auto_fix(content: str, errors: list[str]) -> str:
         m = re.search(r"Command uses inline env var prefix ['\"](\w+=\S+)['\"].*?['\"](.+?)['\"]", error)
         if m:
             original_cmd = m.group(2)
-            fixed_cmd = f'bash -c "{original_cmd}"'
+            escaped = original_cmd.replace("'", "'\\''")
+            fixed_cmd = f"bash -c '{escaped}'"
             content = content.replace(original_cmd, fixed_cmd)
 
     return content

--- a/src/minisweagent/run/preprocess/harness_utils.py
+++ b/src/minisweagent/run/preprocess/harness_utils.py
@@ -1107,7 +1107,6 @@ def execute_harness_validation(
     repo_root: str | None = None,
     gpu_id: int = 0,
     benchmark_extra_args: str | None = None,
-    use_uta_timeouts: bool = False,
 ) -> tuple[bool, list[str], list[dict]]:
     """Run the harness across all modes and return ``(ok, errors, results)``.
 
@@ -1122,12 +1121,6 @@ def execute_harness_validation(
         ``GEAK_BENCHMARK_ITERATIONS`` so harnesses do not need to expose it
         as a CLI flag. Any remaining args are passed via
         ``GEAK_BENCHMARK_EXTRA_ARGS``.
-    use_uta_timeouts:
-        When True, use ``UTA_MODE_TIMEOUTS`` instead of the default
-        ``MODE_TIMEOUTS``.  The UTA timeout for ``--correctness`` is more
-        relaxed (default 900 s, overridable via ``GEAK_UTA_CORRECTNESS_TIMEOUT``)
-        to handle kernels with expensive initialisation (e.g. physics sims)
-        that exceed the normal 300 s limit and cause the agent to retry forever.
 
     Returns
     -------
@@ -1138,7 +1131,7 @@ def execute_harness_validation(
     results : list[dict]
         Per-mode result dicts from :func:`run_harness`.
     """
-    from minisweagent.run.preprocess.run_harness import UTA_MODE_TIMEOUTS, results_errors, run_harness
+    from minisweagent.run.preprocess.run_harness import results_errors, run_harness
 
     env_overrides: dict[str, str] = {}
     # Keep validation fast: override iterations to a small number unless
@@ -1162,15 +1155,12 @@ def execute_harness_validation(
         if remaining_extra_args:
             env_overrides["GEAK_BENCHMARK_EXTRA_ARGS"] = remaining_extra_args
 
-    mode_timeouts = UTA_MODE_TIMEOUTS if use_uta_timeouts else None
-
     results = run_harness(
         harness_path,
         mode="all",
         repo_root=repo_root,
         gpu_id=gpu_id,
         env_overrides=env_overrides,
-        mode_timeouts=mode_timeouts,
     )
     if not isinstance(results, list):
         results = [results]
@@ -1269,7 +1259,6 @@ def create_validated_harness(
             harness,
             repo_root=repo_root,
             gpu_id=gpu_id,
-            use_uta_timeouts=True,
         )
         if exec_ok:
             try:

--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -38,6 +38,7 @@ def _ensure_mcp_importable() -> None:
 
 
 from minisweagent.run.preprocess.benchmark_parsing import extract_latency_ms
+from minisweagent.run.utils.timeouts import GEAK_TEST_TIMEOUT
 from minisweagent.run.preprocess.harness_utils import (
     DEFAULT_EVAL_BENCHMARK_ITERATIONS,
     DEFAULT_PIPELINE_OUTPUT_DIR,
@@ -410,7 +411,7 @@ def run_preprocessor(
     eval_command: str | None = None,
     correctness_command: str | list[str] | None = None,
     performance_command: str | list[str] | None = None,
-    benchmark_timeout: int = 3600,
+    benchmark_timeout: int | None = None,
 ) -> dict[str, Any]:
     """Run all preprocessing steps and return a context dict.
 
@@ -447,7 +448,7 @@ def run_preprocessor(
         directly for profiling and baseline capture — no ``&&`` guessing.
     benchmark_timeout:
         Timeout in seconds for the benchmark baseline subprocess.
-        Defaults to 3600s. Increase for kernels with long runtimes.
+        Defaults to GEAK_TEST_TIMEOUT. Increase for kernels with long runtimes.
 
     Returns
     -------
@@ -459,6 +460,8 @@ def run_preprocessor(
     _preprocess_t0 = time.monotonic()
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+    if benchmark_timeout is None:
+        benchmark_timeout = GEAK_TEST_TIMEOUT
 
     ctx: dict[str, Any] = {}
 
@@ -1047,7 +1050,7 @@ def run_preprocessor(
                 executable="/bin/bash",
                 capture_output=True,
                 text=True,
-                timeout=3600,
+                timeout=GEAK_TEST_TIMEOUT,
                 cwd=_cwd,
             )
             (output_dir / "correctness_stdout.txt").write_text(result.stdout or "")

--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -38,7 +38,6 @@ def _ensure_mcp_importable() -> None:
 
 
 from minisweagent.run.preprocess.benchmark_parsing import extract_latency_ms
-from minisweagent.run.utils.timeouts import GEAK_TEST_TIMEOUT
 from minisweagent.run.preprocess.harness_utils import (
     DEFAULT_EVAL_BENCHMARK_ITERATIONS,
     DEFAULT_PIPELINE_OUTPUT_DIR,
@@ -57,6 +56,7 @@ from minisweagent.run.preprocess.testcase_cache import (
     materialize_cached_harness,
     save_cached_harness,
 )
+from minisweagent.run.utils.timeouts import GEAK_TEST_TIMEOUT
 
 # ── main entry point ─────────────────────────────────────────────────
 

--- a/src/minisweagent/run/preprocess/run_harness.py
+++ b/src/minisweagent/run/preprocess/run_harness.py
@@ -38,23 +38,15 @@ MODE_TO_FLAG: dict[str, str] = {
     "full-benchmark": "--full-benchmark",
 }
 
+from minisweagent.run.utils.timeouts import GEAK_PROFILE_TIMEOUT, GEAK_TEST_TIMEOUT
+
 MODE_TIMEOUTS: dict[str, int] = {
-    "correctness": int(os.environ.get("GEAK_CORRECTNESS_TIMEOUT", "900")),
-    "profile": 120,
-    "benchmark": 600,
-    "full-benchmark": 900,
+    "correctness": GEAK_TEST_TIMEOUT,
+    "profile": GEAK_PROFILE_TIMEOUT,
+    "benchmark": GEAK_TEST_TIMEOUT,
+    "full-benchmark": GEAK_TEST_TIMEOUT,
 }
 
-# During UTA harness-generation validation the kernel may require expensive
-# initialisation (e.g. physics-simulation warm-up) that blows past the normal
-# 300 s correctness timeout.  A separate, more relaxed default applies only to
-# that phase so the pipeline doesn't retry in an infinite loop.
-# Override via GEAK_UTA_CORRECTNESS_TIMEOUT (seconds).
-_UTA_CORRECTNESS_TIMEOUT_DEFAULT = 1800
-
-UTA_MODE_TIMEOUTS: dict[str, int] = {
-    m: int(os.environ.get("GEAK_UTA_CORRECTNESS_TIMEOUT", _UTA_CORRECTNESS_TIMEOUT_DEFAULT)) for m in MODE_TIMEOUTS
-}
 
 _STDERR_TAIL_LINES = 60
 
@@ -148,7 +140,6 @@ def run_harness(
     gpu_id: int = 0,
     timeout: int | None = None,
     env_overrides: dict[str, str] | None = None,
-    mode_timeouts: dict[str, int] | None = None,
 ) -> dict[str, Any] | list[dict[str, Any]]:
     """Execute a test harness and return structured results.
 
@@ -165,14 +156,9 @@ def run_harness(
     gpu_id:
         GPU device for HIP_VISIBLE_DEVICES.
     timeout:
-        Per-mode timeout in seconds.  ``None`` uses the per-mode defaults
-        from :data:`MODE_TIMEOUTS` (or ``mode_timeouts`` if supplied).
+        Per-mode timeout in seconds.  ``None`` uses ``GEAK_TEST_TIMEOUT``.
     env_overrides:
         Extra environment variables merged into the subprocess env.
-    mode_timeouts:
-        Optional per-mode timeout overrides.  When provided, takes precedence
-        over :data:`MODE_TIMEOUTS` (but ``timeout`` still wins over both).
-        Use :data:`UTA_MODE_TIMEOUTS` for harness-generation validation.
 
     Returns
     -------
@@ -194,12 +180,11 @@ def run_harness(
 
     env = _build_env(repo_root, gpu_id, env_overrides)
     cwd = repo_root
-    _timeouts = mode_timeouts if mode_timeouts is not None else MODE_TIMEOUTS
 
     if mode == "all":
         results: list[dict[str, Any]] = []
         for m in MODES:
-            t = timeout if timeout is not None else _timeouts[m]
+            t = timeout if timeout is not None else MODE_TIMEOUTS[m]
             logger.info("run_harness: running --%s (timeout=%ds)", m, t)
             result = _run_single(harness_path, m, env=env, timeout=t, cwd=cwd)
             results.append(result)
@@ -226,7 +211,7 @@ def run_harness(
             "duration_s": 0.0,
         }
 
-    t = timeout if timeout is not None else _timeouts[mode]
+    t = timeout if timeout is not None else MODE_TIMEOUTS[mode]
     return _run_single(harness_path, mode, env=env, timeout=t, cwd=cwd)
 
 

--- a/src/minisweagent/run/task_file.py
+++ b/src/minisweagent/run/task_file.py
@@ -217,8 +217,20 @@ def _copy_nested_git_repos(repo_path: Path, worktree_path: Path) -> None:
             shutil.copytree(current, dst, symlinks=True)
 
 
+_UNTRACKED_SKIP_PATTERNS = (
+    "gpucore.*",
+    "core.*",
+    "*.core",
+    "*.coredump",
+)
+
+_UNTRACKED_MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+
+
 def _copy_untracked_files(repo_path: Path, worktree_path: Path, env: dict[str, str] | None = None) -> None:
     """Copy untracked files from repo to worktree."""
+    from fnmatch import fnmatch
+
     run_env = env if env is not None else None
     resolved_wt = worktree_path.resolve()
     try:
@@ -240,9 +252,24 @@ def _copy_untracked_files(repo_path: Path, worktree_path: Path, env: dict[str, s
                 continue
             except ValueError:
                 pass
-            if src.is_file():
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src, dst)
+            if not src.is_file():
+                continue
+            name = src.name
+            if any(fnmatch(name, pat) for pat in _UNTRACKED_SKIP_PATTERNS):
+                continue
+            try:
+                file_size = src.stat().st_size
+                if file_size > _UNTRACKED_MAX_FILE_SIZE:
+                    logging.getLogger(__name__).warning(
+                        "Skipping large untracked file %s (%.1f MB)",
+                        rel_path,
+                        file_size / (1024 * 1024),
+                    )
+                    continue
+            except OSError:
+                continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
     except subprocess.CalledProcessError:
         pass
 

--- a/src/minisweagent/run/utils/generated_artifacts.py
+++ b/src/minisweagent/run/utils/generated_artifacts.py
@@ -47,6 +47,10 @@ _ROOT_GENERATED_GLOBS = (
     "*.obj",
     "*.out",
     "*.bin",
+    "gpucore.*",
+    "core.*",
+    "*.core",
+    "*.coredump",
 )
 
 

--- a/src/minisweagent/run/utils/timeouts.py
+++ b/src/minisweagent/run/utils/timeouts.py
@@ -1,0 +1,78 @@
+"""Centralized pipeline timeout constants.
+
+Two knobs control all correctness/benchmark/profile timeouts across
+preprocessing, agent execution, and evaluation:
+
+  * ``GEAK_TEST_TIMEOUT``    – correctness, benchmark, full-benchmark, agent test
+  * ``GEAK_PROFILE_TIMEOUT`` – profile harness mode, eval profile, profiler warmup
+
+Each can be set via ``geak.yaml`` or an environment variable.  When both are
+set and disagree, ``geak.yaml`` wins and a warning is logged.
+
+YAML keys:
+  * ``env.timeout``           → GEAK_TEST_TIMEOUT    (default 3600 s)
+  * ``tools.profile_timeout`` → GEAK_PROFILE_TIMEOUT (default 3600 s)
+
+Environment variables:
+  * ``GEAK_TEST_TIMEOUT``
+  * ``GEAK_PROFILE_TIMEOUT``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TEST_TIMEOUT = 3600
+_DEFAULT_PROFILE_TIMEOUT = 3600
+
+
+def _load_yaml_config() -> dict:
+    try:
+        from minisweagent.config import load_config
+
+        return load_config("geak")
+    except Exception:
+        return {}
+
+
+def _resolve(yaml_value: int | None, env_var: str, default: int) -> int:
+    env_raw = os.environ.get(env_var)
+    env_value = int(env_raw) if env_raw is not None else None
+
+    if yaml_value is not None and env_value is not None and yaml_value != env_value:
+        logger.warning(
+            "%s=%d from env differs from geak.yaml value %d; using geak.yaml",
+            env_var,
+            env_value,
+            yaml_value,
+        )
+
+    if yaml_value is not None:
+        return yaml_value
+    if env_value is not None:
+        return env_value
+    return default
+
+
+def _init() -> tuple[int, int]:
+    cfg = _load_yaml_config()
+    env_cfg = cfg.get("env", {}) or {}
+    tools_cfg = cfg.get("tools", {}) or {}
+
+    yaml_test = env_cfg.get("timeout")
+    yaml_profile = tools_cfg.get("profile_timeout")
+
+    if yaml_test is not None:
+        yaml_test = int(yaml_test)
+    if yaml_profile is not None:
+        yaml_profile = int(yaml_profile)
+
+    test = _resolve(yaml_test, "GEAK_TEST_TIMEOUT", _DEFAULT_TEST_TIMEOUT)
+    profile = _resolve(yaml_profile, "GEAK_PROFILE_TIMEOUT", _DEFAULT_PROFILE_TIMEOUT)
+    return test, profile
+
+
+GEAK_TEST_TIMEOUT, GEAK_PROFILE_TIMEOUT = _init()

--- a/src/minisweagent/tools/save_and_test.py
+++ b/src/minisweagent/tools/save_and_test.py
@@ -683,11 +683,15 @@ class SaveAndTestTool:
                 "*.so",
                 ".geak_resolved/",
                 ".git.bak/",
+                "gpucore.*",
+                "core.*",
+                "*.core",
+                "*.coredump",
                 *self._generated_helper_excludes(),
             ]
             exclude_args = " ".join(f"':(exclude){entry}'" for entry in excludes)
             result = subprocess.run(
-                f"git add -N . && git diff --binary -- . {exclude_args}",
+                f"git add -N . && git diff -- . {exclude_args}",
                 cwd=cwd,
                 capture_output=True,
                 text=True,
@@ -697,7 +701,7 @@ class SaveAndTestTool:
             return result.stdout
 
         if ctx.base_repo_path and ctx.base_repo_path.exists():
-            excludes = [".git", "__pycache__", *self._generated_helper_excludes()]
+            excludes = [".git", "__pycache__", "gpucore.*", "core.*", *self._generated_helper_excludes()]
             if ctx.patch_output_dir:
                 run_dir_name = Path(ctx.patch_output_dir).resolve().parent.name
                 if run_dir_name:


### PR DESCRIPTION
 ## Summary

   - **Centralize timeout configuration** by introducing `src/minisweagent/run/utils/timeouts.py`, a single module that resolves `GEAK_TEST_TIMEOUT` and `GEAK_PROFILE_TIMEOUT` from `geak.yaml` or environment variables (with a 3600s
   default).
   - **Replace all scattered hardcoded timeouts** (300s, 600s, 900s, 1800s, 3600s) across preprocessing, harness execution, agent runtime, and evaluation with the two unified constants.
   - **Remove the separate `UTA_MODE_TIMEOUTS`** and the `use_uta_timeouts` / `mode_timeouts` parameters from `run_harness` and `harness_utils`, simplifying the harness execution interface.
   - **Skip coredump and large untracked files** during worktree setup (`task_file.py`) and patch generation (`save_and_test.py`) to avoid copying multi-GB crash artifacts.
   - **Fix shell-injection risk** in `commandment.py` auto-fix by switching from double-quoted to single-quoted `bash -c` wrappers.
   - **Add `profile_timeout`** to `geak.yaml` defaults so profiling timeout is also configurable.

   ## Motivation

   Timeout values were duplicated in ~10 places with inconsistent defaults (some 300s, some 900s, some 3600s), making it hard to tune for different workloads. This PR provides a single source of truth configurable via `geak.yaml`
   (`env.timeout` / `tools.profile_timeout`) or env vars (`GEAK_TEST_TIMEOUT` / `GEAK_PROFILE_TIMEOUT`).

   ## Test plan

   - [ ] Verify `GEAK_TEST_TIMEOUT` / `GEAK_PROFILE_TIMEOUT` resolve correctly from env vars, `geak.yaml`, and defaults
   - [ ] Run a full preprocessing + evaluation pipeline and confirm no timeout regressions
   - [ ] Confirm coredump files are excluded from worktree copies and patches