### PR TITLE
fix: skip rewrite_best_results in homogeneous/parallel mode

### DIFF
--- a/src/minisweagent/agents/parallel_agent.py
+++ b/src/minisweagent/agents/parallel_agent.py
@@ -138,17 +138,22 @@ class ParallelAgent(DefaultAgent):
         model = model_factory()
         _, best_patch_id = run_select_patch(base_patch_dir, num_parallel, metric, model)
 
-        # Override with deterministic benchmark parsing when possible
-        from minisweagent.run.postprocess.benchmark_parsing import rewrite_best_results
+        # Only call rewrite_best_results when patch_*_test.txt files exist
+        # directly in base_patch_dir (heterogeneous flat layout).  In
+        # homogeneous/parallel mode the files live in subdirectories
+        # (parallel_0/, parallel_1/) so compute_best_patch cannot find them
+        # and the fallback would incorrectly clamp the LLM's speedup to 1.0.
+        if list(base_patch_dir.glob("patch_*_test.txt")):
+            from minisweagent.run.postprocess.benchmark_parsing import rewrite_best_results
 
-        det_result = rewrite_best_results(base_patch_dir)
-        if det_result:
-            best_patch_id = det_result.get("best_patch_id", best_patch_id)
-            logger.info(
-                "Deterministic override: %s (%sx)",
-                best_patch_id,
-                det_result.get("best_patch_speedup", "?"),
-            )
+            det_result = rewrite_best_results(base_patch_dir)
+            if det_result:
+                best_patch_id = det_result.get("best_patch_id", best_patch_id)
+                logger.info(
+                    "Deterministic override: %s (%sx)",
+                    best_patch_id,
+                    det_result.get("best_patch_speedup", "?"),
+                )
 
         if not best_patch_id:
             logger.warning("SelectPatchAgent did not produce best_results.json.")

--- a/src/minisweagent/config/mini_kernel_strategy_list.yaml
+++ b/src/minisweagent/config/mini_kernel_strategy_list.yaml
@@ -80,7 +80,9 @@ agent:
        
     4. Before listing strategies, identify the bottleneck of the current kernel:
        - If `profile.json` exists in the workspace, use it as the primary profiling reference for optimization planning.
+    {% if 'profile_kernel' in tool_names %}
        - If `profile.json` is not available, call the `profile_kernel` tool with the appropriate working directory and command used during performance testing.
+    {% endif %}
 
     5. **Analyze and Prioritize Strategies**
        - Analyze computational complexity, memory access patterns, and parallelization opportunities
@@ -108,7 +110,9 @@ agent:
        - **Calculate relative change** compared to baseline (e.g., +21.1% improvement or -4.7% regression)
        - Record ONLY the relative change (percentage) in strategy file, not absolute values
        - Include reference to detailed log file for full metrics
+    {% if 'profile_kernel' in tool_names %}
        - **RECOMMENDED**: Use `profile_kernel` tool to profile the kernel after implementation to identify the bottleneck of the current kernel.
+    {% endif %}
        - **Decision**: If successful (performance improved), keep it. If failed (regression), revert the changes.
 
     8. **Explore Additional Strategies**
@@ -156,8 +160,8 @@ agent:
     ## Important Rules
 
     1. Every response must contain exactly one tool call
-    2. NOTE: This rule applies to `bash` tool only, NOT to `profile_kernel`.
-       For `bash` tool, directory or environment variable changes are not persistent. Every action is executed in a new subshell.
+    2. {% if 'profile_kernel' in tool_names %}NOTE: This rule applies to `bash` tool only, NOT to `profile_kernel`.
+       {% endif %}For `bash` tool, directory or environment variable changes are not persistent. Every action is executed in a new subshell.
        However, you can prefix any bash command with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
     3. Ignore policy: When analyzing logs / drawing conclusions / optimizing, IGNORE all information related to parallel execution or hardware assignment (e.g., "parallel X runs", "gpu idx N", "device id", multi-GPU, threads, streams, scheduling, affinity). This information is already handled by the backend; it MUST NOT enter your reasoning, MUST NOT influence decisions, and MUST NOT be mentioned in the final answer.
     4. All code edits MUST stay inside the current worktree. Never write files using absolute paths outside the current worktree.
@@ -203,6 +207,7 @@ agent:
     - **note**: Add documentation note
     - **summary**: Show statistics
 
+    {% if 'profile_kernel' in tool_names %}
     ### profile_kernel
     Profile GPU kernel with rocprof to identify bottlenecks. Parameters: command, workdir
     - **command**: Must be a single executable invocation (no shell operators). If you use relative paths (e.g. `scripts/...`), they are resolved relative to **workdir**.
@@ -211,6 +216,7 @@ agent:
     - Good example: `command="python3 scripts/task_runner.py performance", workdir="/path/to/project"`
     - Also ok: `command="python3 /absolute/path/to/scripts/task_runner.py performance"`
     - Bad example: `command="cd /path && python3 scripts/task_runner.py performance"`
+    {% endif %}
   
   action_observation_template: |
     <returncode>{{output.returncode}}</returncode>
@@ -225,7 +231,8 @@ agent:
     - **save_and_test**: Save patch and run performance test
     - **submit**: Submit final result and complete task
     - **strategy_manager**: Track optimization strategies
-    - **profile_kernel**: Profile GPU kernel with rocprof
+    {% if 'profile_kernel' in tool_names %}- **profile_kernel**: Profile GPU kernel with rocprof
+    {% endif %}
     {% if 'query' in tool_names %}- **query**: Search knowledge base for optimization techniques
     - **optimize**: Get optimization suggestions for specific kernel types
     {% endif %}</available_tools>


### PR DESCRIPTION
## Summary                                                                                                                                                                       
                                                                                                                                                                                
  - Fix rewrite_best_results incorrectly clamping speedup to 1.0x in homogeneous/parallel mode, even when a patch achieves significant speedup (e.g. 7.9x → 1.0x)               
                                                                                                                                                                                
## Root Cause                                                                                                                                                                    
                                                                                                                                                                                
  In homogeneous mode, ParallelAgent._select_best_from_parallel_runs calls rewrite_best_results(base_patch_dir) where base_patch_dir is round_1/. The internal                  
  compute_best_patch searches for patch_*_test.txt directly in that directory, but in homogeneous mode these files live in subdirectories (parallel_0/, parallel_1/). Since no
  test files are found:                                                                                                                                                         
                                                            
  1. compute_best_patch returns None                                                                                                                                            
  2. The fallback reads the existing best_results.json (correctly written by the LLM select_patch agent with e.g. 7.876x)
  3. Since benchmark_baseline.txt exists, the fallback unconditionally clamps best_patch_speedup to 1.0                                                                         
  4. This clamped value then propagates to final_report.json via BestPatchResult.best_speedup                                                                                   
                                                                                                                                                                                
## Fix                                                                                                                                                                           
                                                                                                                                                                                
  Guard the rewrite_best_results call with a check for patch_*_test.txt files directly in base_patch_dir. This preserves the deterministic override for heterogeneous mode (flat
   layout) while skipping it for homogeneous mode (subdirectory layout) where it cannot work correctly.
                                                                                                                      