### PR TITLE
feat(rag): allow remote OpenAI-compatible embedding endpoint

### DIFF
--- a/mcp_tools/rag-mcp/README.md
+++ b/mcp_tools/rag-mcp/README.md
@@ -23,7 +23,7 @@ pip install -e mcp_tools/rag-mcp
 python scripts/build_index.py --force
 ```
 
-This builds FAISS and BM25 indexes from the documents in `knowledge-base/`. The index is saved to `~/.cache/amd-ai-devtool/semantic-index/`. First run will also download the embedding model (~1.3 GB).
+This builds FAISS and BM25 indexes from the documents in `knowledge-base/`. The index is saved to `~/.cache/amd-ai-devtool/semantic-index/`. First run will also download the embedding model (~1.3 GB) unless a remote embedding endpoint is configured — see [Remote embedding endpoint](#remote-embedding-endpoint).
 
 ### Step 3: Enable RAG in config
 
@@ -70,6 +70,32 @@ When `rag: true`, GEAK performs two checks before running the pipeline:
 
 1. **Dependency check** — Verifies that `rag-mcp` package is installed. If not, an error is shown with the install command.
 2. **Index check** — Verifies that the semantic index exists at `~/.cache/amd-ai-devtool/semantic-index/`. If not, an error is shown with the build command.
+
+## Remote embedding endpoint
+
+CPU embedding inference is slow (`build_index.py` can take an hour on a
+few thousand chunks) and GPU embedding is not always available. To skip
+the local embedding model entirely, point both `build_index.py` and the
+RAG MCP server at an OpenAI-compatible `/v1/embeddings` endpoint (for
+example a LiteLLM proxy that fronts a hosted embedding model):
+
+```bash
+export GEAK_EMBEDDING_BASE_URL="https://your-embedding-endpoint/v1"
+export GEAK_EMBEDDING_API_KEY="<your-key>"          # falls back to OPENAI_API_KEY / SAFE_API_KEY
+export GEAK_EMBEDDING_MODEL="BAAI/bge-large-en-v1.5"  # defaults to the same name passed to build_index.py
+```
+
+When `GEAK_EMBEDDING_BASE_URL` is set:
+
+- `python scripts/build_index.py` builds FAISS using remote embeddings
+  (no 1.3 GB model download, no local GPU/CPU inference).
+- The RAG MCP server's `query` / `optimize` tools issue remote embedding
+  calls at query time using the same endpoint.
+
+Leave `GEAK_EMBEDDING_BASE_URL` unset to keep the historical local
+HuggingFace path. The deployed gateway URL is intentionally not bundled
+in this repo — set the environment variables in your local profile or
+deployment scripts.
 
 ## Postprocessor
 

--- a/mcp_tools/rag-mcp/pyproject.toml
+++ b/mcp_tools/rag-mcp/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "langchain-community",
     "langchain-huggingface",
     "langchain-core",
+    "langchain-openai",
     "faiss-cpu",
     "sentence-transformers",
     "rank-bm25",

--- a/mcp_tools/rag-mcp/src/rag_mcp/embedding_factory.py
+++ b/mcp_tools/rag-mcp/src/rag_mcp/embedding_factory.py
@@ -1,0 +1,100 @@
+"""Embedding factory for GEAK RAG.
+
+By default this returns a local HuggingFaceEmbeddings instance (the
+historical GEAK behavior). When ``GEAK_EMBEDDING_BASE_URL`` is set the
+factory returns an OpenAI-compatible remote embedding client instead, so
+operators can offload the heavy embedding inference to a LiteLLM /
+OpenAI-compatible gateway and avoid the slow first-run CPU build.
+
+Environment variables (all optional):
+
+* ``GEAK_EMBEDDING_BASE_URL`` -- when set, use a remote OpenAI-compatible
+  ``/v1/embeddings`` endpoint. The value is the base URL only.
+* ``GEAK_EMBEDDING_API_KEY`` -- API key for the remote endpoint. Falls
+  back to ``OPENAI_API_KEY`` and ``SAFE_API_KEY``.
+* ``GEAK_EMBEDDING_MODEL`` -- remote model name. Defaults to the same
+  HuggingFace model name the caller would have used locally so a gateway
+  that proxies the BGE model needs no extra configuration.
+
+Leave ``GEAK_EMBEDDING_BASE_URL`` unset to keep the original local
+HuggingFace path, which avoids surprising existing GEAK users.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+_BASE_URL_ENV = "GEAK_EMBEDDING_BASE_URL"
+_API_KEY_ENVS = ("GEAK_EMBEDDING_API_KEY", "OPENAI_API_KEY", "SAFE_API_KEY")
+_MODEL_ENV = "GEAK_EMBEDDING_MODEL"
+
+
+def _strip_env(name: str) -> str:
+    value = os.environ.get(name, "")
+    return value.strip() if isinstance(value, str) else ""
+
+
+def remote_endpoint_configured() -> bool:
+    """True when the caller explicitly opted into a remote embedding endpoint."""
+    return bool(_strip_env(_BASE_URL_ENV))
+
+
+def _resolve_api_key() -> str:
+    for name in _API_KEY_ENVS:
+        value = _strip_env(name)
+        if value:
+            return value
+    return ""
+
+
+def _resolve_model(default_model: str) -> str:
+    return _strip_env(_MODEL_ENV) or default_model
+
+
+def make_embeddings(
+    *,
+    huggingface_model_name: str,
+    device: str = "cpu",
+    normalize: bool = True,
+) -> Any:
+    """Return a LangChain embedding instance.
+
+    Args:
+        huggingface_model_name: Model name to use when falling back to the
+            local HuggingFace path. Also used as the default remote model
+            name when ``GEAK_EMBEDDING_MODEL`` is unset.
+        device: HuggingFace ``model_kwargs.device``. Ignored on the remote
+            path.
+        normalize: Whether to L2-normalize embeddings on the HuggingFace
+            path. Remote endpoints are expected to handle normalization
+            on their side.
+    """
+    base_url = _strip_env(_BASE_URL_ENV)
+    if base_url:
+        try:
+            from langchain_openai import OpenAIEmbeddings
+        except ImportError as exc:  # pragma: no cover - import-time guard
+            raise RuntimeError(
+                f"{_BASE_URL_ENV} is set but langchain-openai is not installed. "
+                "Install it (pip install langchain-openai) or unset "
+                f"{_BASE_URL_ENV} to use the local HuggingFace embedding model."
+            ) from exc
+
+        api_key = _resolve_api_key() or "not-needed"
+        model = _resolve_model(huggingface_model_name)
+        return OpenAIEmbeddings(
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+            check_embedding_ctx_length=False,
+        )
+
+    from langchain_huggingface import HuggingFaceEmbeddings
+
+    return HuggingFaceEmbeddings(
+        model_name=huggingface_model_name,
+        model_kwargs={"device": device},
+        encode_kwargs={"normalize_embeddings": normalize},
+    )

--- a/mcp_tools/rag-mcp/src/rag_mcp/retrieval.py
+++ b/mcp_tools/rag-mcp/src/rag_mcp/retrieval.py
@@ -91,13 +91,14 @@ class HybridRetriever:
 
     @property
     def embeddings(self):
-        """Lazy load HuggingFace embeddings."""
+        """Lazy load embeddings (remote OpenAI-compatible endpoint or local HF)."""
         if self._embeddings is None:
-            from langchain_huggingface import HuggingFaceEmbeddings
-            self._embeddings = HuggingFaceEmbeddings(
-                model_name=self.embedding_model,
-                model_kwargs={"device": "cpu"},
-                encode_kwargs={"normalize_embeddings": True},
+            from rag_mcp.embedding_factory import make_embeddings
+
+            self._embeddings = make_embeddings(
+                huggingface_model_name=self.embedding_model,
+                device="cpu",
+                normalize=True,
             )
         return self._embeddings
 

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -27,13 +27,14 @@ from typing import Callable
 
 from langchain_community.vectorstores import FAISS
 from langchain_core.documents import Document
-from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_text_splitters import (
     Language,
     MarkdownHeaderTextSplitter,
     RecursiveCharacterTextSplitter,
 )
 from rank_bm25 import BM25Okapi
+
+from rag_mcp.embedding_factory import make_embeddings, remote_endpoint_configured
 
 
 # Default paths
@@ -617,13 +618,24 @@ def build_index(
         print(f"    Layer {layer}: {layer_counts[layer]} chunks")
     
     # Step 3: Initialize embeddings
-    print(f"\nStep 3: Initializing embeddings ({model_name}) on {embedding_device}...")
-    embeddings = HuggingFaceEmbeddings(
-        model_name=model_name,
-        model_kwargs={"device": embedding_device},
-        encode_kwargs={"normalize_embeddings": True},
+    if remote_endpoint_configured():
+        print(
+            f"\nStep 3: Initializing embeddings via remote endpoint "
+            f"(GEAK_EMBEDDING_BASE_URL) using model={model_name}..."
+        )
+    else:
+        print(
+            f"\nStep 3: Initializing embeddings ({model_name}) on {embedding_device}..."
+        )
+    embeddings = make_embeddings(
+        huggingface_model_name=model_name,
+        device=embedding_device,
+        normalize=True,
     )
-    print(f"  ✓ Embeddings model loaded on {embedding_device}")
+    if remote_endpoint_configured():
+        print("  ✓ Embeddings client configured against remote endpoint")
+    else:
+        print(f"  ✓ Embeddings model loaded on {embedding_device}")
     
     # Step 4: Build FAISS index
     print("\nStep 4: Building FAISS index...")


### PR DESCRIPTION
## Summary
- Add a small `embedding_factory` so `scripts/build_index.py` and the `rag-mcp` retriever pick a remote OpenAI-compatible `/v1/embeddings` endpoint when `GEAK_EMBEDDING_BASE_URL` is set, otherwise keep the existing `HuggingFaceEmbeddings` path.
- Skip the 1.3 GB local model download and the slow CPU embedding inference at index-build time and query time when a hosted embedding gateway is available.
- Document the new env knobs (`GEAK_EMBEDDING_BASE_URL` / `GEAK_EMBEDDING_API_KEY` / `GEAK_EMBEDDING_MODEL`) without bundling any deployment-specific endpoint URLs.

## Test plan
- [x] `python -m py_compile mcp_tools/rag-mcp/src/rag_mcp/embedding_factory.py mcp_tools/rag-mcp/src/rag_mcp/retrieval.py scripts/build_index.py`
- [x] Verified factory selection: with `GEAK_EMBEDDING_BASE_URL` unset, `make_embeddings()` returns `HuggingFaceEmbeddings`; with it set, returns `OpenAIEmbeddings`.
- [ ] Smoke-run `python scripts/build_index.py --force` against an OpenAI-compatible embedding endpoint, confirm Step 3 logs the remote path and finishes in minutes (not hours).
- [ ] Smoke-run `rag-mcp` `query` / `optimize` against the same endpoint, confirm hits.

## Notes
- Default behavior is unchanged for existing users (HuggingFace local path).
- `langchain-openai` is added to `mcp_tools/rag-mcp/pyproject.toml` so the remote path works out of the box once `GEAK_EMBEDDING_BASE_URL` is set.
- Downstream consumer: AMD-AGI/Hyperloom is being updated in parallel to set these env vars by default and to optionally apply a wekafs overlay so the hot fix is available even before this PR lands.