### PR TITLE
fix(docker): remove stale rocm.list apt source that breaks builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM lmsysorg/sglang:v0.5.11-rocm720-mi35x
+ARG BASE_IMAGE=lmsysorg/sglang:v0.5.11-rocm720-mi35x
+FROM ${BASE_IMAGE}
 
 RUN apt-get update && apt-get install -y git make && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM lmsysorg/sglang:v0.5.9-rocm700-mi35x
 
-RUN apt-get update && apt-get install -y git make && rm -rf /var/lib/apt/lists/*
+RUN rm -f /etc/apt/sources.list.d/rocm.list && \
+    apt-get update && apt-get install -y git make && rm -rf /var/lib/apt/lists/*
 
 # Copy installable sources first (cache-friendly — changes here rebuild pip install)
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM lmsysorg/sglang:v0.5.9-rocm700-mi35x
+FROM lmsysorg/sglang:v0.5.11-rocm720-mi35x
 
-RUN rm -f /etc/apt/sources.list.d/rocm.list && \
-    apt-get update && apt-get install -y git make && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git make && rm -rf /var/lib/apt/lists/*
 
 # Copy installable sources first (cache-friendly — changes here rebuild pip install)
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ GEAK is an agent-driven framework for end-to-end GPU kernel optimization in real
 ```bash
 git clone https://github.com/AMD-AGI/GEAK
 cd GEAK
-# Docker-based
+# Docker-based (default base image targets MI355X / gfx950)
 AMD_LLM_API_KEY=<YOUR_KEY> bash scripts/run-docker.sh
+
+# For MI300X/MI325X (gfx942), override the base image:
+# docker build --build-arg BASE_IMAGE=lmsysorg/sglang:v0.5.11-rocm720-mi30x -t geak-agent:latest .
 
 # Local install (recommended)
 make install              # core + MCP tools (same as Docker)

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -93,6 +93,8 @@ while [[ $# -gt 0 ]]; do
             echo "  geak <github_url>                      Full optimization pipeline"
             echo ""
             echo "Requires: AMD_LLM_API_KEY environment variable"
+            echo "Optional: BASE_IMAGE to override the Docker base image"
+            echo "          (e.g. BASE_IMAGE=lmsysorg/sglang:v0.5.11-rocm720-mi30x for MI300X/MI325X)"
             echo ""
             echo "USER and GEAK_USER are forwarded from the host so the AMD LLM gateway"
             echo "can attribute requests; existing containers must be rebuilt with"
@@ -119,7 +121,9 @@ if [ "$REBUILD" = true ]; then
         docker rm ${CONTAINER_NAME}
     fi
     echo "Rebuilding image ${IMAGE_NAME} (--no-cache)..."
-    docker build --network=host --no-cache -t ${IMAGE_NAME} .
+    BUILD_ARGS=()
+    [ -n "$BASE_IMAGE" ] && BUILD_ARGS+=(--build-arg "BASE_IMAGE=${BASE_IMAGE}")
+    docker build --network=host --no-cache "${BUILD_ARGS[@]}" -t ${IMAGE_NAME} .
     echo ""
 fi
 
@@ -185,7 +189,9 @@ echo ""
 # Check if image exists, build if not (unless we already rebuilt)
 if [[ "$(docker images -q ${IMAGE_NAME} 2> /dev/null)" == "" ]]; then
     echo "Image ${IMAGE_NAME} not found. Building..."
-    docker build --network=host -t ${IMAGE_NAME} .
+    BUILD_ARGS=()
+    [ -n "$BASE_IMAGE" ] && BUILD_ARGS+=(--build-arg "BASE_IMAGE=${BASE_IMAGE}")
+    docker build --network=host "${BUILD_ARGS[@]}" -t ${IMAGE_NAME} .
 elif [ "$REBUILD" != true ]; then
     echo "Using existing image ${IMAGE_NAME}"
     echo "To rebuild from scratch, run: $0 --rebuild"


### PR DESCRIPTION
## Summary

- The base image (`lmsysorg/sglang:v0.5.9-rocm700-mi35x`) ships `/etc/apt/sources.list.d/rocm.list` pointing at an internal AMD Artifactory path (`compute-rocm-rel-7.0/38`) that now returns 404
- This causes `apt-get update` to fail with exit code 100, breaking Docker builds
- The ROCm packages are already installed in the base image, so the source is unnecessary at build time — removing it before `apt-get update` unblocks the build

## Test plan

- [x] Verified the stale source file is `rocm.list` by inspecting the base image
- [ ] Rebuild the Docker image with `--no-cache` and confirm it completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)