### PR TITLE
fix(docker): bump sglang to v0.5.11 and auto-resolve GPU arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM lmsysorg/sglang:v0.5.9-rocm700-mi35x
+ARG BASE_IMAGE=lmsysorg/sglang:v0.5.11-rocm720-mi35x
+FROM ${BASE_IMAGE}
 
 RUN apt-get update && apt-get install -y git make && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -45,6 +45,27 @@ EDITABLE=false
 EXEC_CMD=()  # Command to run inside the container (empty = bash)
 
 #######################################
+# Auto-resolve BASE_IMAGE from host GPU arch (override with BASE_IMAGE env var)
+#######################################
+SGLANG_VERSION="v0.5.11"
+ROCM_TAG="rocm720"
+
+if [ -z "$BASE_IMAGE" ]; then
+    _gfx_arch=$(rocminfo 2>/dev/null | grep -oP 'gfx\d+' | head -1)
+    case "$_gfx_arch" in
+        gfx942) _gpu_suffix="mi30x" ;;
+        gfx950) _gpu_suffix="mi35x" ;;
+        *)      _gpu_suffix="mi35x" ;;
+    esac
+    BASE_IMAGE="lmsysorg/sglang:${SGLANG_VERSION}-${ROCM_TAG}-${_gpu_suffix}"
+    if [ -n "$_gfx_arch" ]; then
+        echo "Detected GPU arch: ${_gfx_arch} → BASE_IMAGE=${BASE_IMAGE}"
+    else
+        echo "Could not detect GPU arch, using default: BASE_IMAGE=${BASE_IMAGE}"
+    fi
+fi
+
+#######################################
 # Parse options
 #######################################
 while [[ $# -gt 0 ]]; do
@@ -118,8 +139,8 @@ if [ "$REBUILD" = true ]; then
         echo "Removing container ${CONTAINER_NAME}..."
         docker rm ${CONTAINER_NAME}
     fi
-    echo "Rebuilding image ${IMAGE_NAME} (--no-cache)..."
-    docker build --network=host --no-cache -t ${IMAGE_NAME} .
+    echo "Rebuilding image ${IMAGE_NAME} (--no-cache, BASE_IMAGE=${BASE_IMAGE})..."
+    docker build --network=host --no-cache --build-arg "BASE_IMAGE=${BASE_IMAGE}" -t ${IMAGE_NAME} .
     echo ""
 fi
 
@@ -184,8 +205,8 @@ echo ""
 
 # Check if image exists, build if not (unless we already rebuilt)
 if [[ "$(docker images -q ${IMAGE_NAME} 2> /dev/null)" == "" ]]; then
-    echo "Image ${IMAGE_NAME} not found. Building..."
-    docker build --network=host -t ${IMAGE_NAME} .
+    echo "Image ${IMAGE_NAME} not found. Building (BASE_IMAGE=${BASE_IMAGE})..."
+    docker build --network=host --build-arg "BASE_IMAGE=${BASE_IMAGE}" -t ${IMAGE_NAME} .
 elif [ "$REBUILD" != true ]; then
     echo "Using existing image ${IMAGE_NAME}"
     echo "To rebuild from scratch, run: $0 --rebuild"


### PR DESCRIPTION
## Summary

- Bumps base image from `v0.5.9-rocm700` to `v0.5.11-rocm720` (aligned with Hyperloom). The old image shipped a stale `rocm.list` pointing at an internal Artifactory build that now 404s, breaking `apt-get update`.
- Adds `ARG BASE_IMAGE` to the Dockerfile so the base image can be overridden at build time.
- `run-docker.sh` now auto-detects the host GPU arch via `rocminfo` and selects the right base image: `gfx942` (MI300X/MI325X) → `mi30x`, `gfx950` (MI355X) → `mi35x`. Override with `BASE_IMAGE` env var if needed.

## Test plan

- [ ] `scripts/run-docker.sh --rebuild` on MI325X picks `mi30x` automatically
- [ ] `scripts/run-docker.sh --rebuild` on MI355X picks `mi35x` automatically
- [ ] `BASE_IMAGE=... scripts/run-docker.sh --rebuild` overrides auto-detection
- [ ] Docker build completes without apt-get errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)