### PR TITLE
fix(docker): drop missing knowledge-base COPY for v3.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN python3 -c "from profiler_mcp.server import profile_kernel; from metrix impo
 # Runtime assets (not needed for install; changes only rebuild cheap COPY layers)
 COPY skills/ skills/
 COPY docs/ docs/
-COPY knowledge-base/ knowledge-base/
 COPY entrypoint.sh ./
 
 RUN chmod +x /workspace/entrypoint.sh


### PR DESCRIPTION
## Summary

Cherry-picks `4cf8ea67` ("Update Dockerfile") onto `release/v3.1.1` so the v3.1.1 image build does not fail at `COPY knowledge-base/ knowledge-base/` (the directory was removed but the `COPY` line lingered on the v3.1.0 base).

Without this, `docker build` aborts with:

```
COPY failed: file not found in build context or excluded by .dockerignore: stat knowledge-base/: file does not exist
```

This is a clean, single-line revert of the dead `COPY` and is already on `main`.

## Test plan

- [ ] `docker build .` against the `release/v3.1.1` tip completes past the previous failure point.

Made with [Cursor](https://cursor.com)