### PR TITLE
Compliance with AMD's guidelines on user request with LLM calls

### DIFF
--- a/mcp_tools/automated-test-discovery/src/automated_test_discovery/server.py
+++ b/mcp_tools/automated-test-discovery/src/automated_test_discovery/server.py
@@ -347,11 +347,19 @@ def _init_llm_client():
     try:
         import anthropic
 
+        try:
+            from minisweagent.models.amd_base import get_amd_llm_user
+
+            user = get_amd_llm_user()
+        except Exception:
+            user = os.environ.get("GEAK_USER") or os.environ.get("USER") or "unknown"
+
         return anthropic.Anthropic(
             api_key="dummy",
             base_url="https://llm-api.amd.com/Anthropic",
             default_headers={
                 "Ocp-Apim-Subscription-Key": api_key,
+                "user": user,
                 "anthropic-version": "2023-10-16",
             },
         )

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -93,6 +93,10 @@ while [[ $# -gt 0 ]]; do
             echo "  geak <github_url>                      Full optimization pipeline"
             echo ""
             echo "Requires: AMD_LLM_API_KEY environment variable"
+            echo ""
+            echo "USER and GEAK_USER are forwarded from the host so the AMD LLM gateway"
+            echo "can attribute requests; existing containers must be rebuilt with"
+            echo "--rebuild to pick up the change."
             exit 0
             ;;
         *)
@@ -218,6 +222,8 @@ docker run -d \
     -e AMD_LLM_API_KEY="${AMD_LLM_API_KEY}" \
     -e AMD_LLM_BASE_URL="${AMD_LLM_BASE_URL}" \
     -e GEAK_MODEL="${GEAK_MODEL}" \
+    -e USER="${USER}" \
+    -e GEAK_USER="${GEAK_USER:-${USER}}" \
     "${EDITABLE_ENV[@]}" \
     --shm-size 8G \
     "${VOLUME_ARGS[@]}" \

--- a/src/minisweagent/models/amd_base.py
+++ b/src/minisweagent/models/amd_base.py
@@ -12,6 +12,30 @@ from minisweagent.models import GLOBAL_MODEL_STATS
 logger = logging.getLogger(__name__)
 
 
+def get_amd_llm_user() -> str:
+    """Resolve the username to attach to AMD LLM gateway requests.
+
+    Order of resolution (first non-empty wins):
+      1. ``$GEAK_USER``  -- explicit override knob.
+      2. ``$USER``       -- conventional POSIX env var, forwarded into the
+         container by ``scripts/run-docker.sh``.
+      3. ``os.getlogin()`` -- bare-metal fallback when no env vars are set.
+      4. ``"unknown"``   -- last-resort sentinel.
+
+    Env-var lookups are checked before ``os.getlogin()`` because the latter
+    raises ``OSError`` under ``docker exec`` (no controlling utmp entry), so
+    it cannot be relied on inside the GEAK container.
+    """
+    for var in ("GEAK_USER", "USER"):
+        val = os.getenv(var)
+        if val:
+            return val
+    try:
+        return os.getlogin()
+    except OSError:
+        return "unknown"
+
+
 @dataclass
 class AmdLlmModelConfig:
     model_name: str
@@ -85,10 +109,7 @@ class AmdLlmModelBase:
         return api_key
 
     def _get_user(self) -> str:
-        try:
-            return os.getlogin()
-        except OSError:
-            return os.getenv("USER", "unknown")
+        return get_amd_llm_user()
 
     # ------------------------------------------------------------------
     # Abstract interface

--- a/src/minisweagent/models/amd_openai.py
+++ b/src/minisweagent/models/amd_openai.py
@@ -21,6 +21,7 @@ class AmdOpenAIModel(AmdLlmModelBase):
 
     def _init_client(self):
         api_key = self._get_api_key()
+        user = self._get_user()
         base_url = self.config.base_url or f"https://llm-api.amd.com/openai/{self.config.model_name}"
         self.client = openai.AzureOpenAI(
             api_key="dummy",
@@ -28,6 +29,7 @@ class AmdOpenAIModel(AmdLlmModelBase):
             base_url=base_url,
             default_headers={
                 "Ocp-Apim-Subscription-Key": api_key,
+                "user": user,
             },
         )
 

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -25,7 +25,7 @@ from tenacity import (
 )
 
 from minisweagent.models import GLOBAL_MODEL_STATS
-from minisweagent.models.amd_base import AmdLlmModelConfig
+from minisweagent.models.amd_base import AmdLlmModelConfig, get_amd_llm_user
 from minisweagent.models.utils.cache_control import set_cache_control
 
 # ---------------------------------------------------------------------------
@@ -292,6 +292,11 @@ class LitellmModel:
             self.tools,
             tool_cache_control=self.config.tool_cache_control,
         )
+        existing_headers = filtered.get("extra_headers") or {}
+        filtered["extra_headers"] = {
+            **existing_headers,
+            "user": existing_headers.get("user") or get_amd_llm_user(),
+        }
         try:
             return litellm.completion(
                 model=self.config.model_name,

--- a/tests/models/test_amd_models.py
+++ b/tests/models/test_amd_models.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from minisweagent.models.amd_base import AmdLlmModelConfig
+from minisweagent.models.amd_base import AmdLlmModelConfig, get_amd_llm_user
 from minisweagent.models.amd_claude import AmdClaudeModel, convert_openai_tools_to_claude
 from minisweagent.models.amd_llm import AmdLlmModel
 from minisweagent.models.amd_openai import AmdOpenAIModel
@@ -316,3 +316,82 @@ class TestAmdLlmModelBaseSetTools:
         names = [t["name"] for t in model.tools]
         assert names == ["bash", "profiling", "submit"]
         assert model.tools is not tools
+
+
+# ---------------------------------------------------------------------------
+# get_amd_llm_user
+# ---------------------------------------------------------------------------
+
+
+class TestGetAmdLlmUser:
+    def test_prefers_geak_user(self, monkeypatch):
+        monkeypatch.setenv("GEAK_USER", "foo")
+        monkeypatch.setenv("USER", "bar")
+        assert get_amd_llm_user() == "foo"
+
+    def test_falls_back_to_user(self, monkeypatch):
+        monkeypatch.delenv("GEAK_USER", raising=False)
+        monkeypatch.setenv("USER", "bar")
+        assert get_amd_llm_user() == "bar"
+
+    def test_empty_env_vars_skipped(self, monkeypatch):
+        monkeypatch.setenv("GEAK_USER", "")
+        monkeypatch.setenv("USER", "bar")
+        assert get_amd_llm_user() == "bar"
+
+    def test_unknown_in_container_like_env(self, monkeypatch):
+        monkeypatch.delenv("GEAK_USER", raising=False)
+        monkeypatch.delenv("USER", raising=False)
+        with patch("minisweagent.models.amd_base.os.getlogin", side_effect=OSError):
+            assert get_amd_llm_user() == "unknown"
+
+    def test_getlogin_fallback_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("GEAK_USER", raising=False)
+        monkeypatch.delenv("USER", raising=False)
+        with patch("minisweagent.models.amd_base.os.getlogin", return_value="login_user"):
+            assert get_amd_llm_user() == "login_user"
+
+
+# ---------------------------------------------------------------------------
+# "user" request header is attached by each AMD model backend
+# ---------------------------------------------------------------------------
+
+
+class TestAmdModelUserHeader:
+    """Verify the AMD LLM gateway "user" header is set for every backend."""
+
+    def test_amd_claude_sends_user_header(self, monkeypatch):
+        monkeypatch.setenv("GEAK_USER", "alice")
+        config = AmdLlmModelConfig(model_name="claude-sonnet-4.5", api_key="test-key")
+        with patch("minisweagent.models.amd_claude.anthropic.Anthropic") as ctor:
+            AmdClaudeModel(config)
+        ctor.assert_called_once()
+        headers = ctor.call_args.kwargs["default_headers"]
+        assert headers["user"] == "alice"
+        assert headers["Ocp-Apim-Subscription-Key"] == "test-key"
+
+    def test_amd_openai_sends_user_header(self, monkeypatch):
+        monkeypatch.setenv("GEAK_USER", "bob")
+        config = AmdLlmModelConfig(model_name="gpt-5", api_key="test-key")
+        with patch("minisweagent.models.amd_openai.openai.AzureOpenAI") as ctor:
+            AmdOpenAIModel(config)
+        ctor.assert_called_once()
+        headers = ctor.call_args.kwargs["default_headers"]
+        assert headers["user"] == "bob"
+        assert headers["Ocp-Apim-Subscription-Key"] == "test-key"
+
+    def test_amd_gemini_sends_user_header(self, monkeypatch):
+        # google.genai is an optional/heavy dep; skip if unavailable in the
+        # test environment rather than failing the whole module.
+        pytest.importorskip("google.genai")
+        from minisweagent.models.amd_gemini import AmdGeminiModel
+
+        monkeypatch.setenv("GEAK_USER", "carol")
+        config = AmdLlmModelConfig(model_name="gemini-2.5-pro", api_key="test-key")
+        with patch("minisweagent.models.amd_gemini.genai.Client") as ctor:
+            AmdGeminiModel(config)
+        ctor.assert_called_once()
+        http_options = ctor.call_args.kwargs["http_options"]
+        headers = http_options.headers
+        assert headers["user"] == "carol"
+        assert headers["Ocp-Apim-Subscription-Key"] == "test-key"

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -2,9 +2,11 @@
 
 import json
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from minisweagent.models.litellm_model import (
     LITELLM_COMPLETION_PARAM_KEYS,
+    LitellmModel,
     _coerce_tool_arguments,
     _first_function_tool_call,
     _openai_tool_call_to_api_shape,
@@ -229,3 +231,82 @@ class TestCompletionParamKeys:
 
     def test_tools_key_present(self):
         assert "tools" in LITELLM_COMPLETION_PARAM_KEYS
+
+
+# ---------------------------------------------------------------------------
+# LitellmModel injects the AMD LLM gateway "user" header
+# ---------------------------------------------------------------------------
+
+
+def _fake_litellm_response() -> MagicMock:
+    """Build a minimal response object covering the fields LitellmModel.query reads."""
+    message = SimpleNamespace(content="hello", tool_calls=None)
+    choice = SimpleNamespace(message=message)
+    response = MagicMock()
+    response.choices = [choice]
+    response.model = "test-model"
+    response.model_dump.return_value = {}
+    return response
+
+
+class TestLitellmModelUserHeader:
+    def test_injects_resolved_user_when_no_headers(self, monkeypatch):
+        monkeypatch.setenv("GEAK_USER", "alice")
+        model = LitellmModel(
+            model_name="anthropic/claude-opus-4.6",
+            model_kwargs={"api_key": "k", "api_base": "https://example/test"},
+        )
+        with (
+            patch("minisweagent.models.litellm_model.litellm.completion", return_value=_fake_litellm_response()) as comp,
+            patch(
+                "minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost",
+                return_value=0.0,
+            ),
+        ):
+            model.query([{"role": "user", "content": "hi"}])
+        headers = comp.call_args.kwargs["extra_headers"]
+        assert headers["user"] == "alice"
+
+    def test_preserves_explicit_user_override(self, monkeypatch):
+        monkeypatch.setenv("GEAK_USER", "alice")
+        model = LitellmModel(
+            model_name="anthropic/claude-opus-4.6",
+            model_kwargs={
+                "api_key": "k",
+                "api_base": "https://example/test",
+                "extra_headers": {"user": "explicit", "Ocp-Apim-Subscription-Key": "k"},
+            },
+        )
+        with (
+            patch("minisweagent.models.litellm_model.litellm.completion", return_value=_fake_litellm_response()) as comp,
+            patch(
+                "minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost",
+                return_value=0.0,
+            ),
+        ):
+            model.query([{"role": "user", "content": "hi"}])
+        headers = comp.call_args.kwargs["extra_headers"]
+        assert headers["user"] == "explicit"
+        assert headers["Ocp-Apim-Subscription-Key"] == "k"
+
+    def test_merges_with_other_extra_headers(self, monkeypatch):
+        monkeypatch.setenv("GEAK_USER", "alice")
+        model = LitellmModel(
+            model_name="anthropic/claude-opus-4.6",
+            model_kwargs={
+                "api_key": "k",
+                "api_base": "https://example/test",
+                "extra_headers": {"Ocp-Apim-Subscription-Key": "k"},
+            },
+        )
+        with (
+            patch("minisweagent.models.litellm_model.litellm.completion", return_value=_fake_litellm_response()) as comp,
+            patch(
+                "minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost",
+                return_value=0.0,
+            ),
+        ):
+            model.query([{"role": "user", "content": "hi"}])
+        headers = comp.call_args.kwargs["extra_headers"]
+        assert headers["user"] == "alice"
+        assert headers["Ocp-Apim-Subscription-Key"] == "k"


### PR DESCRIPTION
Previously only AmdClaudeModel and AmdGeminiModel sent a "user" request header, and the value resolved to "unknown" inside the Docker container because os.getlogin() raises under `docker exec` and $USER was not forwarded. As a result the gateway could not attribute most requests back to the originating host user.

- Add a module-level `get_amd_llm_user()` helper in `amd_base.py` that prefers `$GEAK_USER`, then `$USER`, then `os.getlogin()`, falling back to "unknown". `_get_user` now delegates to it.
- Forward `-e USER` and `-e GEAK_USER` from the host in `scripts/run-docker.sh` (existing containers must be `--rebuild`ed).
- Send the `"user"` header from `AmdOpenAIModel`, the `LitellmModel` completion path (via `extra_headers`, preserving any explicit override), and the standalone test-discovery MCP server.
- Add unit tests for the resolver and for the header construction in each backend (Claude, OpenAI, Gemini via importorskip, LiteLLM).
