### PR TITLE
feat(tools): add translation tool profile for TranslationAgent

### DIFF
--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -57,6 +57,7 @@ class AgentConfig:
     disabled_tools: list[str] = field(default_factory=list)
     source_file_paths: list[str] | None = None
     use_skills: bool = False
+    tool_profile: str = "full"
 
 
 # Unified observation truncation for both bash output and tool call results (head + tail).
@@ -134,6 +135,7 @@ class DefaultAgent:
             else ".optimization_strategies.md",
             on_strategy_change=self._get_strategy_callback(),
             patch_output_dir=self.config.patch_output_dir,
+            tool_profile=self.config.tool_profile,
         )
         if self.config.disabled_tools:
             self.toolruntime.disable_tools(self.config.disabled_tools)

--- a/src/minisweagent/run/preprocess/config/mini_kernel_pytorch_to_flydsl.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_kernel_pytorch_to_flydsl.yaml
@@ -105,6 +105,7 @@ agent:
   cost_limit: 0
   step_limit: 200
   use_skills: true
+  tool_profile: translation
 
 model:
   model_class: amd_llm

--- a/src/minisweagent/tools/tools_runtime.py
+++ b/src/minisweagent/tools/tools_runtime.py
@@ -60,6 +60,12 @@ _TOOL_PROFILES: dict[str, set[str] | None] = {
         "query",
         "optimize",
     },
+    "translation": {
+        "bash",
+        "str_replace_editor",
+        "save_and_test",
+        "submit",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

- Adds a dedicated `"translation"` tool profile to `_TOOL_PROFILES` in `tools_runtime.py`, restricting the TranslationAgent to only the 4 tools it needs: `bash`, `str_replace_editor`, `save_and_test`, and `submit`.
- Wires `tool_profile` through `AgentConfig` and `DefaultAgent` so any agent can declare a restricted tool set via YAML config, enabling future agents to define their own profiles.
- Applies the `translation` profile to the lean PyTorch-to-FlyDSL translation config.

This restricts the TranslationAgent to only the 4 tools it needs, eliminating MCP tool usage during translation runs.

- Validated on Vultr SLURM cluster: translation of `25_Swish` and `14_Gemm` completed without MCP hangs
- Confirmed agent only used the 4 tools in the translation profile (zero MCP tool calls)
