### PR TITLE
feat(preprocess): thread user `-t` task into UTA + ShapeFixerAgent

### DIFF
--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -457,6 +457,9 @@ def main(
         gpu_id=parsed_gpu_ids[0] if parsed_gpu_ids else 0,
         model_factory=lambda: get_model(model_name, config.get("model", {})),
         console=console,
+        # Forward the user's -t task to the preprocess sub-agents (UTA + ShapeFixer)
+        # so a USER TASK CONTEXT block can override op-test default shapes.
+        user_task=task_content,
     )
     logger.debug("Preprocess kwargs: %s", _preprocess_kwargs)
 

--- a/src/minisweagent/run/preprocess/config/mini_shape_fixer.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_shape_fixer.yaml
@@ -1,5 +1,26 @@
 agent:
   system_template: |
+    HIGHEST PRIORITY (overrides Step 1's "source file is authoritative" rule)
+    - If the task message contains a `USER TASK CONTEXT` block delimited by
+      `================================================================`, treat
+      THAT block as the AUTHORITATIVE shape / dtype / template-args contract
+      for this kernel.
+    - In that mode, the SHAPE SOURCE FILE listed below is a REFERENCE for
+      kernel invocation pattern only (helpers, imports, build steps). The
+      harness should sample shapes from the USER TASK CONTEXT, NOT from the
+      source file's default sweep.
+    - Do NOT flag a harness as drifting from the SHAPE SOURCE FILE if the
+      harness's per-cell shapes match the user task contract. Specifically:
+      if the harness's `(m, n, dtype, ...)` cells are the explicit values
+      listed in USER TASK CONTEXT, print SHAPES_VERIFIED even when those
+      cells differ from the source file's default `m`/`n` lists.
+    - Only repair the harness when it disagrees BOTH with the user task
+      contract AND with the source file -- i.e. it has fabricated its own
+      third shape set. In that case, repair it to match the user task
+      contract, not the source file.
+    - This rule applies ONLY when a USER TASK CONTEXT block is present.
+      When absent, use the original rules below verbatim.
+
     You are a harness repair agent. Start by comparing the authoritative
     source file against the generated harness, then apply the smallest
     source-faithful fix needed to make the sampled modes work.

--- a/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
@@ -1,5 +1,31 @@
 agent:
   system_template: |
+    HIGHEST PRIORITY (overrides any later "Shape source priority" rule)
+    - If the task message contains a `USER TASK CONTEXT` block delimited by
+      `================================================================`, treat
+      THAT block as the AUTHORITATIVE shape / dtype / template-args contract.
+    - When the user task lists explicit `(m, n)` shape tuples, `input_shapes`
+      / `output_shapes` arrays, dtypes, or template specializations
+      (e.g. `<Add=true, Quant=true>`), use THOSE values for `ALL_SHAPES` in
+      the harness. Build the per-cell `(m, n, dtype, ...)` stream EXACTLY
+      as the user task specifies.
+    - Do NOT mirror op-test default sweeps (e.g. `m ∈ {1, 32, 64, ..., 163840}`
+      `n ∈ {1024, 4096, 6400, 8192}`) from a discovered benchmark file when
+      the user task supplies an explicit production-shape contract, EVEN IF
+      discovery flagged a benchmark file as "for this kernel".
+    - The discovered benchmark file (if any) is then a REFERENCE for kernel
+      invocation pattern only (helper functions to build inputs, import
+      paths, build steps, correctness reference impl). Borrow those, but do
+      NOT borrow its `m`/`n`/`dtype` value lists.
+    - Write `user_task:production` to `harness_shapes_source.txt` instead of
+      the benchmark file path. This signals to the post-UTA shape fixer
+      agent that the user task is the canonical source.
+    - The order of precedence is:
+        1. USER TASK CONTEXT block (this rule)
+        2. Discovered benchmark file shapes (the legacy rule below)
+        3. Discovered test file shapes
+        4. Shapes inferred from kernel source
+
     Role
     - You are **TestHarnessAgent**.
     - Your responsibility is to create a **fixed, immutable test harness** for a kernel and output the **TEST_COMMAND** to run it.

--- a/src/minisweagent/run/preprocess/harness_utils.py
+++ b/src/minisweagent/run/preprocess/harness_utils.py
@@ -1193,6 +1193,7 @@ def create_validated_harness(
     discovery_context: str,
     max_retries: int = MAX_HARNESS_RETRIES,
     gpu_id: int = 0,
+    user_task: str | None = None,
 ) -> tuple[str, list[dict]]:
     """Run UnitTestAgent with static + runtime validation and retry loop.
 
@@ -1238,6 +1239,7 @@ def create_validated_harness(
             preferred_harness_path=_preferred_harness_path(log_dir, kernel_path) if log_dir else None,
             kernel_path=kernel_path,
             discovery_context=ctx,
+            user_task=user_task,
         )
         logger.info("UnitTestAgent test_command (attempt %d): %s", attempt, test_command)
 

--- a/src/minisweagent/run/preprocess/preprocessor.py
+++ b/src/minisweagent/run/preprocess/preprocessor.py
@@ -411,6 +411,7 @@ def run_preprocessor(
     correctness_command: str | list[str] | None = None,
     performance_command: str | list[str] | None = None,
     benchmark_timeout: int = 3600,
+    user_task: str | None = None,
 ) -> dict[str, Any]:
     """Run all preprocessing steps and return a context dict.
 
@@ -813,6 +814,7 @@ def run_preprocessor(
                     kernel_path=Path(kernel_path),
                     discovery_context=discovery_context,
                     gpu_id=gpu_id,
+                    user_task=user_task,
                 )
                 _uta_harness = extract_harness_path(test_command)
                 _uta_harness = _ensure_harness_has_no_kernel_defs(_uta_harness, output_dir, ctx)
@@ -862,6 +864,7 @@ def run_preprocessor(
                                     log_dir=output_dir,
                                     gpu_id=gpu_id,
                                     validation_feedback=shape_feedback,
+                                    user_task=user_task,
                                 )
                                 if shapes_ok:
                                     if shape_feedback:

--- a/src/minisweagent/run/preprocess/shape_fixer_agent.py
+++ b/src/minisweagent/run/preprocess/shape_fixer_agent.py
@@ -136,6 +136,7 @@ def _build_shape_fixer_task(
     kernel_path: Path | None,
     gpu_id: int,
     validation_feedback: list[str] | None,
+    user_task: str | None = None,
 ) -> str:
     quoted_harness = shlex.quote(str(harness_path))
     validation_prefix = f"HIP_VISIBLE_DEVICES={gpu_id} GEAK_BENCHMARK_ITERATIONS=5"
@@ -180,7 +181,24 @@ def _build_shape_fixer_task(
             ]
         )
 
-    return "\n".join(lines) + "\n"
+    body = "\n".join(lines) + "\n"
+
+    if user_task and user_task.strip():
+        # The user's -t prompt is the HIGHEST-PRIORITY contract: if it
+        # specifies production shapes/dtypes, those override the "source
+        # file is authoritative" rule above. The mini_shape_fixer.yaml
+        # system prompt has a matching override rule that recognises this
+        # block. Do NOT flag a harness as drifting from the benchmark file
+        # if the harness's shapes match the user task contract instead.
+        prefix = (
+            "USER TASK CONTEXT (production workload contract -- HIGHEST PRIORITY):\n"
+            "================================================================\n"
+            + user_task.strip()
+            + "\n================================================================\n\n"
+        )
+        body = prefix + body
+
+    return body
 
 
 def run_shape_fixer(
@@ -193,6 +211,7 @@ def run_shape_fixer(
     log_dir: Path | None = None,
     gpu_id: int = 0,
     validation_feedback: list[str] | None = None,
+    user_task: str | None = None,
 ) -> bool:
     """Run the shape fixer agent. Returns True if shapes were verified or fixed."""
     try:
@@ -228,6 +247,7 @@ def run_shape_fixer(
         kernel_path=kernel_path,
         gpu_id=gpu_id,
         validation_feedback=validation_feedback,
+        user_task=user_task,
     )
 
     timeout_s = int(os.environ.get("GEAK_SHAPE_FIXER_TIMEOUT", "300"))

--- a/src/minisweagent/run/preprocess/unit_test_agent.py
+++ b/src/minisweagent/run/preprocess/unit_test_agent.py
@@ -197,12 +197,18 @@ def run_unit_test_agent(
     preferred_harness_path: Path | None = None,
     kernel_path: Path | None = None,
     discovery_context: str = "",
+    user_task: str | None = None,
 ) -> str:
     """Run UnitTestAgent in ``repo`` and return the extracted test command string.
 
     If *discovery_context* is provided (e.g. from :func:`format_discovery_for_agent`),
     it is appended to the task prompt so the agent starts with pre-scanned results
     instead of exploring from scratch.
+
+    If *user_task* is provided (the user's `-t` prompt forwarded from mini.py via
+    run_preprocessor), it is prepended as a HIGHEST-PRIORITY context block so the
+    UTA can honour production-shape contracts the user supplied (overriding the
+    default "benchmark file → ALL_SHAPES" rule in the system prompt).
     """
     agent_config, _ = load_preprocess_agent_config("mini_unit_test_agent")
 
@@ -244,6 +250,19 @@ def run_unit_test_agent(
             task += f"\nKernel repo-relative directory: {rel_kernel_dir.as_posix()}"
     if discovery_context:
         task += f"\n\n{discovery_context}"
+
+    if user_task and user_task.strip():
+        # Prepend the user's -t prompt as a HIGHEST-PRIORITY context block.
+        # The mini_unit_test_agent.yaml system prompt has a matching rule
+        # that recognises this block and uses its shape/dtype contract in
+        # preference to the discovered benchmark file's defaults.
+        task = (
+            "USER TASK CONTEXT (production workload contract -- HIGHEST PRIORITY):\n"
+            "================================================================\n"
+            + user_task.strip()
+            + "\n================================================================\n\n"
+            + task
+        )
 
     exit_status, result = agent.run(task)
     if exit_status != "Submitted":


### PR DESCRIPTION
Today the user's `-t prompt.md` is read in `mini.py` and forwarded only to the main optimization agent that runs after preprocessing. The preprocess sub-agents (UnitTestAgent in Step 3b, ShapeFixerAgent in Step 3d) never see it, so any production-shape contract the user supplies in the prompt is invisible to the harness-creation step.

The UTA's system prompt currently hard-codes "If a benchmark file exists FOR THIS KERNEL: use it for shapes." (mini_unit_test_agent.yaml). When the discovery MCP finds an op-test for the kernel, the UTA mirrors that op-test's default M/N/dtype sweep verbatim, even when the user prompt declares the workload pins a much narrower production shape (e.g. SGLang serving Qwen3-8B at TP=8, intermediate/TP=1536, decode m=64 dominant). That mismatch makes the resulting micro-benchmark report flat geomeans across irrelevant shape cells, and any per-kernel speedup it surfaces does not predict end-to-end gain.

This change makes the user prompt available to both preprocess sub-agents and lets it override the discovered benchmark file's defaults when (and only when) the prompt contains an explicit `USER TASK CONTEXT` block.

Plumbing (additive, all new params default to None so all existing call sites are unchanged):
- mini.py: forward task_content into _preprocess_kwargs.
- preprocessor.py: run_preprocessor accepts user_task and passes it to create_validated_harness and run_shape_fixer.
- harness_utils.py: create_validated_harness accepts user_task and forwards it to run_unit_test_agent.
- unit_test_agent.py: run_unit_test_agent accepts user_task and prepends a framed "USER TASK CONTEXT (HIGHEST PRIORITY)" block to the agent task.
- shape_fixer_agent.py: run_shape_fixer / _build_shape_fixer_task accept user_task and prepend the same block to the fixer task, so the post-UTA shape verifier does not undo the UTA's compliance with the user task.

System-prompt rules (the LLM-side half of the change):
- mini_unit_test_agent.yaml: new "HIGHEST PRIORITY" block at the top of agent.system_template instructing the UTA to use shapes/dtypes from a USER TASK CONTEXT block in preference to discovered benchmark file defaults, and to write `user_task:production` to harness_shapes_source.txt.
- mini_shape_fixer.yaml: analogous override so the fixer does not flag a harness as drifting from the SHAPE SOURCE FILE when its shapes match the user task contract instead.

The change is fully backward-compatible: when no user_task is supplied (callers other than `mini -t`) or when the task contains no USER TASK CONTEXT block, both agents fall back to their existing discovery-driven behaviour verbatim.

Tested locally against an SGLang/aiter act_and_mul_kernel run: UTA sees the new context block (grep "USER TASK CONTEXT" in unit_test_agent.log returns hits), and the LLM acknowledges the production shape pins in its first reasoning step instead of mirroring the op-test default sweep.

7 files changed, 95 insertions(+), 1 deletion(-)

