### PR TITLE
Fix v3 preprocess sandboxing and context compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 !src/
 !mcp_tools/
 !scripts/
+!subagents/
 !skills/
 !docs/
 !knowledge-base/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN make install
 RUN python3 -c "from profiler_mcp.server import profile_kernel; from metrix import Metrix; print('Core imports verified')"
 
 # Runtime assets (not needed for install; changes only rebuild cheap COPY layers)
+COPY subagents/ subagents/
 COPY skills/ skills/
 COPY docs/ docs/
 COPY scripts/ scripts/

--- a/src/minisweagent/run/preprocess_v3/adapter.py
+++ b/src/minisweagent/run/preprocess_v3/adapter.py
@@ -163,6 +163,10 @@ def run_preprocess_v3(
         repo_root=repo_root,
         output_dir=output_dir,
         kernel_path_input=kernel_path,
+        harness=harness,
+        eval_command=eval_command,
+        correctness_command=correctness_command,
+        performance_command=performance_command,
     )
 
 
@@ -199,7 +203,7 @@ def _resolve_kernel_and_repo(
     resolved = _legacy_resolve(kernel_url, repo=str(repo) if repo is not None else None)
     if resolved.get("error"):
         raise RuntimeError(f"v3 preprocess: resolve-kernel-url failed: {resolved['error']}")
-    kp = Path(str(resolved["kernel_path"])).resolve()
+    kp = Path(str(resolved["local_file_path"])).resolve()
     rr = str(Path(resolved.get("repo_root") or _infer_repo_root(kp)).resolve())
     return kp, rr
 
@@ -293,6 +297,10 @@ def _preprocess_result_to_legacy_context(
     repo_root: str,
     output_dir: Path,
     kernel_path_input: Path,
+    harness: str | None = None,
+    eval_command: str | None = None,
+    correctness_command: str | list[str] | None = None,
+    performance_command: str | list[str] | None = None,
 ) -> dict[str, Any]:
     """Project a :class:`PreprocessResult` into the legacy ``preprocess_ctx`` dict.
 
@@ -333,7 +341,18 @@ def _preprocess_result_to_legacy_context(
     if result.codebase_context is not None and result.codebase_context.out_path is not None:
         codebase_context_path = str(result.codebase_context.out_path)
 
-    test_command = _extract_test_command(result)
+    test_command = _extract_test_command(result) or _join_legacy_command(
+        eval_command=eval_command,
+        correctness_command=correctness_command,
+        performance_command=performance_command,
+    )
+    harness_path = _recover_harness_path(
+        result=result,
+        harness=harness,
+        test_command=test_command,
+        repo_root=repo_root,
+    )
+    benchmark_baseline = _write_benchmark_baseline(result, output_dir)
 
     profiling = None
     if result.profile is not None:
@@ -365,15 +384,15 @@ def _preprocess_result_to_legacy_context(
         },
         "codebase_context_path": codebase_context_path,
         "discovery": discovery,
-        "harness_path": str(result.harness_path) if result.harness_path else "",
+        "harness_path": harness_path,
         "test_command": test_command,
         "harness_results": None,
         "testcase_selection": None,
         "profiling": profiling,
         "baseline_metrics": baseline_metrics or None,
         "baseline_metrics_path": baseline_metrics_path,
-        "benchmark_baseline": None,
-        "full_benchmark_baseline": None,
+        "benchmark_baseline": benchmark_baseline,
+        "full_benchmark_baseline": benchmark_baseline,
         "correctness": None,
         "commandment": commandment_text,
         "commandment_path": commandment_path_str,
@@ -381,6 +400,8 @@ def _preprocess_result_to_legacy_context(
         "evaluation_contract": None,
         "v3_subagent_runs": list(result.subagent_runs),
         "v3_elapsed_s": result.elapsed_s,
+        "v3_path_taken": result.path_taken,
+        "path_taken": result.path_taken,
     }
     if result.translation is not None:
         legacy_ctx["v3_translation"] = asdict(result.translation)
@@ -410,6 +431,77 @@ def _project_baseline(result: PreprocessResult) -> dict[str, Any]:
     if baseline.median_ms is not None:
         out["duration_us"] = baseline.median_ms * 1000.0
     return out
+
+
+def _join_legacy_command(
+    *,
+    eval_command: str | None,
+    correctness_command: str | list[str] | None,
+    performance_command: str | list[str] | None,
+) -> str | None:
+    """Recover the legacy ``test_command`` surface from v3 call-site kwargs."""
+
+    if eval_command and eval_command.strip():
+        return eval_command.strip()
+
+    parts: list[str] = []
+    for cmd in (correctness_command, performance_command):
+        if cmd is None:
+            continue
+        if isinstance(cmd, list):
+            parts.extend(c.strip() for c in cmd if c and c.strip())
+        elif cmd.strip():
+            parts.append(cmd.strip())
+    return " && ".join(parts) if parts else None
+
+
+def _recover_harness_path(
+    *,
+    result: PreprocessResult,
+    harness: str | None,
+    test_command: str | None,
+    repo_root: str,
+) -> str:
+    """Recover legacy ``harness_path`` for postprocess consumers.
+
+    Path-A commandment rendering can legitimately leave
+    ``PreprocessResult.harness_path`` empty, but promoted harness commands
+    still need a harness path in ``preprocess_ctx`` so postprocess can build
+    ``GEAK_HARNESS`` and profile correctly. This mirrors the legacy
+    preprocessor's ``extract_harness_path(test_command)`` fallback.
+    """
+
+    if result.harness_path:
+        return str(result.harness_path)
+
+    candidate = harness or test_command
+    if not candidate:
+        return ""
+    try:
+        from minisweagent.run.preprocess.harness_utils import extract_harness_path
+
+        harness_path = Path(extract_harness_path(candidate)).expanduser()
+    except Exception:
+        return ""
+
+    if not harness_path.is_absolute():
+        harness_path = Path(repo_root).expanduser().resolve() / harness_path
+    return str(harness_path.resolve())
+
+
+def _write_benchmark_baseline(result: PreprocessResult, output_dir: Path) -> str | None:
+    """Persist the raw v3 benchmark baseline text in legacy artifact files."""
+
+    baseline = result.baseline
+    if baseline is None:
+        return None
+    for raw in baseline.raw_outputs:
+        if raw.get("returncode") == 0 and str(raw.get("stdout") or "").strip():
+            text = str(raw["stdout"])
+            (output_dir / "benchmark_baseline.txt").write_text(text, encoding="utf-8")
+            (output_dir / "full_benchmark_baseline.txt").write_text(text, encoding="utf-8")
+            return text
+    return None
 
 
 def _extract_test_command(result: PreprocessResult) -> str | None:

--- a/src/minisweagent/run/preprocess_v3/adapter.py
+++ b/src/minisweagent/run/preprocess_v3/adapter.py
@@ -183,6 +183,11 @@ def _resolve_kernel_and_repo(
     ``resolve_kernel_url`` (which clones if necessary).
     """
     kernel_path_obj = Path(kernel_url).expanduser()
+    # Resolve repo-relative kernel paths before falling back to the URL resolver.
+    if not kernel_path_obj.is_absolute() and repo is not None:
+        candidate = Path(repo).expanduser().resolve() / kernel_path_obj
+        if candidate.is_file():
+            kernel_path_obj = candidate
     if kernel_path_obj.is_file():
         repo_root = str(Path(repo).expanduser().resolve()) if repo is not None else _infer_repo_root(kernel_path_obj)
         return kernel_path_obj.resolve(), repo_root
@@ -191,7 +196,7 @@ def _resolve_kernel_and_repo(
     # run/preprocess/; inline once that package is dismantled.
     from minisweagent.run.preprocess.resolve_kernel_url import resolve_kernel_url as _legacy_resolve
 
-    resolved = _legacy_resolve(kernel_url)
+    resolved = _legacy_resolve(kernel_url, repo=str(repo) if repo is not None else None)
     if resolved.get("error"):
         raise RuntimeError(f"v3 preprocess: resolve-kernel-url failed: {resolved['error']}")
     kp = Path(str(resolved["kernel_path"])).resolve()

--- a/src/minisweagent/run/preprocess_v3/registry.py
+++ b/src/minisweagent/run/preprocess_v3/registry.py
@@ -32,6 +32,7 @@ Design notes
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -84,16 +85,25 @@ UNLIMITED_MAX_STEPS: int = -1
 def _default_root() -> Path:
     """Resolve the default discovery root to ``<repo>/subagents/preprocess``.
 
-    The repository root is inferred by walking up from this file until
-    we find one with a ``pyproject.toml`` next to a ``subagents/`` dir.
-    Falls back to four-levels-up if that lookup fails — matches the
-    on-disk layout of GEAK (``src/minisweagent/run/preprocess_v3/registry.py``
-    is exactly 4 ``parent``s deep from the repo root).
+    Search order:
+    1. ``GEAK_SUBAGENTS_ROOT`` env var (explicit override for containers).
+    2. Walk up from this file looking for ``pyproject.toml`` + ``subagents/``
+       (works when running from a source checkout).
+    3. ``/workspace/subagents/preprocess`` (Docker convention).
+    4. Four-levels-up fallback (matches the on-disk layout when this file
+       is at ``src/minisweagent/run/preprocess_v3/registry.py``).
     """
+    env_root = os.environ.get("GEAK_SUBAGENTS_ROOT")
+    if env_root:
+        return Path(env_root)
     here = Path(__file__).resolve()
     for candidate in here.parents:
         if (candidate / "pyproject.toml").exists() and (candidate / "subagents").is_dir():
             return candidate / "subagents" / "preprocess"
+    # Docker container: subagents/ copied to /workspace/
+    workspace = Path("/workspace/subagents/preprocess")
+    if workspace.is_dir():
+        return workspace
     return here.parents[4] / "subagents" / "preprocess"
 
 
@@ -214,7 +224,7 @@ def _validate_and_build(name_hint: str, data: dict[str, Any], source: Path) -> S
 
     # Fall back to geak.yaml defaults for model and model_kwargs
     default_model, default_model_kwargs = _load_geak_model_defaults()
-    resolved_model = (str(data["model"]).strip() if data.get("model") else default_model)
+    resolved_model = str(data["model"]).strip() if data.get("model") else default_model
     resolved_model_kwargs = {**default_model_kwargs, **model_kwargs_raw}
 
     extras = {k: v for k, v in data.items() if k not in _KNOWN_FIELDS}

--- a/src/minisweagent/run/preprocess_v3/subagent.py
+++ b/src/minisweagent/run/preprocess_v3/subagent.py
@@ -289,10 +289,16 @@ class PreprocessSubagent:
             self._tool_table[name] = callable_
             self._tool_schemas.append(schema)
 
+        tool_env = self.extra_template_vars.get("_tool_env")
+        if not isinstance(tool_env, dict):
+            tool_env = {}
         if self.cwd:
             bash = self._tool_table.get("bash")
             if bash is not None and hasattr(bash, "_cwd"):
                 bash._cwd = self.cwd
+        for tool in self._tool_table.values():
+            if hasattr(tool, "_env_override"):
+                tool._env_override.update({str(k): str(v) for k, v in tool_env.items()})
 
     @property
     def tool_names(self) -> list[str]:

--- a/src/minisweagent/run/preprocess_v3/tools.py
+++ b/src/minisweagent/run/preprocess_v3/tools.py
@@ -1051,7 +1051,9 @@ def _make_tool_commandment_from_user_command(
         cmd = run_command.strip()
         # Rewrite hardcoded repo-root paths to ${GEAK_WORK_DIR} so the
         # COMMANDMENT references the agent's worktree at runtime.
-        repo_root = os.environ.get("GEAK_REPO_ROOT", "")
+        # Use the orchestrator's config.repo (available at preprocess time)
+        # rather than GEAK_REPO_ROOT (only set later for agent subprocesses).
+        repo_root = str(agent.config.repo) if agent.config.repo else os.environ.get("GEAK_REPO_ROOT", "")
         if repo_root and repo_root in cmd:
             cmd = cmd.replace(repo_root, "${GEAK_WORK_DIR}")
         modes_covered_tup = _normalise_modes(modes_covered)

--- a/src/minisweagent/run/preprocess_v3/tools.py
+++ b/src/minisweagent/run/preprocess_v3/tools.py
@@ -50,6 +50,8 @@ import inspect
 import json
 import logging
 import os
+import shlex
+import shutil
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -97,6 +99,64 @@ ALLOWED_SUBAGENT_NAMES: tuple[str, ...] = (
 #: body assembly when projecting the user's command into a
 #: ``COMMANDMENT.md``.
 PATH_A_MODES: tuple[str, ...] = ("correctness", "profile", "benchmark", "full_benchmark")
+
+
+def _copy_repo_sandbox(repo_root: Path, sandbox_root: Path, output_dir: Path) -> None:
+    """Copy a non-git repo into a preprocess subagent sandbox."""
+
+    repo_root = repo_root.resolve()
+    output_dir = output_dir.resolve()
+
+    def _ignore(dir_path: str, names: list[str]) -> set[str]:
+        ignored = {"__pycache__", ".pytest_cache", ".ruff_cache"}
+        current = Path(dir_path).resolve()
+        for name in names:
+            child = current / name
+            try:
+                child_resolved = child.resolve()
+            except OSError:
+                continue
+            # Avoid recursively copying the active GEAK output directory
+            # when users place outputs under the target repo.
+            if child_resolved == output_dir or output_dir in child_resolved.parents:
+                ignored.add(name)
+        return ignored
+
+    shutil.copytree(repo_root, sandbox_root, symlinks=True, ignore=_ignore)
+
+
+def _ensure_preprocess_subagent_sandbox(agent: PreprocessOrchestratorAgent) -> tuple[Path | None, dict[str, str]]:
+    """Create a repo sandbox for preprocess subagents and return tool env."""
+
+    repo_raw = agent._extra_template_vars.get("repo_root") if hasattr(agent, "_extra_template_vars") else None
+    output_raw = agent._extra_template_vars.get("output_dir") if hasattr(agent, "_extra_template_vars") else None
+    gpu_raw = agent._extra_template_vars.get("gpu_id") if hasattr(agent, "_extra_template_vars") else None
+    if not repo_raw or not output_raw:
+        return None, {}
+
+    repo_root = Path(str(repo_raw)).expanduser().resolve()
+    output_dir = Path(str(output_raw)).expanduser().resolve()
+    if not repo_root.is_dir():
+        return None, {}
+
+    sandbox_root = output_dir / "_preprocess_subagent_worktree"
+    if not sandbox_root.exists():
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if (repo_root / ".git").exists():
+            from minisweagent.run.task_file import create_worktree
+
+            create_worktree(repo_root, sandbox_root)
+        else:
+            _copy_repo_sandbox(repo_root, sandbox_root, output_dir)
+
+    gpu_id = str(gpu_raw if gpu_raw is not None else 0)
+    env = {
+        "GEAK_REPO_ROOT": str(repo_root),
+        "GEAK_WORK_DIR": str(sandbox_root.resolve()),
+        "GEAK_GPU_DEVICE": gpu_id,
+        "HIP_VISIBLE_DEVICES": gpu_id,
+    }
+    return sandbox_root.resolve(), env
 
 
 # ---------------------------------------------------------------------------
@@ -267,9 +327,15 @@ class PreprocessSubagentDispatcher:
                 "elapsed_s": 0.0,
             }
 
+        tool_env = None
+        if isinstance(context, dict):
+            tool_env = context.pop("_tool_env", None)
+
         full_task = task if not context else self._format_context_preamble(context) + "\n\n" + task
 
         extra_template_vars = self._resolve_extra_template_vars(spec)
+        if isinstance(tool_env, dict):
+            extra_template_vars["_tool_env"] = tool_env
 
         t0 = time.monotonic()
         try:
@@ -841,6 +907,29 @@ def _make_tool_dispatch_subagent(
             context = {"context": str(context)}
         else:
             context = dict(context)
+        generator_attempts = int(agent._collected.get("_harness_generator_attempts", 0) or 0)
+        if name == "harness-generator":
+            if generator_attempts >= 3:
+                return {
+                    "name": name,
+                    "success": False,
+                    "error": "harness-generator retry budget exhausted after 3 attempts",
+                    "output": (
+                        "HARNESS_VERIFIED=false\n"
+                        "ESCALATE=true\n"
+                        "PHASE=runtime\n"
+                        "FAILED_RULE=generator-retry-budget-exhausted\n"
+                        "FAILED_MODE=n/a\n"
+                        "EVIDENCE=harness-generator was requested after 3 failed attempts\n"
+                    ),
+                    "elapsed_s": 0.0,
+                    "max_steps": None,
+                }
+            generator_attempts += 1
+            agent._collected["_harness_generator_attempts"] = generator_attempts
+            context.setdefault("attempt", generator_attempts)
+        elif name == "harness-verifier":
+            context.setdefault("attempt", max(generator_attempts, 1))
         codebase_ctx = agent._collected.get("codebase_context")
         if (
             codebase_ctx is not None
@@ -862,7 +951,11 @@ def _make_tool_dispatch_subagent(
         _scoring = agent._extra_template_vars.get("scoring_target")
         if _scoring and "scoring_target" not in context:
             context["scoring_target"] = _scoring
-        result = dispatcher(name=name, task=task, model=agent.model, context=context)
+        sandbox_cwd, tool_env = _ensure_preprocess_subagent_sandbox(agent)
+        if sandbox_cwd is not None:
+            context.setdefault("sandbox_repo_root", str(sandbox_cwd))
+            context["_tool_env"] = tool_env
+        result = dispatcher(name=name, task=task, model=agent.model, cwd=str(sandbox_cwd) if sandbox_cwd else None, context=context)
         agent._subagent_runs.append(result)
         # Auto-populate orchestrator state from the subagent's output so
         # the LLM doesn't have to extract structured fields by regex.
@@ -1063,8 +1156,9 @@ def _make_tool_commandment_from_user_command(
         setup_body = (
             "printf '#!/bin/bash\\nexport PYTHONPATH=%s:%s:${PYTHONPATH}\\n"
             "export HIP_VISIBLE_DEVICES=%s\\n"
-            'exec "$@"\\n\' '
+            'cd "%s" && exec bash -lc "$*"\\n\' '
             '"${GEAK_WORK_DIR}" "${GEAK_REPO_ROOT}" "${GEAK_GPU_DEVICE}" '
+            '"${GEAK_WORK_DIR}" '
             "> ${GEAK_WORK_DIR}/run.sh && chmod +x ${GEAK_WORK_DIR}/run.sh"
         )
         sections: dict[str, str] = {
@@ -1073,7 +1167,11 @@ def _make_tool_commandment_from_user_command(
         warnings: list[str] = []
         modes_emitted: list[str] = []
 
-        wrapped_cmd = f"cd ${{GEAK_WORK_DIR}} && {cmd}"
+        # Invoke through run.sh so every Path-A section uses the same
+        # PYTHONPATH/HIP_VISIBLE_DEVICES/worktree contract as legacy
+        # COMMANDMENT generation while still supporting compound shell
+        # commands such as "compile && correctness && performance".
+        wrapped_cmd = f"${{GEAK_WORK_DIR}}/run.sh {shlex.quote(cmd)}"
         for mode in PATH_A_MODES:
             if mode in modes_covered_tup:
                 sections[mode] = wrapped_cmd
@@ -1255,7 +1353,10 @@ def _finish_blockers(
         return blockers
 
     if payload.get("errors"):
-        blockers.append(f"finish_preprocess called with errors={payload['errors']!r}")
+        # A failed preprocess must be allowed to terminate. The final
+        # PreprocessResult will carry success=False; blocking here causes the
+        # orchestrator to spin until its global step limit.
+        return blockers
 
     if not agent._collected.get("harness_path"):
         blockers.append("Path B missing harness_path")

--- a/src/minisweagent/run/preprocess_v3/tools.py
+++ b/src/minisweagent/run/preprocess_v3/tools.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import os
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -1048,24 +1049,37 @@ def _make_tool_commandment_from_user_command(
             )
 
         cmd = run_command.strip()
+        # Rewrite hardcoded repo-root paths to ${GEAK_WORK_DIR} so the
+        # COMMANDMENT references the agent's worktree at runtime.
+        repo_root = os.environ.get("GEAK_REPO_ROOT", "")
+        if repo_root and repo_root in cmd:
+            cmd = cmd.replace(repo_root, "${GEAK_WORK_DIR}")
         modes_covered_tup = _normalise_modes(modes_covered)
         inferred_modes_tup = _normalise_modes(inferred_modes)
         source_mode = modes_covered_tup[0] if modes_covered_tup else None
 
+        setup_body = (
+            "printf '#!/bin/bash\\nexport PYTHONPATH=%s:%s:${PYTHONPATH}\\n"
+            "export HIP_VISIBLE_DEVICES=%s\\n"
+            'exec "$@"\\n\' '
+            '"${GEAK_WORK_DIR}" "${GEAK_REPO_ROOT}" "${GEAK_GPU_DEVICE}" '
+            "> ${GEAK_WORK_DIR}/run.sh && chmod +x ${GEAK_WORK_DIR}/run.sh"
+        )
         sections: dict[str, str] = {
-            "setup": ("# Path-A: user-provided run command assumes the environment is ready.\ntrue"),
+            "setup": setup_body,
         }
         warnings: list[str] = []
         modes_emitted: list[str] = []
 
+        wrapped_cmd = f"cd ${{GEAK_WORK_DIR}} && {cmd}"
         for mode in PATH_A_MODES:
             if mode in modes_covered_tup:
-                sections[mode] = cmd
+                sections[mode] = wrapped_cmd
                 modes_emitted.append(mode)
             elif mode in inferred_modes_tup:
                 src = source_mode or "<unspecified>"
                 marker_line = f"# PATH_A_PARTIAL_COVERAGE: {mode} inferred from {src}"
-                sections[mode] = f"{marker_line}\n{cmd}"
+                sections[mode] = f"{marker_line}\n{wrapped_cmd}"
                 warnings.append(f"PATH_A_PARTIAL_COVERAGE: {mode} inferred from {src}")
                 modes_emitted.append(mode)
             else:

--- a/src/minisweagent/tools/bash_command.py
+++ b/src/minisweagent/tools/bash_command.py
@@ -93,6 +93,31 @@ class BashCommand:
             "rm -rf /",
         ]
 
+    @staticmethod
+    def _sandbox_command(command: str) -> str:
+        """Rewrite absolute paths in the command that target the original repo.
+
+        Agents in worktrees must never write to the original repo
+        (``GEAK_REPO_ROOT``).  Replace occurrences of the repo root with
+        the agent's worktree (``GEAK_WORK_DIR``) so that ``cat >``,
+        ``cp``, ``cd``, and similar commands land in the worktree.
+
+        Safe because every legitimate repo-root reference in agent bash
+        commands (``cd``, ``python -c``, ``cp``) works identically with
+        the worktree path. The PYTHONPATH and COMMANDMENT ``run.sh``
+        scripts read ``$GEAK_REPO_ROOT`` at shell-expansion time, not
+        from the command string, so they are unaffected.
+        """
+        repo_root = os.environ.get("GEAK_REPO_ROOT", "")
+        work_dir = os.environ.get("GEAK_WORK_DIR", "")
+        if not repo_root or not work_dir or repo_root == work_dir:
+            return command
+        if repo_root in command:
+            rewritten = command.replace(repo_root, work_dir)
+            logger.debug("bash_command: rewrote repo_root paths in command")
+            return rewritten
+        return command
+
     def __call__(
         self,
         *,
@@ -110,6 +135,7 @@ class BashCommand:
                 "returncode": 1,
             }
         else:
+            command = self._sandbox_command(command)
             env = os.environ | self._env_override if self._env_override else None
             cwd = self._cwd if self._cwd and Path(self._cwd).is_dir() else None
             result = subprocess.run(

--- a/src/minisweagent/tools/str_replace_editor.py
+++ b/src/minisweagent/tools/str_replace_editor.py
@@ -1,16 +1,38 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
+logger = logging.getLogger(__name__)
+
 
 class str_replace_editor:
     def __init__(self) -> None:
         self.tool_py = Path(__file__).parent / "editor_tool.py"
+
+    @staticmethod
+    def _sandbox_path(path: str) -> str:
+        """Rewrite paths that point into the original repo to the agent's worktree.
+
+        Agents running in worktrees should never write to the original repo
+        (``GEAK_REPO_ROOT``). If the LLM passes an absolute path inside the
+        original repo, silently redirect it to the equivalent path inside
+        ``GEAK_WORK_DIR`` so the original stays pristine.
+        """
+        repo_root = os.environ.get("GEAK_REPO_ROOT", "")
+        work_dir = os.environ.get("GEAK_WORK_DIR", "")
+        if not repo_root or not work_dir or repo_root == work_dir:
+            return path
+        if path.startswith(repo_root + "/") or path == repo_root:
+            rewritten = work_dir + path[len(repo_root) :]
+            logger.debug("str_replace_editor: redirected %s -> %s", path, rewritten)
+            return rewritten
+        return path
 
     def __call__(
         self,
@@ -24,6 +46,7 @@ class str_replace_editor:
         insert_line: int | None = None,
         **kwargs: object,
     ) -> dict[str, str | int]:
+        path = self._sandbox_path(path)
         cmd: list[str] = [sys.executable, str(self.tool_py), command, path]
 
         file_text_path: str | None = None

--- a/src/minisweagent/tools/str_replace_editor.py
+++ b/src/minisweagent/tools/str_replace_editor.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 class str_replace_editor:
     def __init__(self) -> None:
         self.tool_py = Path(__file__).parent / "editor_tool.py"
+        self._env_override: dict[str, str] = {}
 
-    @staticmethod
-    def _sandbox_path(path: str) -> str:
+    def _sandbox_path(self, path: str) -> str:
         """Rewrite paths that point into the original repo to the agent's worktree.
 
         Agents running in worktrees should never write to the original repo
@@ -24,8 +24,9 @@ class str_replace_editor:
         original repo, silently redirect it to the equivalent path inside
         ``GEAK_WORK_DIR`` so the original stays pristine.
         """
-        repo_root = os.environ.get("GEAK_REPO_ROOT", "")
-        work_dir = os.environ.get("GEAK_WORK_DIR", "")
+        env = os.environ | self._env_override if self._env_override else os.environ
+        repo_root = env.get("GEAK_REPO_ROOT", "")
+        work_dir = env.get("GEAK_WORK_DIR", "")
         if not repo_root or not work_dir or repo_root == work_dir:
             return path
         if path.startswith(repo_root + "/") or path == repo_root:
@@ -78,6 +79,7 @@ class str_replace_editor:
         # Child imports minisweagent (via editor_tool → registry); package __init__
         # prints a startup banner to stdout unless silenced.
         subprocess_env = os.environ.copy()
+        subprocess_env.update(self._env_override)
         subprocess_env["MSWEA_SILENT_STARTUP"] = "1"
 
         try:

--- a/tests/run/test_preprocess_v3_bugfixes.py
+++ b/tests/run/test_preprocess_v3_bugfixes.py
@@ -1,0 +1,223 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import minisweagent.run.preprocess.resolve_kernel_url as resolve_kernel_url_module
+import pytest
+from minisweagent.run.preprocess_v3.adapter import _preprocess_result_to_legacy_context, _resolve_kernel_and_repo
+from minisweagent.run.preprocess_v3.orchestrator import (
+    FinishedSuccessfully,
+    PreprocessOrchestratorAgent,
+    PreprocessOrchestratorConfig,
+)
+from minisweagent.run.preprocess_v3.tools import (
+    _make_tool_commandment_from_user_command,
+    _make_tool_dispatch_subagent,
+    _make_tool_finish_preprocess,
+)
+
+
+def test_resolve_kernel_path_relative_to_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    kernel = repo / "kernels" / "silu.hip"
+    kernel.parent.mkdir(parents=True)
+    kernel.write_text("// hip kernel\n")
+
+    resolved_kernel, resolved_repo = _resolve_kernel_and_repo("kernels/silu.hip", repo, console=None)
+
+    assert resolved_kernel == kernel.resolve()
+    assert resolved_repo == str(repo.resolve())
+
+
+def test_resolve_kernel_fallback_uses_legacy_resolver_keys(tmp_path: Path, monkeypatch) -> None:
+    cloned_repo = tmp_path / "cloned-repo"
+    kernel = cloned_repo / "kernel.py"
+    kernel.parent.mkdir(parents=True)
+    kernel.write_text("# kernel\n")
+
+    def fake_resolve_kernel_url(kernel_url: str, repo: str | None = None) -> dict:
+        assert kernel_url == "https://example.test/repo/blob/main/kernel.py"
+        assert repo == str(tmp_path / "repo")
+        return {
+            "error": None,
+            "local_file_path": str(kernel),
+            "local_repo_path": str(cloned_repo),
+        }
+
+    monkeypatch.setattr(resolve_kernel_url_module, "resolve_kernel_url", fake_resolve_kernel_url)
+
+    resolved_kernel, resolved_repo = _resolve_kernel_and_repo(
+        "https://example.test/repo/blob/main/kernel.py",
+        tmp_path / "repo",
+        console=None,
+    )
+
+    assert resolved_kernel == kernel.resolve()
+    assert resolved_repo == str(cloned_repo.resolve())
+
+
+def test_path_a_commandment_runs_user_command_through_run_sh(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_path = tmp_path / "COMMANDMENT.md"
+    raw_command = (
+        f"python3 {repo}/scripts/task_runner.py compile && "
+        "python3 scripts/task_runner.py correctness && "
+        "python3 scripts/task_runner.py performance"
+    )
+    agent = PreprocessOrchestratorAgent(
+        model=object(),
+        config=PreprocessOrchestratorConfig(repo=repo),
+    )
+
+    tool = _make_tool_commandment_from_user_command(agent)
+    result = tool(
+        run_command=raw_command,
+        out_path=str(out_path),
+        modes_covered=["benchmark"],
+        inferred_modes=["correctness", "full_benchmark"],
+    )
+
+    text = out_path.read_text()
+    assert result["ok"] is True
+    assert "printf '#!/bin/bash" in text
+    assert "exec bash -lc" in text
+    assert "${GEAK_WORK_DIR}/run.sh" in text
+    assert "cd ${GEAK_WORK_DIR} && python3" not in text
+    assert str(repo) not in text
+    assert "${GEAK_WORK_DIR}/scripts/task_runner.py" in text
+
+
+def test_dispatch_subagent_uses_sandbox_worktree_env(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "kernel.py").write_text("# kernel\n")
+    output_dir = tmp_path / "out"
+    agent = PreprocessOrchestratorAgent(
+        model=object(),
+        config=PreprocessOrchestratorConfig(repo=repo),
+    )
+    agent._extra_template_vars = {
+        "repo_root": str(repo),
+        "output_dir": str(output_dir),
+        "gpu_id": 2,
+    }
+    seen: dict = {}
+
+    class FakeDispatcher:
+        def __call__(self, **kwargs):
+            seen.update(kwargs)
+            return {
+                "name": kwargs["name"],
+                "success": True,
+                "output": f"HARNESS_PATH: {output_dir / '_preprocess_subagent_worktree' / 'harness.py'}",
+            }
+
+    tool = _make_tool_dispatch_subagent(agent, FakeDispatcher())
+    result = tool(name="harness-generator", task="make a harness", context={"repo_root": str(repo)})
+
+    sandbox = output_dir / "_preprocess_subagent_worktree"
+    assert result["success"] is True
+    assert Path(seen["cwd"]) == sandbox.resolve()
+    assert sandbox.is_dir()
+    assert (sandbox / "kernel.py").is_file()
+    assert seen["context"]["sandbox_repo_root"] == str(sandbox.resolve())
+    assert seen["context"]["_tool_env"]["GEAK_REPO_ROOT"] == str(repo.resolve())
+    assert seen["context"]["_tool_env"]["GEAK_WORK_DIR"] == str(sandbox.resolve())
+    assert seen["context"]["_tool_env"]["GEAK_GPU_DEVICE"] == "2"
+
+
+def test_harness_generator_retry_cap_is_enforced(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "kernel.py").write_text("# kernel\n")
+    output_dir = tmp_path / "out"
+    agent = PreprocessOrchestratorAgent(
+        model=object(),
+        config=PreprocessOrchestratorConfig(repo=repo),
+    )
+    agent._extra_template_vars = {
+        "repo_root": str(repo),
+        "output_dir": str(output_dir),
+        "gpu_id": 0,
+    }
+    calls = {"count": 0}
+
+    class FakeDispatcher:
+        def __call__(self, **kwargs):
+            calls["count"] += 1
+            return {"name": kwargs["name"], "success": False, "output": "HARNESS_VERIFIED=false"}
+
+    tool = _make_tool_dispatch_subagent(agent, FakeDispatcher())
+    for attempt in range(1, 4):
+        result = tool(name="harness-generator", task="try", context={})
+        assert result["success"] is False
+        assert agent._collected["_harness_generator_attempts"] == attempt
+
+    capped = tool(name="harness-generator", task="try again", context={})
+    assert capped["success"] is False
+    assert "retry budget exhausted" in capped["error"]
+    assert calls["count"] == 3
+
+
+def test_finish_preprocess_allows_failed_result_to_terminate() -> None:
+    agent = PreprocessOrchestratorAgent(model=object())
+    agent._collected = {}
+    tool = _make_tool_finish_preprocess(agent)
+
+    with pytest.raises(FinishedSuccessfully):
+        tool(errors=["harness-generator retry budget exhausted"])
+
+
+def test_legacy_context_recovers_harness_path_from_promoted_command(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    harness = repo / "tests" / "test_topk_harness.py"
+    kernel = repo / "aiter" / "ops" / "triton" / "topk.py"
+    output_dir = tmp_path / "out"
+    harness.parent.mkdir(parents=True)
+    kernel.parent.mkdir(parents=True)
+    output_dir.mkdir()
+    harness.write_text("print('harness')\n")
+    kernel.write_text("# kernel\n")
+    commandment = output_dir / "COMMANDMENT.md"
+    commandment.write_text("# Commandment\n")
+    baseline = SimpleNamespace(
+        median_ms=1.25,
+        samples_ms=[1.2, 1.3],
+        stdev_ms=0.1,
+        repeats=2,
+        command="python harness --benchmark",
+        raw_outputs=[
+            {
+                "returncode": 0,
+                "stdout": "GEAK_RESULT_LATENCY_MS=1.25\n",
+            }
+        ],
+    )
+    result = SimpleNamespace(
+        kernel_path=kernel,
+        kernel_language=SimpleNamespace(name="triton"),
+        baseline=baseline,
+        profile=None,
+        commandment_path=commandment,
+        codebase_context=None,
+        harness_path=None,
+        translation=None,
+        subagent_runs=[],
+        elapsed_s=1.0,
+        path_taken="A",
+    )
+
+    ctx = _preprocess_result_to_legacy_context(
+        result=result,
+        repo_root=str(repo),
+        output_dir=output_dir,
+        kernel_path_input=kernel,
+        eval_command=f"python {harness}",
+    )
+
+    assert ctx["test_command"] == f"python {harness}"
+    assert ctx["harness_path"] == str(harness.resolve())
+    assert ctx["benchmark_baseline"] == "GEAK_RESULT_LATENCY_MS=1.25\n"
+    assert ctx["full_benchmark_baseline"] == "GEAK_RESULT_LATENCY_MS=1.25\n"
+    assert (output_dir / "benchmark_baseline.txt").read_text() == "GEAK_RESULT_LATENCY_MS=1.25\n"
+    assert ctx["v3_path_taken"] == "A"


### PR DESCRIPTION
## Summary
- Bring over the non-scheduler fixes from `gwiab-scheduler` for Docker subagent packaging, subprocess sandbox path rewriting, and Path-A COMMANDMENT setup.
- Add v3 preprocess sandboxing so harness subagents operate in an isolated repo copy/worktree instead of mutating the original repo.
- Restore legacy-compatible preprocess context fields (`harness_path`, `test_command`, baseline text, `path_taken`) for downstream postprocess consumers.

## Test plan
- `python3 -m pytest tests/run/test_preprocess_v3_bugfixes.py`
- `python3 -m py_compile src/minisweagent/run/preprocess_v3/adapter.py src/minisweagent/run/preprocess_v3/tools.py src/minisweagent/run/preprocess_v3/subagent.py src/minisweagent/tools/str_replace_editor.py tests/run/test_preprocess_v3_bugfixes.py`
- Container E2E smoke: `topk` completed with exit code 0 and produced `final_report.json`.
- Container E2E smoke: `silu` completed with exit code 0 and produced `final_report.json`.

## Notes
- This intentionally avoids the scheduler/GPUManager commits from `gwiab-scheduler`.
- Postprocess binary/cumulative patch apply robustness is still separate follow-up work.


Made with [Cursor](https://cursor.com)