### PR TITLE
fix(save_and_test): use git diff --no-index for fallback patch capture

### DIFF
--- a/src/minisweagent/tools/save_and_test.py
+++ b/src/minisweagent/tools/save_and_test.py
@@ -33,77 +33,54 @@ from minisweagent.run.utils.generated_artifacts import (
 logger = logging.getLogger(__name__)
 
 
-def _normalize_diff_ruN_to_git(patch_text: str, base_repo: Path, cwd: Path) -> str:
-    """Rewrite ``diff -ruN`` headers (absolute paths) to git-style relative.
+def _normalize_noindex_to_relative(patch_text: str, base_repo: Path, cwd: Path) -> str:
+    """Strip absolute base/cwd prefixes from ``git diff --no-index`` headers.
 
-    ``diff -ruN /abs/base /abs/cwd`` produces headers like::
+    ``git diff --no-index /abs/base /abs/cwd`` emits git-style headers that
+    already carry ``/dev/null`` and ``new file mode`` lines for created files,
+    but the ``a/`` and ``b/`` paths keep the absolute prefixes::
 
-        diff -ruN /abs/base/kernel.py /abs/cwd/kernel.py
-        --- /abs/base/kernel.py    2026-04-17 19:10:02 +0000
-        +++ /abs/cwd/kernel.py     2026-04-19 01:21:00 +0000
+        diff --git a/abs/cwd/newfile.py b/abs/cwd/newfile.py
+        new file mode 100644
+        --- /dev/null
+        +++ b/abs/cwd/newfile.py
 
-    ``git apply`` rejects these because it can't find ``/abs/base/kernel.py``.
-    Rewrite to::
+    ``git apply`` needs repo-relative paths, so rewrite to::
 
-        diff --git a/kernel.py b/kernel.py
-        --- a/kernel.py
-        +++ b/kernel.py
+        diff --git a/newfile.py b/newfile.py
+        new file mode 100644
+        --- /dev/null
+        +++ b/newfile.py
 
-    The relative path is derived by stripping the ``base_repo`` / ``cwd``
-    prefix from each header line. Returns the input unchanged if no
-    rewrite is needed.
+    Only ``diff --git ``, ``--- ``, and ``+++ `` header lines are touched;
+    ``/dev/null``, ``new file mode``, ``index``, and hunk lines pass through
+    untouched. Both base and cwd prefixes are stripped from both the ``a/``
+    and ``b/`` sides because ``git diff --no-index`` uses the cwd path on both
+    sides for a newly created file. Returns the input unchanged if empty.
     """
     if not patch_text:
         return patch_text
-    base_str = str(Path(base_repo).resolve()).rstrip("/")
-    cwd_str = str(Path(cwd).resolve()).rstrip("/")
+    base_rel = str(Path(base_repo).resolve()).lstrip("/").rstrip("/")
+    cwd_rel = str(Path(cwd).resolve()).lstrip("/").rstrip("/")
+
+    # ``a/<abs>/`` -> ``a/`` and ``b/<abs>/`` -> ``b/`` for both trees.
+    replacements = [
+        (f"a/{base_rel}/", "a/"),
+        (f"a/{cwd_rel}/", "a/"),
+        (f"b/{base_rel}/", "b/"),
+        (f"b/{cwd_rel}/", "b/"),
+    ]
 
     out_lines: list[str] = []
     rewrote = False
     for line in patch_text.splitlines():
-        if line.startswith("diff -ruN "):
-            # Try to derive the relative path of the changed file from the
-            # second argument (the cwd-side path).
-            parts = line.split()
-            if len(parts) >= 4:
-                rel = parts[-1]
-                if rel.startswith(cwd_str + "/"):
-                    rel = rel[len(cwd_str) + 1 :]
-                elif rel.startswith(base_str + "/"):
-                    rel = rel[len(base_str) + 1 :]
-                out_lines.append(f"diff --git a/{rel} b/{rel}")
-                rewrote = True
-                continue
-        if line.startswith("--- "):
-            payload = line[4:].split("\t", 1)[0].strip()
-            if payload == "/dev/null":
-                out_lines.append("--- /dev/null")
-                continue
-            rel = payload
-            for prefix in (base_str + "/", cwd_str + "/"):
-                if rel.startswith(prefix):
-                    rel = rel[len(prefix) :]
-                    break
-            else:
-                # Fall back to basename if neither prefix matches.
-                rel = Path(payload).name
-            out_lines.append(f"--- a/{rel}")
-            rewrote = True
-            continue
-        if line.startswith("+++ "):
-            payload = line[4:].split("\t", 1)[0].strip()
-            if payload == "/dev/null":
-                out_lines.append("+++ /dev/null")
-                continue
-            rel = payload
-            for prefix in (base_str + "/", cwd_str + "/"):
-                if rel.startswith(prefix):
-                    rel = rel[len(prefix) :]
-                    break
-            else:
-                rel = Path(payload).name
-            out_lines.append(f"+++ b/{rel}")
-            rewrote = True
+        if line.startswith(("diff --git ", "--- ", "+++ ")):
+            new_line = line
+            for needle, sub in replacements:
+                if needle in new_line:
+                    new_line = new_line.replace(needle, sub)
+                    rewrote = True
+            out_lines.append(new_line)
             continue
         out_lines.append(line)
 
@@ -788,7 +765,7 @@ class SaveAndTestTool:
             )
             if result.returncode == 0 and result.stdout.strip():
                 return self._strip_jit_cache_from_patch(result.stdout)
-            # Fall through to diff -ruN when git diff fails or returns empty.
+            # Fall through to ``git diff --no-index`` when git diff fails or returns empty.
 
         if ctx.base_repo_path and ctx.base_repo_path.exists():
             excludes = [
@@ -814,9 +791,9 @@ class SaveAndTestTool:
                 ".cache",
                 # JIT runtime caches (.aiter_jit, .triton, flydsl_cache,
                 # torch_compile_cache, triton_cache) are pre-excluded here so
-                # ``diff -ruN`` never scans them in the first place. The
-                # ``_strip_jit_cache_from_patch`` post-filter below still runs
-                # as defence-in-depth, but pre-excluding avoids walking
+                # ``git diff --no-index`` never scans them in the first place.
+                # The ``_strip_jit_cache_from_patch`` post-filter below still
+                # runs as defence-in-depth, but pre-excluding avoids walking
                 # potentially large cache trees and keeps the captured patch
                 # narrower from the start.
                 *jit_cache_diff_basename_excludes(),
@@ -827,26 +804,31 @@ class SaveAndTestTool:
                 if run_dir_name:
                     excludes.append(run_dir_name)
 
+            # ``git diff --no-index`` is git-native (unlike plain ``diff -ruN``):
+            # it emits ``--- /dev/null`` + ``new file mode`` for files the agent
+            # created and derives the executable bit from ``stat`` for free, so a
+            # later ``git apply`` recreates new files with the right mode. The
+            # only post-processing needed is stripping the absolute base/cwd
+            # prefixes from the ``a/`` ``b/`` headers. ``--no-index`` exits 1 when
+            # there are differences (like plain diff), so the return code is
+            # intentionally ignored and we read stdout directly.
+            exclude_args = [f":(exclude){entry}" for entry in excludes]
             result = subprocess.run(
                 [
+                    "git",
                     "diff",
-                    "-ruN",
-                    "--exclude=.git",
-                    "--exclude=__pycache__",
-                    *[f"--exclude={p}" for p in excludes if p not in (".git", "__pycache__")],
+                    "--no-index",
+                    "--no-color",
                     str(ctx.base_repo_path),
                     str(cwd),
+                    "--",
+                    *exclude_args,
                 ],
                 capture_output=True,
                 text=True,
                 timeout=30,
             )
-            # Normalize ``diff -ruN`` headers into git-style relative paths
-            # so that ``git apply`` in the eval worktree can apply the patch
-            # without choking on absolute paths like
-            # ``--- /home/user/repo/.../kernel.py``. Otherwise eval fails
-            # with "kernel.py: No such file or directory".
-            normalized = _normalize_diff_ruN_to_git(result.stdout, ctx.base_repo_path, cwd)
+            normalized = _normalize_noindex_to_relative(result.stdout, ctx.base_repo_path, cwd)
             return self._strip_jit_cache_from_patch(normalized)
 
         return ""

--- a/tests/tools/test_save_and_test_diff_fallthrough.py
+++ b/tests/tools/test_save_and_test_diff_fallthrough.py
@@ -15,17 +15,24 @@ The bug being pinned here:
     "no changes detected" even when the agent had really edited
     ``kernel.py`` and the test had really passed.
 
-The fix: the git branch now falls through to the ``diff -ruN`` backup
-path when ``git diff`` returns non-zero or empty stdout, instead of
-returning empty unconditionally. ``diff -ruN`` does not understand
-submodule pointers and therefore is robust to this failure mode.
+The fix: the git branch falls through to a backup directory-diff path when
+``git diff`` returns non-zero or empty stdout, instead of returning empty
+unconditionally. The backup uses ``git diff --no-index <base> <cwd>`` (git's
+own directory-tree diff). Unlike the previous plain ``diff -ruN``, it emits
+``--- /dev/null`` + ``new file mode`` for files the agent created and derives
+the executable bit from ``stat``, so a later ``git apply`` recreates new files
+with the correct mode. The only post-processing is stripping the absolute
+base/cwd prefixes from the ``a/`` ``b/`` headers.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from unittest import mock
+
+import pytest
 
 from minisweagent.tools.save_and_test import SaveAndTestContext, SaveAndTestTool
 
@@ -55,12 +62,50 @@ def _git_diff_result(stdout: str, returncode: int = 0) -> subprocess.CompletedPr
     )
 
 
-def _diff_ruN_result(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+def _no_index_result(stdout: str, returncode: int = 1) -> subprocess.CompletedProcess:
+    """Build a ``CompletedProcess`` shaped like ``git diff --no-index``'s output.
+
+    ``git diff --no-index`` exits 1 when the trees differ (like plain diff),
+    so the default return code here is 1.
+    """
     return subprocess.CompletedProcess(
-        args=["diff", "-ruN"],
+        args=["git", "diff", "--no-index"],
         returncode=returncode,
         stdout=stdout,
         stderr="",
+    )
+
+
+def _no_index_modified(base_repo: Path, cwd: Path) -> str:
+    """``git diff --no-index`` output for a modified ``kernel.py`` (absolute headers)."""
+    base_abs = str(base_repo.resolve()).lstrip("/")
+    cwd_abs = str(cwd.resolve()).lstrip("/")
+    return (
+        f"diff --git a/{base_abs}/kernel.py b/{cwd_abs}/kernel.py\n"
+        "index 3367afd..3e75765 100644\n"
+        f"--- a/{base_abs}/kernel.py\n"
+        f"+++ b/{cwd_abs}/kernel.py\n"
+        "@@ -1 +1 @@\n-old\n+new\n"
+    )
+
+
+def _no_index_new_file(cwd: Path, rel: str, mode: str = "100644", body: str = "import os\n") -> str:
+    """``git diff --no-index`` output for a file present only in ``cwd``.
+
+    For a created file git uses the cwd-side path on BOTH ``a/`` and ``b/``
+    sides and emits ``--- /dev/null`` + ``new file mode``.
+    """
+    cwd_abs = str(cwd.resolve()).lstrip("/")
+    lines = body.splitlines()
+    hunk_body = "".join(f"+{ln}\n" for ln in lines)
+    return (
+        f"diff --git a/{cwd_abs}/{rel} b/{cwd_abs}/{rel}\n"
+        f"new file mode {mode}\n"
+        "index 0000000..21b405d\n"
+        "--- /dev/null\n"
+        f"+++ b/{cwd_abs}/{rel}\n"
+        f"@@ -0,0 +1,{len(lines)} @@\n"
+        f"{hunk_body}"
     )
 
 
@@ -88,23 +133,16 @@ def test_git_branch_returns_stdout_when_nonempty_and_zero_exit(tmp_path):
 
 
 def test_git_branch_falls_through_on_nonzero_exit(tmp_path):
-    """Submodule-missing case: git diff fails -> diff -ruN backup runs."""
+    """Submodule-missing case: git diff fails -> no-index backup runs."""
     base_repo = tmp_path / "base"
     base_repo.mkdir()
     (base_repo / "kernel.py").write_text("old\n")
     (tmp_path / "kernel.py").write_text("new\n")
     tool = _make_tool(tmp_path, base_repo=base_repo)
 
-    diff_ruN_patch = (
-        f"diff -ruN {base_repo}/kernel.py {tmp_path}/kernel.py\n"
-        f"--- {base_repo}/kernel.py\t2026-01-01 00:00:00 +0000\n"
-        f"+++ {tmp_path}/kernel.py\t2026-01-01 00:00:01 +0000\n"
-        "@@ -1 +1 @@\n-old\n+new\n"
-    )
-
     side_effects = [
         _git_diff_result("", returncode=128),  # git aborted on missing submodule .git
-        _diff_ruN_result(diff_ruN_patch, returncode=1),  # diff -ruN exits 1 when files differ
+        _no_index_result(_no_index_modified(base_repo, tmp_path)),
     ]
 
     with (
@@ -116,32 +154,28 @@ def test_git_branch_falls_through_on_nonzero_exit(tmp_path):
     ):
         out = tool._get_patch_content()
 
-    assert run.call_count == 2, "fall-through must invoke diff -ruN backup branch"
-    # The output should be the normalised git-style patch derived from diff -ruN.
+    assert run.call_count == 2, "fall-through must invoke the no-index backup branch"
+    # The output should be the normalised (relative) git-style patch.
     assert out.startswith("diff --git a/kernel.py b/kernel.py"), (
         f"expected normalised git-style header, got: {out[:120]!r}"
     )
     assert "+new" in out and "-old" in out
+    # Absolute prefixes must be gone.
+    assert str(base_repo.resolve()).lstrip("/") not in out
+    assert str(tmp_path.resolve()).lstrip("/") not in out
 
 
 def test_git_branch_falls_through_on_empty_stdout(tmp_path):
-    """git diff exits 0 but returns empty -> diff -ruN backup picks up the change."""
+    """git diff exits 0 but returns empty -> no-index backup picks up the change."""
     base_repo = tmp_path / "base"
     base_repo.mkdir()
     (base_repo / "kernel.py").write_text("old\n")
     (tmp_path / "kernel.py").write_text("new\n")
     tool = _make_tool(tmp_path, base_repo=base_repo)
 
-    diff_ruN_patch = (
-        f"diff -ruN {base_repo}/kernel.py {tmp_path}/kernel.py\n"
-        f"--- {base_repo}/kernel.py\t2026-01-01 00:00:00 +0000\n"
-        f"+++ {tmp_path}/kernel.py\t2026-01-01 00:00:01 +0000\n"
-        "@@ -1 +1 @@\n-old\n+new\n"
-    )
-
     side_effects = [
         _git_diff_result("", returncode=0),
-        _diff_ruN_result(diff_ruN_patch, returncode=1),
+        _no_index_result(_no_index_modified(base_repo, tmp_path)),
     ]
 
     with (
@@ -155,6 +189,66 @@ def test_git_branch_falls_through_on_empty_stdout(tmp_path):
 
     assert run.call_count == 2
     assert "+new" in out and "-old" in out
+
+
+def test_no_index_new_file_becomes_create_section(tmp_path):
+    """A file present only in cwd must normalise to a proper create section.
+
+    This pins the core bug fix: ``git diff --no-index`` emits
+    ``--- /dev/null`` + ``new file mode`` for created files, and the
+    normaliser only strips the absolute prefix, so the result is a valid
+    ``git apply`` create. The previous ``diff -ruN`` path mislabelled new
+    files as modifications of a non-existent base file and apply failed.
+    """
+    base_repo = tmp_path / "base"
+    base_repo.mkdir()
+    tool = _make_tool(tmp_path, base_repo=base_repo)
+
+    side_effects = [
+        _git_diff_result("", returncode=0),
+        _no_index_result(_no_index_new_file(tmp_path, "newfile.py")),
+    ]
+
+    with (
+        mock.patch.object(SaveAndTestTool, "_is_git_repo", return_value=True),
+        mock.patch(
+            "minisweagent.tools.save_and_test.subprocess.run",
+            side_effect=side_effects,
+        ),
+    ):
+        out = tool._get_patch_content()
+
+    assert "diff --git a/newfile.py b/newfile.py" in out
+    assert "new file mode 100644" in out
+    assert "--- /dev/null" in out
+    assert "+++ b/newfile.py" in out
+    # Must NOT look like a modification of a (non-existent) base file.
+    assert "--- a/newfile.py" not in out
+
+
+def test_no_index_new_executable_file_preserves_mode(tmp_path):
+    """The stat-derived executable bit (100755) must survive normalisation."""
+    base_repo = tmp_path / "base"
+    base_repo.mkdir()
+    tool = _make_tool(tmp_path, base_repo=base_repo)
+
+    side_effects = [
+        _git_diff_result("", returncode=0),
+        _no_index_result(_no_index_new_file(tmp_path, "run.sh", mode="100755", body="#!/bin/sh\necho hi\n")),
+    ]
+
+    with (
+        mock.patch.object(SaveAndTestTool, "_is_git_repo", return_value=True),
+        mock.patch(
+            "minisweagent.tools.save_and_test.subprocess.run",
+            side_effect=side_effects,
+        ),
+    ):
+        out = tool._get_patch_content()
+
+    assert "diff --git a/run.sh b/run.sh" in out
+    assert "new file mode 100755" in out, "executable bit must be preserved"
+    assert "--- /dev/null" in out
 
 
 def test_git_branch_empty_returns_empty_when_no_base_repo(tmp_path):
@@ -177,9 +271,7 @@ def test_git_branch_empty_returns_empty_when_no_base_repo(tmp_path):
 def test_git_branch_success_path_still_strips_jit_cache(tmp_path):
     """Composition guard: the fall-through fix and the JIT-cache strip must coexist.
 
-    PR #244 (this branch) and ``fix/final_report_optimized_codes`` both
-    rewrite the git-branch return statement. After merging both, the
-    successful git-branch return path must still apply
+    The successful git-branch return path must still apply
     ``_strip_jit_cache_from_patch`` — otherwise we silently regress the
     "no JIT pkls in final_report.optimized_codes" behaviour.
     """
@@ -188,9 +280,8 @@ def test_git_branch_success_path_still_strips_jit_cache(tmp_path):
     tool = _make_tool(tmp_path, base_repo=base_repo)
 
     real_section = "diff --git a/kernel.py b/kernel.py\n@@ -1 +1 @@\n-old\n+new\n"
-    # Use the public helper to construct a JIT-cache section the stripper
-    # is guaranteed to recognise, so this test does not encode a private
-    # path convention from generated_artifacts.py.
+    # Use a JIT-cache section the stripper is guaranteed to recognise, so this
+    # test does not encode a private path convention from generated_artifacts.py.
     jit_section = (
         "diff --git a/flydsl_cache/abc.pkl b/flydsl_cache/abc.pkl\n"
         "new file mode 100644\n"
@@ -213,15 +304,13 @@ def test_git_branch_success_path_still_strips_jit_cache(tmp_path):
     )
 
 
-def test_diff_ruN_excludes_jit_cache_basenames(tmp_path):
-    """``diff -ruN`` must pre-exclude every JIT-cache directory basename.
+def test_no_index_excludes_jit_cache_basenames(tmp_path):
+    """The no-index backup must pre-exclude every JIT-cache directory basename.
 
     Pins that ``_get_patch_content`` wires the shared
-    ``jit_cache_diff_basename_excludes()`` helper into the diff command,
-    so that JIT caches (e.g. ``flydsl_cache/``, ``.triton/``) are never
-    even scanned. The post-strip ``_strip_jit_cache_from_patch`` still
-    runs as defence-in-depth, but this guard pins the pre-filter so we
-    don't silently regress to a "post-strip only" world.
+    ``jit_cache_diff_basename_excludes()`` helper into the ``git diff
+    --no-index`` command as ``:(exclude)<basename>`` pathspecs, so JIT
+    caches (e.g. ``flydsl_cache/``, ``.triton/``) are never even scanned.
     """
     from minisweagent.run.utils.generated_artifacts import jit_cache_diff_basename_excludes
 
@@ -235,7 +324,7 @@ def test_diff_ruN_excludes_jit_cache_basenames(tmp_path):
         captured_args.append(cmd)
         if isinstance(cmd, str):
             return _git_diff_result("", returncode=0)
-        return _diff_ruN_result("", returncode=0)
+        return _no_index_result("", returncode=0)
 
     with (
         mock.patch.object(SaveAndTestTool, "_is_git_repo", return_value=True),
@@ -246,12 +335,76 @@ def test_diff_ruN_excludes_jit_cache_basenames(tmp_path):
     ):
         tool._get_patch_content()
 
-    diff_ruN_cmd = next(c for c in captured_args if isinstance(c, list) and c[0] == "diff")
+    no_index_cmd = next(c for c in captured_args if isinstance(c, list) and c[:3] == ["git", "diff", "--no-index"])
     expected = jit_cache_diff_basename_excludes()
     assert expected, "helper must return a non-empty list (test guards the contract)"
     for basename in expected:
-        assert f"--exclude={basename}" in diff_ruN_cmd, (
-            f"diff -ruN must include --exclude={basename}; got: {diff_ruN_cmd}"
+        assert f":(exclude){basename}" in no_index_cmd, (
+            f"no-index backup must include :(exclude){basename}; got: {no_index_cmd}"
         )
 
 
+def _git(args, cwd):
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def test_real_round_trip_new_file_applies_with_correct_mode(tmp_path):
+    """End-to-end proof: capture via the real fall-through, then ``git apply``.
+
+    Builds a base dir + a cwd dir on disk (cwd is NOT a git repo, forcing the
+    no-index fall-through), runs the real ``_get_patch_content``, then applies
+    the captured patch into a throwaway repo and asserts the new files are
+    created — the executable one with its bit preserved (0o755), the regular
+    one without (0o644). This is the regression the previous ``diff -ruN``
+    path failed on (``newfile.py: No such file or directory``).
+    """
+    if not os.access("/usr/bin/git", os.X_OK) and subprocess.run(["git", "--version"], capture_output=True).returncode:
+        pytest.skip("git not available")
+
+    base_repo = tmp_path / "base"
+    cwd = tmp_path / "cwd"
+    base_repo.mkdir()
+    cwd.mkdir()
+    (base_repo / "kernel.py").write_text("old\n")
+    (cwd / "kernel.py").write_text("new\n")
+    (cwd / "newfile.py").write_text("import os\n")
+    # An executable the agent might legitimately create. NB: do not use
+    # ``run.sh`` etc. here — those are GEAK-generated harness names that
+    # ``_strip_jit_cache_from_patch``'s sibling stripper deliberately removes.
+    script = cwd / "bench.sh"
+    script.write_text("#!/bin/sh\necho hi\n")
+    script.chmod(0o755)
+
+    tool = _make_tool(cwd, base_repo=base_repo)
+    # cwd is not a git repo, so the primary branch is skipped and the
+    # no-index fall-through produces the patch.
+    patch = tool._get_patch_content()
+
+    assert "new file mode 100755" in patch, f"executable create section missing: {patch!r}"
+    assert "new file mode 100644" in patch
+    assert "--- a/newfile.py" not in patch, "new file must use /dev/null, not a modification header"
+
+    # Apply into a fresh repo seeded with the baseline kernel.py.
+    target = tmp_path / "target"
+    target.mkdir()
+    _git(["init", "-q"], target)
+    _git(["config", "user.email", "t@t"], target)
+    _git(["config", "user.name", "t"], target)
+    (target / "kernel.py").write_text("old\n")
+    _git(["add", "."], target)
+    _git(["commit", "-qm", "base"], target)
+
+    apply_res = subprocess.run(
+        ["git", "apply", "--whitespace=nowarn", "-"],
+        cwd=str(target),
+        input=patch,
+        capture_output=True,
+        text=True,
+    )
+    assert apply_res.returncode == 0, f"git apply failed: {apply_res.stderr}"
+
+    assert (target / "newfile.py").read_text() == "import os\n"
+    assert (target / "kernel.py").read_text() == "new\n"
+    assert (target / "bench.sh").exists()
+    assert os.stat(target / "bench.sh").st_mode & 0o111, "executable bit must survive apply"
+    assert not (os.stat(target / "newfile.py").st_mode & 0o111), "regular file must not be executable"


### PR DESCRIPTION
The diff -ruN fallback in _get_patch_content mislabelled agent-created files (present in cwd, absent in base_repo) as modifications of a non-existent base file: GNU diff emits `--- /abs/base/newfile` with a 1970 epoch timestamp instead of `/dev/null`, so the normalizer produced `--- a/newfile` and `git apply` later failed with "No such file or directory" — silently dropping new files from the captured patch.

Replace diff -ruN with `git diff --no-index`, which is git-native: it emits `--- /dev/null` + `new file mode` for created files and derives the executable bit from stat (100755 vs 100644) for free, so a later git apply recreates new files with the correct mode and no privilege escalation. Excludes move from --exclude flags to :(exclude) pathspecs. The fragile header-rewriting normalizer is replaced with a simple prefix-stripper (_normalize_noindex_to_relative). The git-repo-first / fallback two-tier structure is preserved.

Tests cover new-file, executable-new-file, modified-file, and a real no-mocks round-trip (capture -> git apply -> assert mode).

