### PR TITLE
fix(amd_llm): read api_key and api_base from model_kwargs as fallback

### DIFF
--- a/src/minisweagent/models/amd_base.py
+++ b/src/minisweagent/models/amd_base.py
@@ -93,13 +93,19 @@ class AmdLlmModelBase:
     # ------------------------------------------------------------------
 
     def _get_api_key(self) -> str:
-        api_key = self.config.api_key or os.getenv("AMD_LLM_API_KEY") or os.getenv("LLM_GATEWAY_KEY")
+        api_key = (
+            self.config.api_key
+            or self.config.model_kwargs.get("api_key")
+            or os.getenv("AMD_LLM_API_KEY")
+            or os.getenv("LLM_GATEWAY_KEY")
+        )
         if not api_key:
             raise ValueError(
                 "API key not provided. Please set it via:\n"
                 "  1. VSCode settings (mini-swe-agent.apiKey), or\n"
-                "  2. Environment variable AMD_LLM_API_KEY, or\n"
-                "  3. Environment variable LLM_GATEWAY_KEY"
+                "  2. model_kwargs.api_key in the task config, or\n"
+                "  3. Environment variable AMD_LLM_API_KEY, or\n"
+                "  4. Environment variable LLM_GATEWAY_KEY"
             )
         return api_key
 

--- a/src/minisweagent/models/amd_claude.py
+++ b/src/minisweagent/models/amd_claude.py
@@ -52,7 +52,7 @@ class AmdClaudeModel(AmdLlmModelBase):
     def _init_client(self):
         api_key = self._get_api_key()
         user = self._get_user()
-        base_url = self.config.base_url or "https://llm-api.amd.com/Anthropic"
+        base_url = self.config.base_url or self.config.model_kwargs.get("api_base") or "https://llm-api.amd.com/Anthropic"
         self.client = anthropic.Anthropic(
             api_key="dummy",
             base_url=base_url,

--- a/src/minisweagent/models/amd_claude.py
+++ b/src/minisweagent/models/amd_claude.py
@@ -52,7 +52,9 @@ class AmdClaudeModel(AmdLlmModelBase):
     def _init_client(self):
         api_key = self._get_api_key()
         user = self._get_user()
-        base_url = self.config.base_url or self.config.model_kwargs.get("api_base") or "https://llm-api.amd.com/Anthropic"
+        base_url = (
+            self.config.base_url or self.config.model_kwargs.get("api_base") or "https://llm-api.amd.com/Anthropic"
+        )
         self.client = anthropic.Anthropic(
             api_key="dummy",
             base_url=base_url,


### PR DESCRIPTION
## Problem

When tasks are submitted via the GEAK online API, the runtime serialises the task config with  (empty string) regardless of what is set in . This causes  to always fall through to the  env-var lookup, which is also unset in the task container. Result: **every  task fails immediately** at agent startup with:

```
ValueError: API key not provided. Please set it via:
  1. VSCode settings (mini-swe-agent.apiKey), or
  2. Environment variable AMD_LLM_API_KEY, or
  3. Environment variable LLM_GATEWAY_KEY
```

The actual key *is* present in  (set via  or ), but  never checks there.

The same issue exists in :  is ignored when building the Anthropic client, so the caller-specified gateway URL is silently replaced by the hardcoded  default.

## Fix

** — **: add  as a fallback between  and the env-var lookups.

** — **: add  as a fallback before the hardcoded default base URL.

## Testing

Confirmed via  from GEAK tasks submitted with  set and  — all failed before this fix. The fallback chain is: .
