### PR TITLE
fix the tools call list in litellm

### DIFF
--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -104,7 +104,7 @@ def convert_openai_tools_to_litellm(
         function: dict[str, Any] = {
             "name": name,
             "description": func.get("description", ""),
-            "input_schema": func.get(
+            "parameters": func.get(
                 "parameters",
                 {
                     "type": "object",
@@ -344,9 +344,9 @@ class LitellmModel:
             raise
 
     def query(self, messages: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
-        messages = normalize_messages_for_litellm_api(messages)
         if self.config.set_cache_control:
             messages = set_cache_control(messages, mode=self.config.set_cache_control)
+        messages = normalize_messages_for_litellm_api(messages)
 
         response = self._query(messages, **kwargs)
 

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -44,9 +44,10 @@ class TestConvertOpenaiToolsToLitellm:
         assert result[0]["function"]["name"] == "bash"
         assert result[1]["function"]["name"] == "submit"
 
-    def test_input_schema_used(self):
+    def test_parameters_schema_used(self):
+        # LiteLLM consumes OpenAI-style tool schemas, where the JSON Schema lives under "parameters".
         result = convert_openai_tools_to_litellm(self.TOOLS)
-        assert result[0]["function"]["input_schema"]["properties"]["cmd"]["type"] == "string"
+        assert result[0]["function"]["parameters"]["properties"]["cmd"]["type"] == "string"
 
     def test_skips_tools_without_name(self):
         tools = [{"function": {"description": "no name"}}]


### PR DESCRIPTION

## Summary
LitellmModel was producing tool definitions that LiteLLM's OpenAI-compatible completion() could not consume, and was applying Anthropic prompt-cache breakpoints after assistant tool_calls had already been coerced into LiteLLM's API shape. This PR fixes both in a single 2-line change to src/minisweagent/models/litellm_model.py.

## Changes
1. convert_openai_tools_to_litellm: input_schema → parameters
LiteLLM's litellm.completion(tools=...) expects the OpenAI tool schema, where each function's JSON Schema lives under the parameters key:

{"type": "function", "function": {"name": ..., "description": ..., "parameters": {...}}}
We were emitting function.input_schema (the Anthropic-native key). On the OpenAI-compatible path LiteLLM silently dropped the schema, so the model received tools with no argument types and could not produce well-typed tool calls (manifested as empty / malformed tool_use blocks against Anthropic via LiteLLM, and as schemaless tool listings against OpenAI gateways).

2. LitellmModel.query: run set_cache_control before normalize_messages_for_litellm_api
set_cache_control operates on the agent-internal message list (where tool_calls is a single dict, as written by DefaultAgent). normalize_messages_for_litellm_api then deep-copies and rewrites tool_calls into the OpenAI list shape required by LiteLLM's Anthropic/Vertex path.

The previous order normalized first, so cache-control breakpoints were placed on the post-coercion copy rather than on the canonical agent messages. The new order matches the in-file comment ("attach cache breakpoints on the agent message list before coercing tool_calls shape for LiteLLM") and mirrors AmdOpenAIModel._query_api semantics.

## Impact
Tool-using models routed through LitellmModel (including AnthropicModel, which subclasses it) now receive correctly typed tool schemas and call tools reliably.
Anthropic prompt caching is again applied to the actual agent messages, restoring the intended cache-hit behavior for Claude routes.
No public API or config changes; default behavior is preserved for non-Anthropic models (set_cache_control still defaults to None for plain LitellmModel).
## Test Plan

- [x] pytest tests/models/test_litellm_model.py
Note: TestConvertOpenaiToolsToLitellm::test_input_schema_used asserts on the now-removed input_schema key and must be renamed/updated to check function["parameters"] 

- [x] Smoke run via python -m minisweagent.models.litellm_model (the __main__ block) against an Anthropic-via-LiteLLM gateway and confirm the assistant emits a tool call for the "list all tools you have" turn.
