### PR TITLE
fix(patch-capture): keep JIT/compiled cache artifacts out of the round patch (fixes 1.0x self-score)

### DIFF
--- a/ADAPTIVE_MIXED_MODE.md
+++ b/ADAPTIVE_MIXED_MODE.md
@@ -1,0 +1,509 @@
+# GEAK Adaptive Mixed Mode — Full Documentation
+
+**Branch:** `mixed-optimizer` (pushed to `origin/mixed-optimizer`)
+**Base:** `gwiab-scheduler` at commit `f2f0e1b`
+**Commit:** `1433875` — "Adaptive K allocation for mixed mode dispatch"
+**Repo:** `git@github.com:AMD-AGI/GEAK.git`
+**Local clone:** `/data/sapmajum/GEAK_scheduler`
+
+---
+
+## 1. Problem Statement
+
+GEAK has three pipeline modes for multi-GPU kernel optimization:
+
+| Mode | K (planned slots) | N-K (fixed slots) | Behavior |
+|------|-------------------|-------------------|----------|
+| **fixed** | 0 | N | All workers get identical canonical prompt — pure brute-force exploration |
+| **planned** | N | 0 | All workers get distinct LLM-generated strategies — pure diversity |
+| **mixed** | K | N-K | Some planned, some fixed — hybrid |
+
+The old mixed mode used a **static** split: `K = N // 2` (half each). This is suboptimal:
+- If planned strategies consistently outperform fixed, we waste half the GPU slots
+- If fixed outperforms planned (e.g., on simple kernels), we waste the other half
+- No learning across rounds — round 5 makes the same allocation as round 1
+
+---
+
+## 2. Solution: Adaptive K Allocation
+
+**Core idea:** After each round, measure which source (planned vs fixed) produced better speedups. Allocate proportionally in the next round.
+
+### Algorithm
+
+```
+Round 1: K = N // 2 (equal split, no history)
+
+Round R > 1:
+  planned_avg = mean(speedup of all kind="planned" tasks across rounds 1..R-1)
+  fixed_avg   = mean(speedup of all kind="fixed" tasks across rounds 1..R-1)
+
+  K = round(N * planned_avg / (planned_avg + fixed_avg))
+  K = clamp(K, 1, N-1)  ← exploration floor
+```
+
+### Properties
+
+- **Proportional:** Better source gets more slots, proportional to its advantage
+- **Cumulative:** Uses ALL historical data, not just last round (more stable)
+- **Exploration floor:** Both sources always get at least 1 slot (never starves either)
+- **Backward compatible:** fixed mode (K=0) and planned mode (K=N) unchanged
+- **Graceful degradation:** If no per-task data exists (old eval format), falls back to N//2
+
+### Example
+
+With N=4 GPUs:
+```
+Round 1: K=2 (2 planned, 2 fixed)
+  → planned tasks: 2.0x, 1.5x (avg=1.75)
+  → fixed tasks:   1.1x, 1.0x (avg=1.05)
+
+Round 2: K = round(4 * 1.75 / 2.80) = round(2.5) = 2
+  → Still 2/2, but if planned pulls further ahead...
+
+Round 3: (planned_avg=2.5, fixed_avg=1.05)
+  K = round(4 * 2.5 / 3.55) = round(2.82) = 3
+  → 3 planned, 1 fixed — shifted toward planned
+
+Round 4: (planned_avg=2.75, fixed_avg=1.0)
+  K = round(4 * 2.75 / 3.75) = round(2.93) = 3
+  → Stays 3/1, clamped by exploration floor (min 1 fixed)
+```
+
+---
+
+## 3. Architecture
+
+### Pipeline Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        UNIFIED ROUND LOOP                          │
+│                     (unified.py:_run_unified_loop)                  │
+│                                                                     │
+│  for round_num in 1..max_rounds:                                    │
+│                                                                     │
+│    ┌──────────┐     ┌────────────┐     ┌─────────┐     ┌────────┐  │
+│    │   PLAN   │────▶│   SELECT   │────▶│  WRITE  │────▶│EXECUTE │  │
+│    │TaskPlanner│    │ Dispatcher │    │task files│    │ staged │  │
+│    │.build_pool│    │  .select() │    │  (.md)  │    │dispatch│  │
+│    └──────────┘     └────────────┘     └─────────┘     └────────┘  │
+│         │                │                                    │     │
+│    M candidates     K planned +              per-task best_results  │
+│    (pool)           (N-K) fixed              + patches on disk      │
+│                     (DispatchPlan)                             │     │
+│                          ▲                                    ▼     │
+│                          │              ┌──────────┐               │
+│                          │              │ EVALUATE │               │
+│                    round_evals ◀────────│ evaluate │               │
+│                    (per_task with        │ round_best│               │
+│                     kind + speedup)     └──────────┘               │
+│                                              │                      │
+│                                      round_N_evaluation.json        │
+│                                      (includes per_task array)      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+
+| Component | File | Role |
+|-----------|------|------|
+| TaskPlanner | `run/planner/task_planner.py` | LLM generates M candidate strategies; always injects canonical fixed entry |
+| CandidatePool | `run/planner/candidate_pool.py` | Pool of M candidates with `.planned`, `.fixed` filtering |
+| **Dispatcher** | `run/dispatcher/selector.py` | **THE adaptive seam** — picks K planned + (N-K) fixed |
+| Writer | `run/dispatcher/writer.py` | Writes DispatchPlan as `.md` task files (YAML frontmatter + markdown body) |
+| Staged dispatch | `run/dispatch.py` | Priority-staged execution with early exit on improvement |
+| Evaluation | `run/postprocess/evaluation.py` | FULL_BENCHMARK verification, per-task outcome tagging |
+| Unified loop | `run/unified.py` | Orchestrates PLAN→SELECT→WRITE→EXECUTE→EVALUATE per round |
+
+### Data Flow for `kind`
+
+```
+CandidateTask.kind ──▶ DispatchPlanItem.kind ──▶ task file YAML (kind: planned/fixed)
+                                                        │
+                                                        ▼
+                                              task_file_to_agent_task()
+                                                  cfg["kind"] = meta["kind"]  ← NEW
+                                                        │
+                                                        ▼
+                                              results/{label}/best_results.json
+                                                        │
+                                              evaluate_round_best() scans results
+                                              _resolve_task_kind() reads YAML ← NEW
+                                                        │
+                                                        ▼
+                                              round_N_evaluation.json
+                                                { ..., "per_task": [
+                                                    {"label": "...", "kind": "planned", "speedup": 1.5},
+                                                    {"label": "...", "kind": "fixed", "speedup": 1.1}
+                                                ]}
+                                                        │
+                                                        ▼
+                                              Dispatcher._k_for_mode(round_evals=...)
+                                              → adaptive K for next round
+```
+
+---
+
+## 4. Code Changes (4 files)
+
+### 4.1 `src/minisweagent/run/dispatcher/selector.py`
+
+**Full file after changes (172 lines):**
+
+The `Dispatcher.select()` now accepts `round_evals` and passes it to `_k_for_mode()`.
+
+`_k_for_mode()` was replaced from a one-liner:
+```python
+# OLD:
+return {"fixed": 0, "planned": n, "mixed": n // 2}.get(mode, n // 2)
+```
+to the adaptive algorithm that:
+1. Returns 0 for fixed, N for planned (unchanged)
+2. For mixed: scans `per_task` entries across all `round_evals`, computes per-source average speedup, allocates K proportionally, clamps to [1, N-1]
+
+### 4.2 `src/minisweagent/run/postprocess/evaluation.py`
+
+Three additions:
+1. **`_resolve_task_kind(task_files_dir, label)`** — looks up `kind` from the `.md` task file matching a given label
+2. In `evaluate_round_best()`: each candidate now includes `"kind"` resolved from the task file; `round_eval["per_task"]` is populated before any return path
+3. In `write_eval_results()`: imports `PerTaskOutcome`, converts `round_eval["per_task"]` into typed objects on the returned `RoundEvaluation`
+
+### 4.3 `src/minisweagent/run/dispatch.py`
+
+One-line change at line 317:
+```python
+# OLD:
+for _passthrough_key in ("baseline_metrics", "benchmark_baseline"):
+# NEW:
+for _passthrough_key in ("baseline_metrics", "benchmark_baseline", "kind"):
+```
+
+### 4.4 `src/minisweagent/run/unified.py`
+
+One-line change at line 581:
+```python
+# OLD:
+plan = dispatcher.select(pool, mode, n_workers)
+# NEW:
+plan = dispatcher.select(pool, mode, n_workers, round_evals=round_evals)
+```
+
+---
+
+## 5. Setup on a New Node
+
+### 5.1 Clone the branch
+
+```bash
+cd /data/$USER
+git clone -b mixed-optimizer git@github.com:AMD-AGI/GEAK.git GEAK_mixed
+cd GEAK_mixed
+```
+
+### 5.2 Container requirements
+
+GEAK runs inside Docker containers with ROCm and GPU access. You need two containers:
+
+**Triton container** (for Triton kernels):
+```bash
+# Example: create or reuse a container with ROCm + Triton support
+# The parity test used: geak_gwiab_triton (image: geak-agent:latest)
+docker run -d --name geak_mixed_triton \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --group-add render \
+  -v /data:/data \
+  -e HSA_XNACK=1 \
+  geak-agent:latest sleep infinity
+```
+
+**HIP container** (for HIP/CUDA kernels):
+```bash
+# The parity test used: geak_gwiab_hip (image: rocm/pytorch:rocm7.1.1)
+docker run -d --name geak_mixed_hip \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --group-add render \
+  -v /data:/data \
+  rocm/pytorch:rocm7.1.1 sleep infinity
+```
+
+### 5.3 Copy GEAK into containers
+
+```bash
+GEAK_SRC="/data/$USER/GEAK_mixed"
+
+# Triton container
+docker exec geak_mixed_triton bash -c "rm -rf /workspace/src && mkdir -p /workspace"
+docker cp "$GEAK_SRC/src" geak_mixed_triton:/workspace/src
+docker exec geak_mixed_triton pip install -e /workspace 2>/dev/null || true
+
+# HIP container
+docker exec geak_mixed_hip bash -c "rm -rf /workspace/src && mkdir -p /workspace"
+docker cp "$GEAK_SRC/src" geak_mixed_hip:/workspace/src
+docker exec geak_mixed_hip pip install -e /workspace 2>/dev/null || true
+```
+
+### 5.4 API key
+
+```bash
+export AMD_LLM_API_KEY="7d3c15d3142b4d1492859da87f16d9fc"
+```
+
+The model is `claude-opus-4.6` via AMD's LLM gateway.
+
+### 5.5 Kernel test data (AKA)
+
+The parity test kernels are in the AKA (Automated Kernel Archive):
+```
+/data/sapmajum/parity_test/runs_20260514/AKA_triton/tasks/triton2triton/geak_eval/
+/data/sapmajum/parity_test/runs_20260514/AKA_hip/tasks/hip2hip/others/
+```
+
+If running on a different node, you'll need to either:
+- Copy these directories to the new node
+- Or clone AKA fresh from the repository
+
+---
+
+## 6. Test Plan: Mixed Mode vs Planned vs Fixed
+
+### 6.1 Goal
+
+Run the same 30 kernels (18 Triton + 12 HIP) in **mixed mode** and compare with the existing **planned** (Triton) and **fixed** (HIP) baselines from the May 14 parity test.
+
+### 6.2 Previous baseline results
+
+#### Triton kernels (planned mode, May 14)
+
+| Kernel | Level | Final Speedup | Rounds |
+|--------|-------|---------------|--------|
+| fused_append_shared_experts | L1 | 2.99x | 5 |
+| llama_ff_triton | L1 | 5.03x | 5 |
+| mla_decode | L1 | 1.18x | 2 |
+| moe_routing_sigmoid_top1 | L1 | 1.26x | 5 |
+| refk_fp8_blockwise_mm | L1 | 1.00x | 4 |
+| refk_identity | L1 | 1.02x | 4 |
+| fast_rms_layernorm | L2 | 10.37x | 5 |
+| ff_backward | L2 | 1.00x | 2 |
+| lean_atten_paged | L2 | 1.00x | 5 |
+| topk | L2 | 1.21x | 5 |
+| fused_moe_mxfp4 | L3 | 1.06x | 2 |
+| fused_mxfp4_quant_moe_sort | L3 | 1.84x | 2 |
+| fused_qk_rope_cache_mla | L3 | 8.25x | 5 |
+| fused_qkv_rope | L3 | 3.93x | 4 |
+| fused_rms_fp8 | L3 | 2.31x | 3 |
+| gemm | L3 | 3.13x | 5 |
+| gemm_a16w16_atomic | L3 | — | 0 (preflight fail) |
+| gemm_a16wfp4 | L3 | 1.01x | 5 |
+
+#### HIP kernels (fixed mode, May 14)
+
+| Kernel | Final Speedup |
+|--------|---------------|
+| roiaware_pool3d | 27.01x |
+| roipoint_pool3d | 14.76x |
+| assign_score_withk | 2.81x |
+| knn | 2.54x |
+| three_nn | 1.98x |
+| three_interpolate | 1.80x |
+| gather_points | 1.46x |
+| silu | 1.27x (incomplete) |
+| furthest_point_sample | 1.13x |
+| ball_query | 1.18x |
+| matrix_multiplication | 1.09x |
+| points_in_boxes | 1.03x |
+
+### 6.3 Run commands
+
+**Mixed mode** is the hardcoded default in `mini.py` (`pipeline_mode = "mixed"`). The key env var is `GEAK_PIPELINE_MODE` which overrides it from the launch script.
+
+#### Single kernel test (quick validation):
+
+```bash
+# Pick a well-known kernel for quick validation
+KERNEL_DIR="/path/to/AKA_triton/tasks/triton2triton/geak_eval/L1/llama_ff_triton"
+OUT_DIR="/data/$USER/mixed_test/triton_llama_ff_triton"
+
+docker exec \
+  -e "GEAK_MODEL=claude-opus-4.6" \
+  -e "AMD_LLM_API_KEY=$AMD_LLM_API_KEY" \
+  -e "GEAK_PIPELINE_MODE=mixed" \
+  geak_mixed_triton bash -c \
+  "cd /workspace && geak -t 'Optimize the Triton kernel at ${KERNEL_DIR}/kernel.py. Use the test harness at ${KERNEL_DIR}/test_kernel_harness.py.' \
+   --num-parallel 4 --gpu-ids 0,1,2,3 --mode full -y --exit-immediately" \
+  > "$OUT_DIR/run.log" 2>&1
+```
+
+#### Full batch script template:
+
+```bash
+#!/usr/bin/env bash
+# Mixed mode parity test: 18 Triton + 12 HIP
+set -euo pipefail
+
+AMD_LLM_API_KEY="${AMD_LLM_API_KEY:-7d3c15d3142b4d1492859da87f16d9fc}"
+BATCH_DIR="/data/$USER/mixed_test"
+MODEL="claude-opus-4.6"
+
+TRITON_CONTAINER="geak_mixed_triton"
+HIP_CONTAINER="geak_mixed_hip"
+
+# Point these to your AKA directories
+AKA_TRITON="/path/to/AKA_triton/tasks/triton2triton/geak_eval"
+AKA_HIP="/path/to/AKA_hip/tasks/hip2hip/others"
+
+RESULTS_CSV="$BATCH_DIR/results.csv"
+mkdir -p "$BATCH_DIR"
+echo "name,language,level,mode,verified_speedups,final_speedup,status,elapsed_s" > "$RESULTS_CSV"
+
+TRITON_KERNELS=(
+  "fused_append_shared_experts|L1|fused_append_shared_experts"
+  "llama_ff_triton|L1|llama_ff_triton"
+  "mla_decode|L1|mla_decode"
+  "moe_routing_sigmoid_top1|L1|moe_routing_sigmoid_top1"
+  "refk_fp8_blockwise_mm|L1|refk_fp8_blockwise_mm"
+  "refk_identity|L1|refk_identity"
+  "fast_rms_layernorm|L2|fast_rms_layernorm"
+  "ff_backward|L2|ff_backward"
+  "lean_atten_paged|L2|lean_atten_paged"
+  "topk|L2|topk"
+  "fused_moe_mxfp4|L3|fused_moe_mxfp4"
+  "fused_mxfp4_quant_moe_sort|L3|fused_mxfp4_quant_moe_sort"
+  "fused_qk_rope_cache_mla|L3|fused_qk_rope_cache_mla"
+  "fused_qkv_rope|L3|fused_qkv_rope"
+  "fused_rms_fp8|L3|fused_rms_fp8"
+  "gemm|L3|gemm"
+  "gemm_a16w16_atomic|L3|gemm_a16w16_atomic"
+  "gemm_a16wfp4|L3|gemm_a16wfp4"
+)
+
+HIP_KERNELS=(
+  "assign_score_withk" "ball_query" "furthest_point_sample"
+  "gather_points" "knn" "matrix_multiplication"
+  "points_in_boxes" "roiaware_pool3d" "roipoint_pool3d"
+  "silu" "three_interpolate" "three_nn"
+)
+
+run_triton_one() {
+  local NAME=$1 LEVEL=$2 DIRNAME=$3
+  local KERNEL_DIR="${AKA_TRITON}/${LEVEL}/${DIRNAME}"
+  local OUT_DIR="$BATCH_DIR/triton_${NAME}"
+  [[ -f "$OUT_DIR/out/final_report.json" ]] && return 0
+  rm -rf "$OUT_DIR" 2>/dev/null; mkdir -p "$OUT_DIR"
+
+  local T0=$(date +%s)
+  docker exec \
+    -e "GEAK_MODEL=$MODEL" \
+    -e "AMD_LLM_API_KEY=$AMD_LLM_API_KEY" \
+    -e "GEAK_PIPELINE_MODE=mixed" \
+    "$TRITON_CONTAINER" bash -c \
+    "cd /workspace && geak -t 'Optimize the Triton kernel at ${KERNEL_DIR}/kernel.py. Use the test harness at ${KERNEL_DIR}/test_kernel_harness.py.' \
+     --num-parallel 4 --gpu-ids 0,1,2,3 --mode full -y --exit-immediately" \
+    > "$OUT_DIR/run.log" 2>&1 || true
+
+  local ELAPSED=$(($(date +%s) - T0))
+  # Extract results (same helper as parity test)
+  local FINAL="" VS="" STATUS="done"
+  [[ -f "$OUT_DIR/out/final_report.json" ]] && \
+    FINAL=$(python3 -c "import json; d=json.load(open('$OUT_DIR/out/final_report.json')); print(d.get('total_speedup') or d.get('best_speedup') or '')" 2>/dev/null) || STATUS="no_final_report"
+  VS=$(grep -oE "Verified speedup: [0-9.]+x" "$OUT_DIR/run.log" 2>/dev/null | tr '\n' ' ') || true
+
+  echo "${NAME},triton,${LEVEL},mixed,\"${VS}\",${FINAL},${STATUS},${ELAPSED}" >> "$RESULTS_CSV"
+}
+
+run_hip_one() {
+  local NAME=$1
+  local REPO_DIR="${AKA_HIP}/${NAME}"
+  local OUT_DIR="$BATCH_DIR/hip_${NAME}"
+  [[ -f "$OUT_DIR/out/final_report.json" ]] && return 0
+  rm -rf "$OUT_DIR" 2>/dev/null; mkdir -p "$OUT_DIR"
+
+  local KERNEL_PATH=$(find "$REPO_DIR" \( -name '*.hip' \) ! -name '*_ref.hip' ! -path '*/build/*' -print 2>/dev/null | head -1)
+  local T0=$(date +%s)
+  docker exec \
+    -e "GEAK_MODEL=$MODEL" \
+    -e "AMD_LLM_API_KEY=$AMD_LLM_API_KEY" \
+    -e "GEAK_PIPELINE_MODE=mixed" \
+    "$HIP_CONTAINER" bash -c \
+    "cd /workspace && geak -t 'Optimize the HIP kernel at ${KERNEL_PATH}.' \
+     --num-parallel 4 --gpu-ids 4,5,6,7 --mode full -y --exit-immediately" \
+    > "$OUT_DIR/run.log" 2>&1 || true
+
+  local ELAPSED=$(($(date +%s) - T0))
+  local FINAL="" VS="" STATUS="done"
+  [[ -f "$OUT_DIR/out/final_report.json" ]] && \
+    FINAL=$(python3 -c "import json; d=json.load(open('$OUT_DIR/out/final_report.json')); print(d.get('total_speedup') or d.get('best_speedup') or '')" 2>/dev/null) || STATUS="no_final_report"
+  VS=$(grep -oE "Verified speedup: [0-9.]+x" "$OUT_DIR/run.log" 2>/dev/null | tr '\n' ' ') || true
+
+  echo "${NAME},hip,,mixed,\"${VS}\",${FINAL},${STATUS},${ELAPSED}" >> "$RESULTS_CSV"
+}
+
+# Run Triton sequentially on GPUs 0-3
+for entry in "${TRITON_KERNELS[@]}"; do
+  IFS='|' read -r NAME LEVEL DIRNAME <<< "$entry"
+  run_triton_one "$NAME" "$LEVEL" "$DIRNAME"
+done &
+
+# Run HIP sequentially on GPUs 4-7 (in parallel with Triton)
+for NAME in "${HIP_KERNELS[@]}"; do
+  run_hip_one "$NAME"
+done &
+
+wait
+echo "All runs complete. Results: $RESULTS_CSV"
+```
+
+### 6.4 What to look for in logs
+
+The adaptive K is logged by the Dispatcher. Grep for:
+```bash
+grep "Dispatcher: mode=mixed" run.log
+```
+
+Expected output progression:
+```
+Dispatcher: mode=mixed N=4 K=2 → 2 planned + 2 fill    # Round 1: equal split
+Dispatcher: mode=mixed N=4 K=3 → 3 planned + 1 fill    # Round 2+: shifted toward planned
+```
+
+Also check per-task outcomes in evaluation JSONs:
+```bash
+cat out/round_1_evaluation.json | python3 -m json.tool | grep -A3 "per_task"
+```
+
+### 6.5 Comparison methodology
+
+After runs complete, compare the `results.csv` against the May 14 baselines above. Key metrics:
+- **Win rate:** How many kernels does mixed beat planned (for Triton) or fixed (for HIP)?
+- **Geometric mean speedup:** Overall performance across the kernel set
+- **Worst-case regression:** Any kernel where mixed is significantly worse?
+
+---
+
+## 7. Important Notes
+
+1. **`GEAK_PIPELINE_MODE=mixed`** must be set in the container env. Without it, `mini.py` defaults to `pipeline_mode = "mixed"` (hardcoded at line 972), so it should work by default — but set it explicitly for clarity.
+
+2. **The adaptive behavior only matters for N >= 3.** With N=2 (2 GPUs), it falls back to K=1 (one of each), same as the old static split. Use N=4 to see the adaptation in action.
+
+3. **Round 1 is always equal split.** The adaptation only kicks in from round 2 onward, after per-task outcomes are available.
+
+4. **Existing test suite:** 132/132 dispatcher/evaluation/pipeline tests pass. Only failure is a pre-existing litellm import error (unrelated).
+
+5. **No config knobs.** The exploration floor (min 1 slot each) is hardcoded. To change it, modify `_k_for_mode` in `selector.py`.
+
+---
+
+## 8. File Reference
+
+| File | Path | Lines changed |
+|------|------|---------------|
+| Dispatcher | `src/minisweagent/run/dispatcher/selector.py` | 91-133 (adaptive _k_for_mode) |
+| Evaluation | `src/minisweagent/run/postprocess/evaluation.py` | 85-95 (_resolve_task_kind), 908+ (per_task population) |
+| Dispatch | `src/minisweagent/run/dispatch.py` | 317 (kind passthrough) |
+| Unified loop | `src/minisweagent/run/unified.py` | 581 (round_evals threading) |
+| Pipeline types | `src/minisweagent/run/pipeline_types.py` | 111-134 (PerTaskOutcome — already existed, now populated) |
+| Candidate pool | `src/minisweagent/run/planner/candidate_pool.py` | Unchanged (kind field already existed) |
+| Task planner | `src/minisweagent/run/planner/task_planner.py` | Unchanged (canonical fixed injection already existed) |
+| Writer | `src/minisweagent/run/dispatcher/writer.py` | Unchanged (kind already written to YAML) |
+| Task file I/O | `src/minisweagent/run/task_file.py` | Unchanged |

--- a/scripts/preprocess_v3_test_runner.py
+++ b/scripts/preprocess_v3_test_runner.py
@@ -189,12 +189,8 @@ def child_run_scenario(scenario_payload: dict[str, Any]) -> int:
     elapsed_s = round(time.monotonic() - t0, 3)
 
     result_dump = _serialise_result(result, error_payload, elapsed_s, kernel_path, detected_language)
-    (output_dir / "preprocess_result.json").write_text(
-        json.dumps(result_dump, indent=2, default=str), encoding="utf-8"
-    )
-    (output_dir / "agent_messages.json").write_text(
-        json.dumps(agent.messages, indent=2, default=str), encoding="utf-8"
-    )
+    (output_dir / "preprocess_result.json").write_text(json.dumps(result_dump, indent=2, default=str), encoding="utf-8")
+    (output_dir / "agent_messages.json").write_text(json.dumps(agent.messages, indent=2, default=str), encoding="utf-8")
     sys.stdout.write(f"CHILD_DONE elapsed_s={elapsed_s}\n")
     return 0
 
@@ -248,7 +244,9 @@ def _load_model_config() -> dict[str, Any]:
             merged[key] = value
     model_cfg = dict(merged.get("model") or {})
     model_cfg.setdefault("model_class", "amd_llm")
-    model_cfg.setdefault("model_name", "claude-opus-4.6")
+    from minisweagent.models import get_model_name
+
+    model_cfg.setdefault("model_name", get_model_name())
     return model_cfg
 
 
@@ -399,7 +397,8 @@ def _coerce_node(node: ast.AST) -> Any:
         return [_coerce_node(e) for e in node.elts]
     if isinstance(node, ast.Dict):
         return {
-            _coerce_node(k) if k is not None else None: _coerce_node(v) for k, v in zip(node.keys, node.values, strict=False)
+            _coerce_node(k) if k is not None else None: _coerce_node(v)
+            for k, v in zip(node.keys, node.values, strict=False)
         }
     if isinstance(node, ast.Call):
         return tuple(_coerce_node(a) for a in node.args)
@@ -538,41 +537,46 @@ def assert_path_a(scenario_cfg: dict[str, Any], artifacts: dict[str, Any], run_m
     checks: list[dict[str, Any]] = []
 
     path_taken = result.get("path_taken")
-    checks.append({
-        "name": "path_taken == A",
-        "ok": path_taken == "A",
-        "detail": f"observed path_taken={path_taken!r}",
-    })
+    checks.append(
+        {
+            "name": "path_taken == A",
+            "ok": path_taken == "A",
+            "detail": f"observed path_taken={path_taken!r}",
+        }
+    )
 
     commandment_path = result.get("commandment_path")
     text = artifacts.get("commandment_text") or ""
-    checks.append({
-        "name": "COMMANDMENT.md rendered to disk",
-        "ok": bool(commandment_path) and bool(text),
-        "detail": f"commandment_path={commandment_path!r}, text_len={len(text)}",
-    })
+    checks.append(
+        {
+            "name": "COMMANDMENT.md rendered to disk",
+            "ok": bool(commandment_path) and bool(text),
+            "detail": f"commandment_path={commandment_path!r}, text_len={len(text)}",
+        }
+    )
 
     harness_path = result.get("harness_path")
     kernel_path = result.get("kernel_path")
-    harness_ok = (
-        harness_path in (None, "")
-        or (kernel_path is not None and harness_path == kernel_path)
+    harness_ok = harness_path in (None, "") or (kernel_path is not None and harness_path == kernel_path)
+    checks.append(
+        {
+            "name": "harness_path None or == kernel_path",
+            "ok": harness_ok,
+            "detail": f"harness_path={harness_path!r}, kernel_path={kernel_path!r}",
+            "warn_only": True,
+        }
     )
-    checks.append({
-        "name": "harness_path None or == kernel_path",
-        "ok": harness_ok,
-        "detail": f"harness_path={harness_path!r}, kernel_path={kernel_path!r}",
-        "warn_only": True,
-    })
 
     expected_substring = scenario_cfg.get("expect_command_substring", "")
     if expected_substring:
         ok = expected_substring in text
-        checks.append({
-            "name": "COMMANDMENT contains user command substring",
-            "ok": ok,
-            "detail": f"substring={expected_substring!r} present={ok}",
-        })
+        checks.append(
+            {
+                "name": "COMMANDMENT contains user command substring",
+                "ok": ok,
+                "detail": f"substring={expected_substring!r} present={ok}",
+            }
+        )
     return _bundle_checks(checks, run_meta)
 
 
@@ -584,11 +588,13 @@ def assert_path_a_partial(
     checks: list[dict[str, Any]] = []
 
     path_taken = result.get("path_taken")
-    checks.append({
-        "name": "path_taken == A",
-        "ok": path_taken == "A",
-        "detail": f"observed path_taken={path_taken!r}",
-    })
+    checks.append(
+        {
+            "name": "path_taken == A",
+            "ok": path_taken == "A",
+            "detail": f"observed path_taken={path_taken!r}",
+        }
+    )
 
     text = artifacts.get("commandment_text") or ""
     expected_modes = scenario_cfg.get("expect_partial_modes", ["correctness", "full_benchmark", "profile"])
@@ -600,13 +606,13 @@ def assert_path_a_partial(
         )
         if not marker_present:
             missing_markers.append(mode)
-    checks.append({
-        "name": "PATH_A_PARTIAL_COVERAGE markers present for uncovered modes",
-        "ok": not missing_markers,
-        "detail": (
-            f"expected modes with marker: {expected_modes}; missing markers: {missing_markers}"
-        ),
-    })
+    checks.append(
+        {
+            "name": "PATH_A_PARTIAL_COVERAGE markers present for uncovered modes",
+            "ok": not missing_markers,
+            "detail": (f"expected modes with marker: {expected_modes}; missing markers: {missing_markers}"),
+        }
+    )
     return _bundle_checks(checks, run_meta)
 
 
@@ -621,11 +627,13 @@ def assert_path_b_coverage(
     checks: list[dict[str, Any]] = []
 
     path_taken = result.get("path_taken")
-    checks.append({
-        "name": "path_taken == B",
-        "ok": path_taken == "B",
-        "detail": f"observed path_taken={path_taken!r}",
-    })
+    checks.append(
+        {
+            "name": "path_taken == B",
+            "ok": path_taken == "B",
+            "detail": f"observed path_taken={path_taken!r}",
+        }
+    )
 
     harness_files = artifacts.get("harness_files") or []
     if not harness_files:
@@ -650,12 +658,14 @@ def assert_path_b_coverage(
     else:
         ok = True
         status = "harness signatures == oracle signatures"
-    checks.append({
-        "name": "harness signatures cover oracle",
-        "ok": ok,
-        "detail": f"{status}; oracle={sorted(oracle_sigs)}, parsed={sorted(parsed_sigs)}, missing={missing}, extras={extras}",
-        "warn_only": ok and bool(extras),
-    })
+    checks.append(
+        {
+            "name": "harness signatures cover oracle",
+            "ok": ok,
+            "detail": f"{status}; oracle={sorted(oracle_sigs)}, parsed={sorted(parsed_sigs)}, missing={missing}, extras={extras}",
+            "warn_only": ok and bool(extras),
+        }
+    )
     return _bundle_checks(checks, run_meta)
 
 
@@ -668,11 +678,13 @@ def assert_task_override(
 
     expected_shape = tuple(scenario_cfg["expect_shape"])
     path_taken = result.get("path_taken")
-    checks.append({
-        "name": "path_taken == B",
-        "ok": path_taken == "B",
-        "detail": f"observed path_taken={path_taken!r}",
-    })
+    checks.append(
+        {
+            "name": "path_taken == B",
+            "ok": path_taken == "B",
+            "detail": f"observed path_taken={path_taken!r}",
+        }
+    )
 
     harness_files = artifacts.get("harness_files") or []
     if not harness_files:
@@ -687,17 +699,21 @@ def assert_task_override(
     contains_expected = expected_sig in parsed_sigs
     extras = sorted(parsed_sigs - {expected_sig}, key=lambda t: (len(t), t))
 
-    checks.append({
-        "name": "harness contains user-specified shape",
-        "ok": contains_expected,
-        "detail": f"expected_sig={expected_sig}, parsed={sorted(parsed_sigs)}",
-    })
-    checks.append({
-        "name": "no shapes leaked from source discovery",
-        "ok": not extras,
-        "detail": f"extra signatures present: {extras}",
-        "warn_only": True,
-    })
+    checks.append(
+        {
+            "name": "harness contains user-specified shape",
+            "ok": contains_expected,
+            "detail": f"expected_sig={expected_sig}, parsed={sorted(parsed_sigs)}",
+        }
+    )
+    checks.append(
+        {
+            "name": "no shapes leaked from source discovery",
+            "ok": not extras,
+            "detail": f"extra signatures present: {extras}",
+            "warn_only": True,
+        }
+    )
     return _bundle_checks(checks, run_meta)
 
 
@@ -735,28 +751,34 @@ def assert_verifier_escalation(
     checks: list[dict[str, Any]] = []
 
     success = bool(result.get("success"))
-    checks.append({
-        "name": "result.success == False",
-        "ok": not success,
-        "detail": f"observed success={success}",
-    })
+    checks.append(
+        {
+            "name": "result.success == False",
+            "ok": not success,
+            "detail": f"observed success={success}",
+        }
+    )
 
     errors = result.get("errors") or []
-    checks.append({
-        "name": "result.errors populated",
-        "ok": bool(errors),
-        "detail": f"errors={errors}",
-    })
+    checks.append(
+        {
+            "name": "result.errors populated",
+            "ok": bool(errors),
+            "detail": f"errors={errors}",
+        }
+    )
 
     runs = result.get("subagent_runs") or []
     verifier_runs = [r for r in runs if isinstance(r, dict) and r.get("name") == "harness-verifier"]
     rejected = [r for r in verifier_runs if not r.get("success")]
     threshold = int(scenario_cfg.get("min_verifier_rejections", 1))
-    checks.append({
-        "name": f">= {threshold} verifier rejections recorded",
-        "ok": len(rejected) >= threshold,
-        "detail": f"verifier_runs={len(verifier_runs)}, rejected={len(rejected)}",
-    })
+    checks.append(
+        {
+            "name": f">= {threshold} verifier rejections recorded",
+            "ok": len(rejected) >= threshold,
+            "detail": f"verifier_runs={len(verifier_runs)}, rejected={len(rejected)}",
+        }
+    )
     return _bundle_checks(checks, run_meta)
 
 
@@ -811,10 +833,7 @@ def _build_task_for_scenario(scenario: dict[str, Any], kernel: dict[str, Any]) -
             "python3 scripts/task_runner.py performance"
         )
     if kind == "path_a_partial":
-        return (
-            f"Optimize the repository {repo_path}, test command is "
-            "python3 scripts/task_runner.py performance"
-        )
+        return f"Optimize the repository {repo_path}, test command is python3 scripts/task_runner.py performance"
     if kind == "path_b_determinism" or kind == "path_b_coverage" or kind == "cross_language":
         return (
             f"Optimize the {kernel_name} HIP kernel located at {kernel_url} "
@@ -956,9 +975,7 @@ def run_plan(
                     model=model,
                     log_file=log_file,
                 )
-                (run_dir / "run_meta.json").write_text(
-                    json.dumps(run_meta, indent=2), encoding="utf-8"
-                )
+                (run_dir / "run_meta.json").write_text(json.dumps(run_meta, indent=2), encoding="utf-8")
                 artifacts = _load_run_artifacts(run_dir)
                 run_record = _apply_assertions(scenario, artifacts, run_meta, oracle)
                 run_record["run_dir"] = str(run_dir)
@@ -974,11 +991,13 @@ def run_plan(
             scenario_summary["task"] = run_results[0]["task"] if run_results else None
             summary_records.append(scenario_summary)
             if scenario["kind"] == "path_b_determinism":
-                determinism_records.append({
-                    "kernel": kernel["name"],
-                    "hashes": scenario_summary.get("determinism_hashes", []),
-                    "all_match": scenario_summary.get("all_hashes_match", False),
-                })
+                determinism_records.append(
+                    {
+                        "kernel": kernel["name"],
+                        "hashes": scenario_summary.get("determinism_hashes", []),
+                        "all_match": scenario_summary.get("all_hashes_match", False),
+                    }
+                )
                 # Piggyback assertions on run1 of the determinism scenario:
                 # both coverage (vs oracle) and cross-language (HIP markers)
                 # are properties of any clean Path-B run, so we extract them
@@ -996,9 +1015,12 @@ def run_plan(
                     summary_records.append(coverage_record)
 
                     crosslang_record = assert_cross_language(
-                        {"expected_phrases_present": list(HIP_CANONICAL_PHRASES),
-                         "expected_phrases_absent": list(TRITON_CANONICAL_PHRASES)},
-                        run1_artifacts, run1_meta,
+                        {
+                            "expected_phrases_present": list(HIP_CANONICAL_PHRASES),
+                            "expected_phrases_absent": list(TRITON_CANONICAL_PHRASES),
+                        },
+                        run1_artifacts,
+                        run1_meta,
                     )
                     crosslang_record["kernel"] = kernel["name"]
                     crosslang_record["scenario"] = "cross_language"

--- a/scripts/preprocess_v3_triton_runner.py
+++ b/scripts/preprocess_v3_triton_runner.py
@@ -158,12 +158,8 @@ def child_run_scenario(scenario_payload: dict[str, Any]) -> int:
     elapsed_s = round(time.monotonic() - t0, 3)
 
     result_dump = _serialise_result(result, error_payload, elapsed_s, kernel_path, detected_language)
-    (output_dir / "preprocess_result.json").write_text(
-        json.dumps(result_dump, indent=2, default=str), encoding="utf-8"
-    )
-    (output_dir / "agent_messages.json").write_text(
-        json.dumps(agent.messages, indent=2, default=str), encoding="utf-8"
-    )
+    (output_dir / "preprocess_result.json").write_text(json.dumps(result_dump, indent=2, default=str), encoding="utf-8")
+    (output_dir / "agent_messages.json").write_text(json.dumps(agent.messages, indent=2, default=str), encoding="utf-8")
     sys.stdout.write(f"CHILD_DONE elapsed_s={elapsed_s}\n")
     return 0
 
@@ -206,7 +202,9 @@ def _load_model_config() -> dict[str, Any]:
             merged[key] = value
     model_cfg = dict(merged.get("model") or {})
     model_cfg.setdefault("model_class", "amd_llm")
-    model_cfg.setdefault("model_name", "claude-opus-4.6")
+    from minisweagent.models import get_model_name
+
+    model_cfg.setdefault("model_name", get_model_name())
     return model_cfg
 
 
@@ -386,11 +384,7 @@ def parse_harness_shapes(harness_path: str | Path) -> list[tuple]:
                 if isinstance(target, ast.Name) and target.id in _SHAPE_LIST_NAMES:
                     candidates.append(_coerce_node(node.value))
         elif isinstance(node, ast.AnnAssign):
-            if (
-                isinstance(node.target, ast.Name)
-                and node.target.id in _SHAPE_LIST_NAMES
-                and node.value is not None
-            ):
+            if isinstance(node.target, ast.Name) and node.target.id in _SHAPE_LIST_NAMES and node.value is not None:
                 candidates.append(_coerce_node(node.value))
 
     out: list[tuple] = []
@@ -475,41 +469,46 @@ def assert_path_a(scenario_cfg: dict[str, Any], artifacts: dict[str, Any], run_m
     checks: list[dict[str, Any]] = []
 
     path_taken = result.get("path_taken")
-    checks.append({
-        "name": "path_taken == A",
-        "ok": path_taken == "A",
-        "detail": f"observed path_taken={path_taken!r}",
-    })
+    checks.append(
+        {
+            "name": "path_taken == A",
+            "ok": path_taken == "A",
+            "detail": f"observed path_taken={path_taken!r}",
+        }
+    )
 
     commandment_path = result.get("commandment_path")
     text = artifacts.get("commandment_text") or ""
-    checks.append({
-        "name": "COMMANDMENT.md rendered to disk",
-        "ok": bool(commandment_path) and bool(text),
-        "detail": f"commandment_path={commandment_path!r}, text_len={len(text)}",
-    })
+    checks.append(
+        {
+            "name": "COMMANDMENT.md rendered to disk",
+            "ok": bool(commandment_path) and bool(text),
+            "detail": f"commandment_path={commandment_path!r}, text_len={len(text)}",
+        }
+    )
 
     harness_path = result.get("harness_path")
     kernel_path = result.get("kernel_path")
-    harness_ok = (
-        harness_path in (None, "")
-        or (kernel_path is not None and harness_path == kernel_path)
+    harness_ok = harness_path in (None, "") or (kernel_path is not None and harness_path == kernel_path)
+    checks.append(
+        {
+            "name": "harness_path None or == kernel_path",
+            "ok": harness_ok,
+            "detail": f"harness_path={harness_path!r}, kernel_path={kernel_path!r}",
+            "warn_only": True,
+        }
     )
-    checks.append({
-        "name": "harness_path None or == kernel_path",
-        "ok": harness_ok,
-        "detail": f"harness_path={harness_path!r}, kernel_path={kernel_path!r}",
-        "warn_only": True,
-    })
 
     expected_substring = scenario_cfg.get("expect_command_substring", "")
     if expected_substring:
         ok = expected_substring in text
-        checks.append({
-            "name": "COMMANDMENT contains user command substring",
-            "ok": ok,
-            "detail": f"substring={expected_substring!r} present={ok}",
-        })
+        checks.append(
+            {
+                "name": "COMMANDMENT contains user command substring",
+                "ok": ok,
+                "detail": f"substring={expected_substring!r} present={ok}",
+            }
+        )
     return _bundle_checks(checks, run_meta)
 
 
@@ -520,11 +519,13 @@ def assert_path_a_partial(
     checks: list[dict[str, Any]] = []
 
     path_taken = result.get("path_taken")
-    checks.append({
-        "name": "path_taken == A",
-        "ok": path_taken == "A",
-        "detail": f"observed path_taken={path_taken!r}",
-    })
+    checks.append(
+        {
+            "name": "path_taken == A",
+            "ok": path_taken == "A",
+            "detail": f"observed path_taken={path_taken!r}",
+        }
+    )
 
     text = artifacts.get("commandment_text") or ""
     expected_modes = scenario_cfg.get("expect_partial_modes", ["correctness", "full_benchmark", "profile"])
@@ -536,13 +537,13 @@ def assert_path_a_partial(
         )
         if not marker_present:
             missing_markers.append(mode)
-    checks.append({
-        "name": "PATH_A_PARTIAL_COVERAGE markers present for uncovered modes",
-        "ok": not missing_markers,
-        "detail": (
-            f"expected modes with marker: {expected_modes}; missing markers: {missing_markers}"
-        ),
-    })
+    checks.append(
+        {
+            "name": "PATH_A_PARTIAL_COVERAGE markers present for uncovered modes",
+            "ok": not missing_markers,
+            "detail": (f"expected modes with marker: {expected_modes}; missing markers: {missing_markers}"),
+        }
+    )
     return _bundle_checks(checks, run_meta)
 
 
@@ -556,11 +557,13 @@ def assert_path_b_coverage(
     checks: list[dict[str, Any]] = []
 
     path_taken = result.get("path_taken")
-    checks.append({
-        "name": "path_taken == B",
-        "ok": path_taken == "B",
-        "detail": f"observed path_taken={path_taken!r}",
-    })
+    checks.append(
+        {
+            "name": "path_taken == B",
+            "ok": path_taken == "B",
+            "detail": f"observed path_taken={path_taken!r}",
+        }
+    )
 
     harness_files = artifacts.get("harness_files") or []
     if not harness_files:
@@ -585,12 +588,14 @@ def assert_path_b_coverage(
     else:
         ok = True
         status = "harness signatures == oracle signatures"
-    checks.append({
-        "name": "harness signatures cover oracle",
-        "ok": ok,
-        "detail": f"{status}; oracle={sorted(oracle_sigs)[:6]}{'...' if len(oracle_sigs)>6 else ''}, parsed={sorted(parsed_sigs)[:6]}{'...' if len(parsed_sigs)>6 else ''}, missing={missing[:8]}, extras_n={len(extras)}",
-        "warn_only": ok and bool(extras),
-    })
+    checks.append(
+        {
+            "name": "harness signatures cover oracle",
+            "ok": ok,
+            "detail": f"{status}; oracle={sorted(oracle_sigs)[:6]}{'...' if len(oracle_sigs) > 6 else ''}, parsed={sorted(parsed_sigs)[:6]}{'...' if len(parsed_sigs) > 6 else ''}, missing={missing[:8]}, extras_n={len(extras)}",
+            "warn_only": ok and bool(extras),
+        }
+    )
     return _bundle_checks(checks, run_meta)
 
 
@@ -602,11 +607,13 @@ def assert_task_override(
 
     expected_shape = tuple(scenario_cfg["expect_shape"])
     path_taken = result.get("path_taken")
-    checks.append({
-        "name": "path_taken == B",
-        "ok": path_taken == "B",
-        "detail": f"observed path_taken={path_taken!r}",
-    })
+    checks.append(
+        {
+            "name": "path_taken == B",
+            "ok": path_taken == "B",
+            "detail": f"observed path_taken={path_taken!r}",
+        }
+    )
 
     harness_files = artifacts.get("harness_files") or []
     if not harness_files:
@@ -621,17 +628,21 @@ def assert_task_override(
     contains_expected = expected_sig in parsed_sigs
     extras = sorted(parsed_sigs - {expected_sig}, key=lambda t: (len(t), t))
 
-    checks.append({
-        "name": "harness contains user-specified shape",
-        "ok": contains_expected,
-        "detail": f"expected_sig={expected_sig}, parsed_n={len(parsed_sigs)}",
-    })
-    checks.append({
-        "name": "no shapes leaked from source discovery",
-        "ok": not extras,
-        "detail": f"extra signatures present (n={len(extras)}): {extras[:6]}",
-        "warn_only": True,
-    })
+    checks.append(
+        {
+            "name": "harness contains user-specified shape",
+            "ok": contains_expected,
+            "detail": f"expected_sig={expected_sig}, parsed_n={len(parsed_sigs)}",
+        }
+    )
+    checks.append(
+        {
+            "name": "no shapes leaked from source discovery",
+            "ok": not extras,
+            "detail": f"extra signatures present (n={len(extras)}): {extras[:6]}",
+            "warn_only": True,
+        }
+    )
     return _bundle_checks(checks, run_meta)
 
 
@@ -668,28 +679,34 @@ def assert_verifier_escalation(
     checks: list[dict[str, Any]] = []
 
     success = bool(result.get("success"))
-    checks.append({
-        "name": "result.success == False",
-        "ok": not success,
-        "detail": f"observed success={success}",
-    })
+    checks.append(
+        {
+            "name": "result.success == False",
+            "ok": not success,
+            "detail": f"observed success={success}",
+        }
+    )
 
     errors = result.get("errors") or []
-    checks.append({
-        "name": "result.errors populated",
-        "ok": bool(errors),
-        "detail": f"errors={errors}",
-    })
+    checks.append(
+        {
+            "name": "result.errors populated",
+            "ok": bool(errors),
+            "detail": f"errors={errors}",
+        }
+    )
 
     runs = result.get("subagent_runs") or []
     verifier_runs = [r for r in runs if isinstance(r, dict) and r.get("name") == "harness-verifier"]
     rejected = [r for r in verifier_runs if not r.get("success")]
     threshold = int(scenario_cfg.get("min_verifier_rejections", 1))
-    checks.append({
-        "name": f">= {threshold} verifier rejections recorded",
-        "ok": len(rejected) >= threshold,
-        "detail": f"verifier_runs={len(verifier_runs)}, rejected={len(rejected)}",
-    })
+    checks.append(
+        {
+            "name": f">= {threshold} verifier rejections recorded",
+            "ok": len(rejected) >= threshold,
+            "detail": f"verifier_runs={len(verifier_runs)}, rejected={len(rejected)}",
+        }
+    )
     return _bundle_checks(checks, run_meta)
 
 
@@ -894,9 +911,7 @@ def run_plan(
                     model=model,
                     log_file=log_file,
                 )
-                (run_dir / "run_meta.json").write_text(
-                    json.dumps(run_meta, indent=2), encoding="utf-8"
-                )
+                (run_dir / "run_meta.json").write_text(json.dumps(run_meta, indent=2), encoding="utf-8")
                 artifacts = _load_run_artifacts(run_dir)
                 run_record = _apply_assertions(scenario, artifacts, run_meta, oracle)
                 run_record["run_dir"] = str(run_dir)
@@ -912,11 +927,13 @@ def run_plan(
             scenario_summary["task"] = run_results[0]["task"] if run_results else None
             summary_records.append(scenario_summary)
             if scenario["kind"] == "path_b_determinism":
-                determinism_records.append({
-                    "kernel": kernel["name"],
-                    "hashes": scenario_summary.get("determinism_hashes", []),
-                    "all_match": scenario_summary.get("all_hashes_match", False),
-                })
+                determinism_records.append(
+                    {
+                        "kernel": kernel["name"],
+                        "hashes": scenario_summary.get("determinism_hashes", []),
+                        "all_match": scenario_summary.get("all_hashes_match", False),
+                    }
+                )
                 if run_results:
                     # Piggyback coverage + cross-language on run1 of determinism.
                     # Both are properties of any clean Path-B run, so we extract
@@ -933,9 +950,12 @@ def run_plan(
                     summary_records.append(coverage_record)
 
                     crosslang_record = assert_cross_language(
-                        {"expected_phrases_present": list(TRITON_CANONICAL_PHRASES),
-                         "expected_phrases_absent": list(HIP_CANONICAL_PHRASES)},
-                        run1_artifacts, run1_meta,
+                        {
+                            "expected_phrases_present": list(TRITON_CANONICAL_PHRASES),
+                            "expected_phrases_absent": list(HIP_CANONICAL_PHRASES),
+                        },
+                        run1_artifacts,
+                        run1_meta,
                     )
                     crosslang_record["kernel"] = kernel["name"]
                     crosslang_record["scenario"] = "cross_language"
@@ -1017,7 +1037,9 @@ def main() -> int:
     parser.add_argument("--plan", type=Path, help="Path to test_plan_triton.yaml.")
     parser.add_argument("--output", type=Path, help="Output root directory.")
     parser.add_argument("--timeout-s", type=int, default=DEFAULT_PER_RUN_TIMEOUT_S)
-    parser.add_argument("--gpu-id", type=int, default=4, help="GPU ID for child orchestrator runs (default: 4, Triton slot).")
+    parser.add_argument(
+        "--gpu-id", type=int, default=4, help="GPU ID for child orchestrator runs (default: 4, Triton slot)."
+    )
     parser.add_argument("--only-kernels", type=str, default="", help="Comma-separated kernel names.")
     parser.add_argument("--only-scenarios", type=str, default="", help="Comma-separated scenario kinds.")
     parser.add_argument("--model", type=str, default=None, help="Model override; default = router/env.")

--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -244,6 +244,7 @@ class DefaultAgent:
             # when those wire ``registry`` through. Lets the budget watchdog
             # SIGTERM/SIGKILL long-running test/benchmark subprocesses.
             registry=getattr(self, "_registry", None),
+            gpu_manager=getattr(self, "_gpu_manager", None),
         )
 
         save_and_test_tool = self.toolruntime._tool_table.get("save_and_test")

--- a/src/minisweagent/agents/default.py
+++ b/src/minisweagent/agents/default.py
@@ -405,7 +405,14 @@ class DefaultAgent:
             if _wm_text and not any("[Working Memory" in m.get("content", "") for m in self.messages[-3:]):
                 self.messages.append({"role": "user", "content": f"[Working Memory Update]\n{_wm_text}"})
 
-        response = self.model.query(self.messages)
+        _sem = getattr(self, "_llm_semaphore", None)
+        if _sem is not None:
+            _sem.acquire()
+        try:
+            response = self.model.query(self.messages)
+        finally:
+            if _sem is not None:
+                _sem.release()
         output = response["content"]
         # Include tool_calls in assistant message when the model requests a tool call
         # and there is no bash block (bash takes priority in parse_action).

--- a/src/minisweagent/agents/heterogeneous/prompts.py
+++ b/src/minisweagent/agents/heterogeneous/prompts.py
@@ -202,8 +202,10 @@ them priority 15 behind kernel-body algorithmic work.
    dependency to identify what to optimize.
 3. Read the discovery file for kernel metadata (language, inner kernel, etc.).
 4. Read the knowledge base for applicable optimization strategies.
-5. Optionally read baseline metrics, COMMANDMENT.md, deep search findings,
-   or prior results if the paths are provided.
+5. Always read the COMMANDMENT.md when its path is provided -- it is the
+   inviolable contract for what the sub-agent may and may not do.
+   Optionally read baseline metrics, deep search findings, or prior results
+   if those paths are provided.
 6. Group related kernels (e.g., multiple Tensile GEMMs with different tile
    sizes are one target; CK GEMM variants are another).
 7. For each group, propose a specific optimization task naming:
@@ -267,13 +269,17 @@ compare its results against the baseline metrics provided in the task
 metadata. The sub-agent should report the specific metric improvement
 (e.g. duration reduction, bandwidth improvement) relative to baseline.
 
-**COMMANDMENT adherence**: Each task_prompt MUST instruct the sub-agent
-to read and follow the COMMANDMENT file. The COMMANDMENT defines the
-correctness criteria and constraints. Any changes that violate the
-COMMANDMENT must be rejected by the sub-agent itself.
+**COMMANDMENT adherence**: COMMANDMENT is the inviolable contract between
+the orchestrator and the sub-agent. Each task_prompt MUST instruct the
+sub-agent to read the COMMANDMENT file and obey every rule in it with
+ZERO exceptions. Any patch that violates any rule in COMMANDMENT MUST be
+reverted by the sub-agent before reporting results -- a violating patch
+is not a candidate, no matter its measured speedup.
 
 **Verification**: Each task_prompt MUST include instructions to:
-1. Read the COMMANDMENT and follow its constraints
+1. Read the COMMANDMENT and follow its constraints exactly -- any patch
+   that violates COMMANDMENT must be reverted and reported as a failed
+   attempt, regardless of measured performance
 2. Verify correctness after making changes (use the `save_and_test` tool)
 3. Profile the result to measure improvement (use the `profile_kernel` tool)
 4. Compare results against baseline metrics and report before/after numbers

--- a/src/minisweagent/agents/optimization_agent.py
+++ b/src/minisweagent/agents/optimization_agent.py
@@ -424,6 +424,7 @@ class OptimizationAgent:
             log_fn=self._log_message,
             patch_counter=self.patch_counter,
             source_file_paths=source_file_paths,
+            gpu_manager=getattr(self, "_gpu_manager", None),
         )
 
         save_and_test_tool = self.toolruntime._tool_table.get("save_and_test")

--- a/src/minisweagent/agents/optimization_agent.py
+++ b/src/minisweagent/agents/optimization_agent.py
@@ -580,7 +580,14 @@ class OptimizationAgent:
             if _wm_text and not any("[Working Memory" in m.get("content", "") for m in self.messages[-3:]):
                 self.messages.append({"role": "user", "content": f"[Working Memory Update]\n{_wm_text}"})
 
-        response = self.model.query(self.messages)
+        _sem = getattr(self, "_llm_semaphore", None)
+        if _sem is not None:
+            _sem.acquire()
+        try:
+            response = self.model.query(self.messages)
+        finally:
+            if _sem is not None:
+                _sem.release()
         output = response["content"]
         msg_kwargs = {}
         if response.get("tools") and not self._will_use_bash(response):

--- a/src/minisweagent/agents/parallel_agent.py
+++ b/src/minisweagent/agents/parallel_agent.py
@@ -404,6 +404,7 @@ class ParallelAgent(DefaultAgent):
         deadline=None,
         soft_stop=None,
         registry=None,
+        gpu_manager=None,
     ) -> list[tuple[int, Any, Any, Any]]:
         """Run multiple parallel agents and return their results.
 
@@ -437,6 +438,7 @@ class ParallelAgent(DefaultAgent):
                 deadline=deadline,
                 soft_stop=soft_stop,
                 registry=registry,
+                gpu_manager=gpu_manager,
             )
 
         # Heterogeneous mode: use agent_specs if provided (legacy)

--- a/src/minisweagent/agents/parallel_agent.py
+++ b/src/minisweagent/agents/parallel_agent.py
@@ -405,6 +405,7 @@ class ParallelAgent(DefaultAgent):
         soft_stop=None,
         registry=None,
         gpu_manager=None,
+        llm_semaphore=None,
     ) -> list[tuple[int, Any, Any, Any]]:
         """Run multiple parallel agents and return their results.
 
@@ -439,6 +440,7 @@ class ParallelAgent(DefaultAgent):
                 soft_stop=soft_stop,
                 registry=registry,
                 gpu_manager=gpu_manager,
+                llm_semaphore=llm_semaphore,
             )
 
         # Heterogeneous mode: use agent_specs if provided (legacy)

--- a/src/minisweagent/config/geak.yaml
+++ b/src/minisweagent/config/geak.yaml
@@ -56,3 +56,12 @@ run:
     full:
       orchestrator:
         max_rounds: 5
+parallel:
+  num_parallel: null              # null -> ceil(len(gpu_ids) * gpu_oversubscribe)
+  gpu_oversubscribe: 1.0          # bump to 2.0 once stats validate headroom
+  max_concurrent_llm: null        # null -> num_parallel
+gpu_manager:
+  job_timeout_default_s: 900
+  stats_log_interval_s: 30        # 0 disables periodic stats logging
+pipeline:
+  mode: mixed

--- a/src/minisweagent/config/geak.yaml
+++ b/src/minisweagent/config/geak.yaml
@@ -13,8 +13,8 @@ env:
   timeout: 3600
 model:
   model_class: amd_llm
-  # claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
-  model_name: claude-opus-4.6
+  # claude-opus-4.7, claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
+  model_name: claude-opus-4.7
   api_key: ""
   model_kwargs:
     temperature: 0.0

--- a/src/minisweagent/config/mini.yaml
+++ b/src/minisweagent/config/mini.yaml
@@ -153,8 +153,8 @@ env:
   timeout: 3600
 model:
   model_class: amd_llm
-  # claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
-  model_name: claude-opus-4.6
+  # claude-opus-4.7, claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
+  model_name: claude-opus-4.7
   # API key is read from AMD_LLM_API_KEY environment variable
   # Set it in .env file or: export AMD_LLM_API_KEY=your_key_here
   api_key: null

--- a/src/minisweagent/config/mini_select_patch.yaml
+++ b/src/minisweagent/config/mini_select_patch.yaml
@@ -103,5 +103,5 @@ agent:
 
 model:
   model_class: amd_llm
-  model_name: claude-opus-4.6
+  model_name: claude-opus-4.7
   api_key: ""

--- a/src/minisweagent/config/mini_unit_test_agent.yaml
+++ b/src/minisweagent/config/mini_unit_test_agent.yaml
@@ -162,8 +162,8 @@ env:
 
 model:
   model_class: amd_llm
-  # claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
-  model_name: claude-opus-4.6
+  # claude-opus-4.7, claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
+  model_name: claude-opus-4.7
   api_key: ""
   # model_kwargs:
   #   temperature: 0.0

--- a/src/minisweagent/kernel_languages/hip/commandment.j2
+++ b/src/minisweagent/kernel_languages/hip/commandment.j2
@@ -24,6 +24,11 @@ mandatory and enforced by kernel_languages/contract.py::validate_commandment.
 ```bash
 export GEAK_WORK_DIR="${GEAK_WORK_DIR:-{{ repo_root }}}"
 export PYTHONPATH="${GEAK_WORK_DIR}:${GEAK_REPO_ROOT:-{{ repo_root }}}:${PYTHONPATH:-}"
+# Keep any JIT/Triton compile cache OUTSIDE the worktree so the per-round patch
+# capture never sweeps compiled blobs into the diff (honours an inherited value;
+# default lands in /tmp keyed per GPU slot).
+export GEAK_JIT_CACHE_DIR="${GEAK_JIT_CACHE_DIR:-/tmp/geak_jit_cache/gpu${GEAK_GPU_DEVICE:-0}}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${GEAK_JIT_CACHE_DIR}/triton}"
 {% if compile_command -%}
 {{ compile_command }}
 {%- endif %}

--- a/src/minisweagent/kernel_languages/triton/commandment.j2
+++ b/src/minisweagent/kernel_languages/triton/commandment.j2
@@ -27,7 +27,12 @@ mandatory and enforced by kernel_languages/contract.py::validate_commandment.
 
 ```bash
 export GEAK_WORK_DIR="${GEAK_WORK_DIR:-{{ repo_root }}}"
-printf '#!/bin/bash\nexport PYTHONPATH=%s:%s:${PYTHONPATH}\nexport HIP_VISIBLE_DEVICES=%s\ncd "%s" && exec python3 "$@"\n' "${GEAK_WORK_DIR}" "${GEAK_REPO_ROOT:-{{ repo_root }}}" "${GEAK_GPU_DEVICE:-0}" "${GEAK_WORK_DIR}" > ${GEAK_WORK_DIR}/run.sh && chmod +x ${GEAK_WORK_DIR}/run.sh
+# Keep the Triton/JIT compile cache OUTSIDE the worktree so the per-round patch
+# capture never sweeps compiled blobs (*.hsaco / IR) into the diff (which broke
+# re-apply and pinned GEAK's A/B speedup at 1.0x). Honour an inherited value
+# (GEAK sets GEAK_JIT_CACHE_DIR/TRITON_CACHE_DIR in the eval env); only the
+# default lands in /tmp, keyed per GPU slot.
+printf '#!/bin/bash\nexport PYTHONPATH=%s:%s:${PYTHONPATH}\nexport HIP_VISIBLE_DEVICES=%s\nexport GEAK_JIT_CACHE_DIR="${GEAK_JIT_CACHE_DIR:-/tmp/geak_jit_cache/gpu${GEAK_GPU_DEVICE:-0}}"\nexport TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${GEAK_JIT_CACHE_DIR}/triton}"\ncd "%s" && exec python3 "$@"\n' "${GEAK_WORK_DIR}" "${GEAK_REPO_ROOT:-{{ repo_root }}}" "${GEAK_GPU_DEVICE:-0}" "${GEAK_WORK_DIR}" > ${GEAK_WORK_DIR}/run.sh && chmod +x ${GEAK_WORK_DIR}/run.sh
 {% if inner_kernel -%}
 mkdir -p "${GEAK_WORK_DIR}/_work"
 cp "{{ kernel_path }}" "${GEAK_WORK_DIR}/_work/kernel.py"

--- a/src/minisweagent/models/__init__.py
+++ b/src/minisweagent/models/__init__.py
@@ -76,7 +76,7 @@ def get_model_name(input_model_name: str | None = None, config: dict | None = No
         return from_env
     if from_env := os.getenv("MSWEA_MODEL_NAME"):
         return from_env
-    return "claude-opus-4.6"  # GEAK default
+    return "claude-opus-4.7"  # GEAK default
 
 
 _MODEL_CLASS_MAPPING = {

--- a/src/minisweagent/run/dispatch.py
+++ b/src/minisweagent/run/dispatch.py
@@ -345,6 +345,8 @@ def run_task_batch(
     deadline=None,
     soft_stop=None,
     registry=None,
+    gpu_manager=None,
+    num_parallel: int | None = None,
 ) -> dict[str, Any]:
     """Run a batch of task files via ParallelAgent pool mode.
 
@@ -458,7 +460,7 @@ def run_task_batch(
 
     try:
         raw_results = ParallelAgent.run_parallel(
-            num_parallel=len(gpu_ids),
+            num_parallel=num_parallel or len(gpu_ids),
             repo_path=repo_path,
             is_git_repo=is_git,
             task_content="",
@@ -474,6 +476,7 @@ def run_task_batch(
             deadline=deadline,
             soft_stop=soft_stop,
             registry=registry,
+            gpu_manager=gpu_manager,
         )
     except Exception as exc:
         logger.error("Task batch execution failed: %s", exc, exc_info=True)
@@ -620,6 +623,8 @@ def run_staged_task_batch(
     deadline=None,
     soft_stop=None,
     registry=None,
+    gpu_manager=None,
+    num_parallel: int | None = None,
 ) -> dict[str, Any]:
     """Priority-staged dispatch with early exit on improvement.
 
@@ -653,6 +658,8 @@ def run_staged_task_batch(
             deadline=deadline,
             soft_stop=soft_stop,
             registry=registry,
+            gpu_manager=gpu_manager,
+            num_parallel=num_parallel,
         )
         all_results.append(
             {

--- a/src/minisweagent/run/dispatch.py
+++ b/src/minisweagent/run/dispatch.py
@@ -347,6 +347,7 @@ def run_task_batch(
     registry=None,
     gpu_manager=None,
     num_parallel: int | None = None,
+    llm_semaphore=None,
 ) -> dict[str, Any]:
     """Run a batch of task files via ParallelAgent pool mode.
 
@@ -477,6 +478,7 @@ def run_task_batch(
             soft_stop=soft_stop,
             registry=registry,
             gpu_manager=gpu_manager,
+            llm_semaphore=llm_semaphore,
         )
     except Exception as exc:
         logger.error("Task batch execution failed: %s", exc, exc_info=True)
@@ -625,6 +627,7 @@ def run_staged_task_batch(
     registry=None,
     gpu_manager=None,
     num_parallel: int | None = None,
+    llm_semaphore=None,
 ) -> dict[str, Any]:
     """Priority-staged dispatch with early exit on improvement.
 
@@ -660,6 +663,7 @@ def run_staged_task_batch(
             registry=registry,
             gpu_manager=gpu_manager,
             num_parallel=num_parallel,
+            llm_semaphore=llm_semaphore,
         )
         all_results.append(
             {

--- a/src/minisweagent/run/dispatch.py
+++ b/src/minisweagent/run/dispatch.py
@@ -319,7 +319,7 @@ def task_file_to_agent_task(task_file: Path):
     if meta.get("starting_patch"):
         cfg["starting_patch"] = meta["starting_patch"]
 
-    for _passthrough_key in ("baseline_metrics", "benchmark_baseline"):
+    for _passthrough_key in ("baseline_metrics", "benchmark_baseline", "kind"):
         if meta.get(_passthrough_key):
             cfg[_passthrough_key] = meta[_passthrough_key]
 

--- a/src/minisweagent/run/dispatch.py
+++ b/src/minisweagent/run/dispatch.py
@@ -319,7 +319,11 @@ def task_file_to_agent_task(task_file: Path):
     if meta.get("starting_patch"):
         cfg["starting_patch"] = meta["starting_patch"]
 
-    for _passthrough_key in ("baseline_metrics", "benchmark_baseline", "kind"):
+    # kind is dispatcher scheduling metadata persisted to the task .md YAML by the
+    # writer and read back by _resolve_task_kind() in postprocess.evaluation. It is
+    # intentionally NOT passed to AgentConfig: agents behave identically regardless
+    # of how they were scheduled (planned vs fixed canonical fill).
+    for _passthrough_key in ("baseline_metrics", "benchmark_baseline"):
         if meta.get(_passthrough_key):
             cfg[_passthrough_key] = meta[_passthrough_key]
 

--- a/src/minisweagent/run/dispatcher/selector.py
+++ b/src/minisweagent/run/dispatcher/selector.py
@@ -2,14 +2,16 @@
 
 The dispatcher is the **only** component that knows about mode semantics.
 Its job is purely selection: from a pool of M candidates, pick N to run
-on the available parallel workers.  The selection rule is determined by
-``_k_for_mode``, the single seam that the adaptive future replaces.
+on the available parallel workers.  In mixed mode, K (the number of
+planned slots) is determined adaptively based on per-task outcomes from
+prior rounds.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import replace
+from typing import Any
 
 from minisweagent.run.dispatch_plan import DispatchPlan, DispatchPlanItem
 from minisweagent.run.planner.candidate_pool import CandidatePool, CandidateTask
@@ -25,6 +27,7 @@ class Dispatcher:
         pool: CandidatePool,
         mode: str,
         n: int,
+        round_evals: list[dict[str, Any]] | None = None,
     ) -> DispatchPlan:
         """Pick exactly N items from *pool* according to *mode*.
 
@@ -33,7 +36,7 @@ class Dispatcher:
         if n < 1:
             n = 1
 
-        k = self._k_for_mode(mode, n)
+        k = self._k_for_mode(mode, n, round_evals)
         planned = sorted(pool.planned, key=lambda c: c.priority)
         fixed = pool.fixed
         registry = pool.registry
@@ -90,14 +93,48 @@ class Dispatcher:
         )
 
     @staticmethod
-    def _k_for_mode(mode: str, n: int) -> int:
-        """THE ONLY PLACE the mode-to-K mapping lives.
+    def _k_for_mode(
+        mode: str, n: int, round_evals: list[dict[str, Any]] | None = None
+    ) -> int:
+        """Adaptive K allocation for mixed mode.
 
-        Adaptive K replaces this function; signature stays the same.
-
-        Returns the number of slots to fill with planned candidates.
+        Fixed/planned modes are unchanged. Mixed mode allocates K
+        proportionally based on which source (planned vs fixed) produced
+        better speedups in prior rounds, with an exploration floor of 1
+        slot for each source.
         """
-        return {"fixed": 0, "planned": n, "mixed": n // 2}.get(mode, n // 2)
+        if mode == "fixed":
+            return 0
+        if mode == "planned":
+            return n
+        if not round_evals or n <= 2:
+            return max(1, n // 2)
+
+        planned_speeds: list[float] = []
+        fixed_speeds: list[float] = []
+        for rev in round_evals:
+            for pt in rev.get("per_task", []):
+                spd = pt.get("speedup")
+                if spd is None or spd <= 0:
+                    continue
+                if pt.get("kind") == "planned":
+                    planned_speeds.append(spd)
+                elif pt.get("kind") == "fixed":
+                    fixed_speeds.append(spd)
+
+        if not planned_speeds and not fixed_speeds:
+            return max(1, n // 2)
+
+        planned_avg = (
+            sum(planned_speeds) / len(planned_speeds) if planned_speeds else 1.0
+        )
+        fixed_avg = (
+            sum(fixed_speeds) / len(fixed_speeds) if fixed_speeds else 1.0
+        )
+
+        k = round(n * planned_avg / (planned_avg + fixed_avg))
+        k = max(1, min(k, n - 1))
+        return k
 
     @staticmethod
     def _fill(

--- a/src/minisweagent/run/dispatcher/selector.py
+++ b/src/minisweagent/run/dispatcher/selector.py
@@ -50,6 +50,15 @@ class Dispatcher:
                 n,
                 len(items),
             )
+            # Invariant (post-TaskPlanner refactor): when the planner has run,
+            # ``pool.fixed`` always contains the canonical fixed entry. We rely
+            # on it here so pad tasks dispatch the same body as fixed-mode would,
+            # never an empty string. A violation means TaskPlanner.build_pool
+            # stopped injecting canonical_fixed — fail loudly so we notice.
+            assert fixed, (
+                "selector pad branch reached with empty pool.fixed — "
+                "TaskPlanner.build_pool must always inject canonical_fixed"
+            )
             while len(items) < n:
                 idx = len(items)
                 base_fixed = fixed[0] if fixed else None

--- a/src/minisweagent/run/dispatcher/selector.py
+++ b/src/minisweagent/run/dispatcher/selector.py
@@ -18,6 +18,11 @@ from minisweagent.run.planner.candidate_pool import CandidatePool, CandidateTask
 
 logger = logging.getLogger(__name__)
 
+# Speedups at or above this are treated as timing-saturation / measurement
+# garbage (e.g. a divide-by-near-zero "10000x" artifact) and are excluded from
+# adaptive-K scoring so they cannot hijack slot allocation.
+MAX_PLAUSIBLE_SPEEDUP = 100.0
+
 
 class Dispatcher:
     """Select N tasks from a CandidatePool based on mode."""
@@ -98,10 +103,21 @@ class Dispatcher:
     ) -> int:
         """Adaptive K allocation for mixed mode.
 
-        Fixed/planned modes are unchanged. Mixed mode allocates K
-        proportionally based on which source (planned vs fixed) produced
-        better speedups in prior rounds, with an exploration floor of 1
-        slot for each source.
+        Fixed/planned modes are unchanged. Mixed mode splits the N slots
+        between the planned and fixed sources using a **max-seeking** signal:
+        kernel optimization cares about the *best* result a source produced,
+        not its mean — a single strong planned candidate should attract slots
+        even if most planned attempts were mediocre, and mean-averaging
+        otherwise collapses both sources to parity. Each source's peak speedup
+        is:
+
+          * **clamped** to the plausible open range ``(0, MAX_PLAUSIBLE_SPEEDUP)``
+            so timing-saturation / garbage speedups can't hijack allocation, and
+          * **weighted by the source's success rate** (plausible results /
+            dispatched count) so failure-prone sources lose slots.
+
+        K is allocated proportionally to the two scores and clamped to
+        ``[1, n - 1]`` to keep an exploration floor of one slot per source.
         """
         if mode == "fixed":
             return 0
@@ -111,30 +127,44 @@ class Dispatcher:
             return max(1, n // 2)
 
         planned_speeds: list[float] = []
+        planned_total = 0
         fixed_speeds: list[float] = []
+        fixed_total = 0
         for rev in round_evals:
             for pt in rev.get("per_task", []):
-                spd = pt.get("speedup")
-                if spd is None or spd <= 0:
+                kind = pt.get("kind")
+                if kind == "planned":
+                    planned_total += 1
+                elif kind == "fixed":
+                    fixed_total += 1
+                else:
                     continue
-                if pt.get("kind") == "planned":
-                    planned_speeds.append(spd)
-                elif pt.get("kind") == "fixed":
-                    fixed_speeds.append(spd)
+                spd = pt.get("speedup")
+                # plausibility clamp: drop non-positive, None, and
+                # saturation/garbage artifacts at or above MAX_PLAUSIBLE_SPEEDUP
+                if spd is None or spd <= 0 or spd >= MAX_PLAUSIBLE_SPEEDUP:
+                    continue
+                (planned_speeds if kind == "planned" else fixed_speeds).append(spd)
 
         if not planned_speeds and not fixed_speeds:
             return max(1, n // 2)
 
-        planned_avg = (
-            sum(planned_speeds) / len(planned_speeds) if planned_speeds else 1.0
-        )
-        fixed_avg = (
-            sum(fixed_speeds) / len(fixed_speeds) if fixed_speeds else 1.0
-        )
+        def _source_score(speeds: list[float], total: int) -> float:
+            # max-seeking (optimization cares about the BEST result a source
+            # produced), discounted by the source's success rate (failure
+            # penalty). A source with no plausible result scores a neutral 1.0.
+            if not speeds:
+                return 1.0
+            best = max(speeds)
+            success_rate = len(speeds) / max(1, total)
+            return best * success_rate
 
-        k = round(n * planned_avg / (planned_avg + fixed_avg))
-        k = max(1, min(k, n - 1))
-        return k
+        planned_score = _source_score(planned_speeds, planned_total)
+        fixed_score = _source_score(fixed_speeds, fixed_total)
+        if planned_score + fixed_score <= 0:
+            return max(1, n // 2)
+        k = round(n * planned_score / (planned_score + fixed_score))
+        return max(1, min(k, n - 1))
 
     @staticmethod
     def _fill(

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -623,14 +623,16 @@ def main(
     # ── force-terminate registry and re-raise.                     ──
     state = PreprocessState(output_dir=preprocess_output_dir)
     _gpu_mgr_cfg = config.get("gpu_manager") or {}
+    if "cpu_pressure_threshold" in _gpu_mgr_cfg:
+        logger.warning(
+            "gpu_manager.cpu_pressure_threshold is no longer a YAML knob — "
+            "the dispatcher now uses normalized per-core load with a fixed "
+            "default. Ignoring the configured value."
+        )
     gpu_manager = GPUManager(
         parsed_gpu_ids,
         registry=state.registry,
         stats_log_interval_s=float(_gpu_mgr_cfg.get("stats_log_interval_s", 30.0)),
-        cpu_pressure_threshold=float(_gpu_mgr_cfg.get(
-            "cpu_pressure_threshold",
-            max(len(parsed_gpu_ids) * 4, 8),
-        )),
         event_log_path=preprocess_output_dir / "gpu_events.jsonl",
     )
 

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -523,7 +523,8 @@ def main(
         from math import ceil
 
         _oversubscribe = float(
-            (config.get("parallel") or {}).get("gpu_oversubscribe", 1.0)
+            parsed_config.get("gpu_oversubscribe")
+            or (config.get("parallel") or {}).get("gpu_oversubscribe", 1.0)
         )
         num_parallel = max(1, ceil(len(parsed_gpu_ids) * _oversubscribe))
         logger.info(
@@ -629,7 +630,7 @@ def main(
     )
 
     _parallel_cfg = config.get("parallel") or {}
-    _max_llm = _parallel_cfg.get("max_concurrent_llm")
+    _max_llm = parsed_config.get("max_concurrent_llm") or _parallel_cfg.get("max_concurrent_llm")
     _llm_cap = int(_max_llm) if _max_llm is not None else (num_parallel or len(parsed_gpu_ids))
     llm_semaphore: threading.Semaphore | None = threading.Semaphore(_llm_cap) if _llm_cap > 0 else None
     if llm_semaphore is not None:

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -627,6 +627,11 @@ def main(
         parsed_gpu_ids,
         registry=state.registry,
         stats_log_interval_s=float(_gpu_mgr_cfg.get("stats_log_interval_s", 30.0)),
+        cpu_pressure_threshold=float(_gpu_mgr_cfg.get(
+            "cpu_pressure_threshold",
+            max(len(parsed_gpu_ids) * 4, 8),
+        )),
+        event_log_path=preprocess_output_dir / "gpu_events.jsonl",
     )
 
     _parallel_cfg = config.get("parallel") or {}

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -980,7 +980,10 @@ def main(
 
         from minisweagent.run.unified import PipelineContext, run_pipeline
 
-        pipeline_mode = "mixed"
+        pipeline_mode = os.environ.get("GEAK_PIPELINE_MODE", "mixed").strip().lower()
+        if pipeline_mode not in {"fixed", "planned", "mixed"}:
+            logger.warning("Invalid GEAK_PIPELINE_MODE=%r, falling back to 'mixed'", pipeline_mode)
+            pipeline_mode = "mixed"
         logger.info("Running unified pipeline mode: %s", pipeline_mode)
         pipeline_result = run_pipeline(
             PipelineContext(

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -627,6 +627,14 @@ def main(
         registry=state.registry,
         stats_log_interval_s=float(_gpu_mgr_cfg.get("stats_log_interval_s", 30.0)),
     )
+
+    _parallel_cfg = config.get("parallel") or {}
+    _max_llm = _parallel_cfg.get("max_concurrent_llm")
+    _llm_cap = int(_max_llm) if _max_llm is not None else (num_parallel or len(parsed_gpu_ids))
+    llm_semaphore: threading.Semaphore | None = threading.Semaphore(_llm_cap) if _llm_cap > 0 else None
+    if llm_semaphore is not None:
+        logger.info("LLM concurrency cap: %d", _llm_cap)
+
     _sigint_count = {"n": 0}
     _orig_sigint = signal.getsignal(signal.SIGINT)
 
@@ -993,6 +1001,7 @@ def main(
                 registry=state.registry,
                 preprocess_only=preprocess_only,
                 gpu_manager=gpu_manager,
+                llm_semaphore=llm_semaphore,
             ),
             mode=pipeline_mode,
         )

--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -40,6 +40,7 @@ from minisweagent.run.state import (
     preprocess_hard_stop_handler,
     preprocess_soft_stop_handler,
 )
+from minisweagent.run.utils.gpu_manager import GPUManager
 from minisweagent.run.utils.task_parser import (
     _resolve_path_case,
     display_parsed_config,
@@ -519,8 +520,17 @@ def main(
     if num_parallel is None:
         num_parallel = _as_int(parsed_config.get("num_parallel"))
     if num_parallel is None and parsed_gpu_ids:
-        num_parallel = len(parsed_gpu_ids)
-        logger.info("Auto-setting num_parallel=%s from gpu_ids.", num_parallel)
+        from math import ceil
+
+        _oversubscribe = float(
+            (config.get("parallel") or {}).get("gpu_oversubscribe", 1.0)
+        )
+        num_parallel = max(1, ceil(len(parsed_gpu_ids) * _oversubscribe))
+        logger.info(
+            "Auto-setting num_parallel=%s from gpu_ids (oversubscribe=%.1f).",
+            num_parallel,
+            _oversubscribe,
+        )
 
     kernel_name_for_output = parsed_config.get("kernel_name")
     if not kernel_name_for_output and kernel_url:
@@ -611,6 +621,12 @@ def main(
     # ── SIGINT handler: first Ctrl-C -> SoftStop; second Ctrl-C -> ──
     # ── force-terminate registry and re-raise.                     ──
     state = PreprocessState(output_dir=preprocess_output_dir)
+    _gpu_mgr_cfg = config.get("gpu_manager") or {}
+    gpu_manager = GPUManager(
+        parsed_gpu_ids,
+        registry=state.registry,
+        stats_log_interval_s=float(_gpu_mgr_cfg.get("stats_log_interval_s", 30.0)),
+    )
     _sigint_count = {"n": 0}
     _orig_sigint = signal.getsignal(signal.SIGINT)
 
@@ -976,6 +992,7 @@ def main(
                 soft_stop=budget.soft_stop,
                 registry=state.registry,
                 preprocess_only=preprocess_only,
+                gpu_manager=gpu_manager,
             ),
             mode=pipeline_mode,
         )
@@ -997,6 +1014,10 @@ def main(
         # 4. Then run finalize + retention. Both are broad-except wrapped
         #    so a hook failure can't mask the original exception.
         budget.cancel_all_timers()
+        try:
+            gpu_manager.shutdown(cancel_pending=True)
+        except Exception:
+            logger.exception("gpu_manager.shutdown() failed during run cleanup")
         try:
             state.registry.terminate_all()
         except Exception:

--- a/src/minisweagent/run/pipeline_helpers.py
+++ b/src/minisweagent/run/pipeline_helpers.py
@@ -219,14 +219,13 @@ def load_geak_model(
     from minisweagent.config import get_config_path
     from minisweagent.models import get_model
 
-    resolved_name = model_name or os.environ.get("GEAK_MODEL") or "claude-opus-4.6"
     cfg_path = get_config_path(config_spec)
     model_config: dict[str, Any] = {}
     if cfg_path.exists():
         full_cfg = yaml.safe_load(cfg_path.read_text()) or {}
         model_config = full_cfg.get("model", {})
 
-    return get_model(resolved_name, config=model_config)
+    return get_model(model_name, config=model_config)
 
 
 def geak_model_factory(
@@ -240,7 +239,6 @@ def geak_model_factory(
     from minisweagent.config import get_config_path
     from minisweagent.models import get_model
 
-    resolved_name = model_name or os.environ.get("GEAK_MODEL") or "claude-opus-4.6"
     cfg_path = get_config_path(config_spec)
     model_config: dict[str, Any] = {}
     if cfg_path.exists():
@@ -248,7 +246,7 @@ def geak_model_factory(
         model_config = full_cfg.get("model", {})
 
     def _factory():
-        return get_model(resolved_name, config=copy.deepcopy(model_config))
+        return get_model(model_name, config=copy.deepcopy(model_config))
 
     return _factory
 

--- a/src/minisweagent/run/planner/task_planner.py
+++ b/src/minisweagent/run/planner/task_planner.py
@@ -52,11 +52,16 @@ class TaskPlanner:
         num_parallel: int = 1,
         rag_enabled: bool = False,
     ) -> CandidatePool:
-        """Produce a ``CandidatePool`` of M tasks for the current round.
+        """Produce a ``CandidatePool`` for the current round.
 
-        - ``mode="fixed"``: skip LLM, return a single ``kind="fixed"`` entry
-        - ``mode="planned"`` or ``"mixed"``: call the LLM planner and include
-          a canonical fixed entry alongside the planned ones
+        ``num_parallel`` is the number of subagent slots to plan for —
+        which may exceed the physical GPU count under the gwiab-scheduler.
+        It is NOT ``len(gpu_ids)``.
+
+        - ``mode="fixed"``: skip LLM, return a single ``kind="fixed"`` entry.
+        - ``mode="planned"`` or ``"mixed"``: call the LLM planner and ALWAYS
+          include the canonical fixed entry alongside the planned ones, so
+          downstream fill/pad has a guaranteed source for the canonical body.
         """
         from minisweagent.run.compose import ComposeInputs, compose_task_body
 
@@ -92,7 +97,7 @@ class TaskPlanner:
             round_evals=round_evals,
             agent_class=agent_class,
             output_dir=output_dir,
-            num_gpus=num_gpus,
+            num_slots=num_slots,
             rag_enabled=rag_enabled,
         )
 
@@ -110,27 +115,19 @@ class TaskPlanner:
                 )
             )
 
-        # Only inject fixed-canonical when planned tasks don't fill all GPU slots
-        planned_gpu_total = sum(c.num_gpus for c in candidates)
-        if planned_gpu_total < num_gpus:
-            candidates.append(canonical_fixed)
-            logger.info(
-                "TaskPlanner: round %d pool has %d candidates (%d planned, 1 fixed fallback; planned %d/%d GPUs)",
-                round_num,
-                len(candidates),
-                len(planned_tasks),
-                planned_gpu_total,
-                num_gpus,
-            )
-        else:
-            logger.info(
-                "TaskPlanner: round %d pool has %d candidates (%d planned, no fixed needed; planned %d/%d GPUs)",
-                round_num,
-                len(candidates),
-                len(planned_tasks),
-                planned_gpu_total,
-                num_gpus,
-            )
+        # Always inject canonical_fixed so pool.fixed is never empty.
+        # The dispatcher's fill/pad paths rely on this body to top up
+        # subagent slots the planner did not produce a task for.
+        candidates.append(canonical_fixed)
+        planned_slot_total = sum(c.num_gpus for c in candidates if c.kind == "planned")
+        logger.info(
+            "TaskPlanner: round %d pool has %d candidates (%d planned + 1 canonical fixed; planned slots %d/%d)",
+            round_num,
+            len(candidates),
+            len(planned_tasks),
+            planned_slot_total,
+            num_slots,
+        )
         return CandidatePool(round_num=round_num, items=tuple(candidates))
 
     def _call_llm_planner(
@@ -141,7 +138,7 @@ class TaskPlanner:
         round_evals: list[dict[str, Any]],
         agent_class: type,
         output_dir: Path | None = None,
-        num_gpus: int = 1,
+        num_slots: int = 1,
         rag_enabled: bool = False,
     ) -> list[Any]:
         """Delegate to the existing ``task_generator.generate_tasks``."""
@@ -170,7 +167,7 @@ class TaskPlanner:
             previous_tasks_dir=Path(output_dir) / "tasks" if output_dir else None,
             round_evaluations=round_evals,
             current_round=round_num,
-            num_gpus=num_gpus,
+            num_gpus=num_slots,
             output_dir=Path(output_dir) / "tasks" / f"round_{round_num}" if output_dir else None,
             rag_enabled=rag_enabled,
             subagent_registry=self._subagent_registry,

--- a/src/minisweagent/run/planner/task_planner.py
+++ b/src/minisweagent/run/planner/task_planner.py
@@ -97,7 +97,7 @@ class TaskPlanner:
             round_evals=round_evals,
             agent_class=agent_class,
             output_dir=output_dir,
-            num_slots=num_slots,
+            num_slots=num_parallel,
             rag_enabled=rag_enabled,
         )
 
@@ -126,7 +126,7 @@ class TaskPlanner:
             len(candidates),
             len(planned_tasks),
             planned_slot_total,
-            num_slots,
+            num_parallel,
         )
         return CandidatePool(round_num=round_num, items=tuple(candidates))
 

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -39,6 +39,7 @@ from minisweagent.run.postprocess.benchmark_parsing import (
 )
 from minisweagent.run.utils.generated_artifacts import (
     apply_patch_with_generated_helper_fallback,
+    jit_cache_env,
 )
 from minisweagent.run.utils.git_safe_env import get_git_safe_env
 
@@ -329,6 +330,11 @@ def build_eval_env(
             pass
     pp_parts.append(env.get("PYTHONPATH", ""))
     env["PYTHONPATH"] = ":".join(p for p in pp_parts if p)
+    # Relocate Triton / JIT caches to a per-worktree dir OUTSIDE ``work_dir`` so
+    # the eval-side patch capture / re-apply A/B never sweeps compiled blobs into
+    # the diff and the patched kernel is always recompiled fresh (mirrors the
+    # reactor-side save_and_test._build_test_env relocation).
+    env.update(jit_cache_env(work_dir))
     alloc_conf = env.get("PYTORCH_CUDA_ALLOC_CONF", "")
     if "expandable_segments" in alloc_conf:
         logger.debug("build_eval_env: removing PYTORCH_CUDA_ALLOC_CONF with expandable_segments.")

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -22,6 +22,11 @@ import time
 from pathlib import Path
 from typing import Any
 
+from minisweagent.run.pipeline_types import (
+    FullBenchmarkResult,
+    PerTaskOutcome,
+    RoundEvaluation,
+)
 from minisweagent.run.postprocess.benchmark_parsing import (
     compute_shape_speedups,
     compute_speedup,
@@ -994,8 +999,6 @@ def write_eval_results(
         fb_output_path = output_dir / f"round_{round_num}_full_benchmark.txt"
         fb_output_path.write_text(fb_raw["stdout"])
 
-    from minisweagent.run.pipeline_types import FullBenchmarkResult, PerTaskOutcome, RoundEvaluation
-
     fb_typed = None
     if isinstance(fb_raw, dict):
         failure = None
@@ -1050,26 +1053,46 @@ def evaluate_round_best(
     # --- Collect candidates ---
     task_files_dir = output_dir / "tasks" / f"round_{round_num}"
     candidates: list[dict[str, Any]] = []
+    # Dispatched candidates that failed / produced no improvement. Recorded so
+    # the dispatcher's adaptive-K success-rate penalty sees per-source totals
+    # (not just the survivors). Their speedups are dropped by the plausibility
+    # clamp downstream; only the per-kind counts matter.
+    failed_outcomes: list[dict[str, Any]] = []
+
+    def _record_failed(label: str, spd: float = 0.0) -> None:
+        failed_outcomes.append(
+            {
+                "label": label,
+                "kind": _resolve_task_kind(task_files_dir, label),
+                "speedup": spd,
+                "status": "failed",
+            }
+        )
+
     for task_dir in sorted(results_dir.iterdir()):
         if not task_dir.is_dir() or task_dir.name == "worktrees":
             continue
         br_file = task_dir / "best_results.json"
         if not br_file.exists():
             logger.warning("No best_results.json in %s", task_dir.name)
+            _record_failed(task_dir.name)
             continue
         try:
             br = json.loads(br_file.read_text())
         except (json.JSONDecodeError, ValueError, TypeError) as exc:
             logger.warning("Failed to parse %s: %s", br_file, exc)
+            _record_failed(task_dir.name)
             continue
 
         speedup = float(br.get("best_patch_speedup", 0))
         patch_file = br.get("best_patch_file")
         if not patch_file:
             logger.warning("No patch file in %s", br_file)
+            _record_failed(task_dir.name, speedup)
             continue
         if speedup <= 0:
             logger.info("No improvement (speedup=%.4f) in %s", speedup, task_dir.name)
+            _record_failed(task_dir.name, speedup)
             continue
 
         kernel_time: float | None = None
@@ -1176,9 +1199,9 @@ def evaluate_round_best(
         round_eval["candidate_shape_latency_ms"] = best["candidate_shape_latency_ms"]
 
     round_eval["per_task"] = [
-        {"label": c["task"], "kind": c.get("kind", "planned"), "speedup": c["speedup"]}
+        {"label": c["task"], "kind": c.get("kind", "planned"), "speedup": c["speedup"], "status": "ok"}
         for c in candidates
-    ]
+    ] + failed_outcomes
 
     # --- GEAK_AGENT_SELECT_PATCH: trust agent-reported speedup, skip eval ---
     if os.environ.get("GEAK_AGENT_SELECT_PATCH", "").strip() == "1":
@@ -1197,10 +1220,12 @@ def evaluate_round_best(
         logger.warning("COMMANDMENT.md not found at %s; skipping FULL_BENCHMARK and PROFILE", commandment_path)
         eval_path = output_dir / f"round_{round_num}_evaluation.json"
         eval_path.write_text(json.dumps(round_eval, indent=2, default=str))
-        from minisweagent.run.pipeline_types import RoundEvaluation
-
         return RoundEvaluation(
-            round=round_num, best_patch=best_patch_file or "", best_task=best_task, benchmark_speedup=best_speedup
+            round=round_num,
+            best_patch=best_patch_file or "",
+            best_task=best_task,
+            benchmark_speedup=best_speedup,
+            per_task=[PerTaskOutcome.from_dict(o) for o in round_eval.get("per_task", [])],
         )
 
     repo_root = ctx.get("repo_root")
@@ -1229,14 +1254,13 @@ def evaluate_round_best(
         round_eval["status"] = "patch_failed"
         eval_path = output_dir / f"round_{round_num}_evaluation.json"
         eval_path.write_text(json.dumps(round_eval, indent=2, default=str))
-        from minisweagent.run.pipeline_types import FullBenchmarkResult, RoundEvaluation
-
         return RoundEvaluation(
             round=round_num,
             best_patch=best_patch_file or "",
             best_task=best_task,
             benchmark_speedup=best_speedup,
             full_benchmark=FullBenchmarkResult(failure_reason=f"patch apply failed: {exc}"),
+            per_task=[PerTaskOutcome.from_dict(o) for o in round_eval.get("per_task", [])],
         )
 
     try:

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -365,8 +365,26 @@ def preflight_commandment_contract(
 
         preflight_dir = (Path(output_dir) / "_preflight_worktree").resolve()
         create_worktree(repo_root_path, preflight_dir)
+
+        # The COMMANDMENT references the sanitized harness via
+        # ``${GEAK_WORK_DIR}_logs/...`` (repo_root rewritten to GEAK_WORK_DIR
+        # in tools.py). Per-agent worktrees get a matching ``<worktree>_logs``
+        # sibling, but the bare worktree created here does not — so mirror the
+        # sanitized scripts into ``<preflight_dir>_logs`` so those references
+        # resolve. ``output_dir`` is the original ``<repo_root>_logs`` dir.
+        preflight_logs_dir = Path(str(preflight_dir) + "_logs")
+        try:
+            shutil.copytree(output_dir, preflight_logs_dir, dirs_exist_ok=True)
+        except (OSError, shutil.Error) as exc:
+            logger.warning(
+                "preflight_commandment_contract: could not mirror %s -> %s: %s",
+                output_dir,
+                preflight_logs_dir,
+                exc,
+            )
     else:
         preflight_dir = repo_root_path
+        preflight_logs_dir = None
 
     try:
         env = build_eval_env(preflight_dir, str(repo_root_path), harness_path, gpu_ids)
@@ -432,6 +450,8 @@ def preflight_commandment_contract(
     finally:
         if preflight_dir != repo_root_path:
             cleanup_eval_worktree(repo_root, preflight_dir)
+            if preflight_logs_dir is not None:
+                shutil.rmtree(preflight_logs_dir, ignore_errors=True)
 
 
 def recapture_commandment_baseline(

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -94,6 +94,29 @@ def _stderr_indicates_broken_contract(stderr: str) -> str | None:
     return None
 
 
+# Stderr signatures of transient/environmental GPU failures that are unrelated
+# to the kernel or the COMMANDMENT contract — typically a momentary ROCm hiccup
+# under heavy worker oversubscription. These should NOT abort the whole task.
+_TRANSIENT_GPU_PATTERNS: tuple[str, ...] = (
+    "No HIP GPUs are available",
+    "No CUDA GPUs are available",
+    "HIP error",
+    "hipErrorNoDevice",
+    "CUDA error: out of memory",
+    "HSA_STATUS_ERROR",
+)
+
+
+def _stderr_indicates_transient_gpu_error(stderr: str) -> str | None:
+    """Return the first transient-GPU signature found in *stderr*, or None."""
+    if not stderr:
+        return None
+    for pattern in _TRANSIENT_GPU_PATTERNS:
+        if pattern in stderr:
+            return pattern
+    return None
+
+
 def _format_stderr_tail(stderr: str, *, max_lines: int = 20) -> str:
     """Return the last *max_lines* of *stderr*, joined for log inclusion."""
     if not stderr:
@@ -145,6 +168,11 @@ def setup_eval_worktree(repo_root: str, patch_file: str, output_dir: Path) -> Pa
         )
         logger.warning("Initialised temporary git repo in non-git eval worktree: %s", eval_dir)
 
+    # The COMMANDMENT references the sanitized harness via ``${GEAK_WORK_DIR}_logs/...``
+    # which at eval time resolves to ``<eval_dir>_logs``; mirror the original _logs
+    # dir there so those references resolve. Cleaned up by cleanup_eval_worktree.
+    mirror_sanitized_logs(output_dir, eval_dir)
+
     git_env = get_git_safe_env(output_dir)
     patch_text = patch_path.read_text(encoding="utf-8", errors="replace")
     # errors="replace" is the Unicode error handling mode for str.decode()
@@ -183,8 +211,31 @@ def setup_eval_worktree(repo_root: str, patch_file: str, output_dir: Path) -> Pa
     return eval_dir
 
 
+def mirror_sanitized_logs(output_dir: Path, worktree_dir: Path) -> Path | None:
+    """Mirror the original ``_logs`` dir next to a temporary worktree.
+
+    The COMMANDMENT references the sanitized harness via
+    ``${GEAK_WORK_DIR}_logs/_geak_sanitized_test_kernel_harness.sh`` (the
+    original repo_root is rewritten to ``${GEAK_WORK_DIR}`` in
+    preprocess_v3/tools.py). At runtime ``GEAK_WORK_DIR`` is the worktree, so
+    those references resolve to a ``<worktree>_logs`` sibling. Per-agent
+    worktrees get that sibling automatically; the bare worktrees created for
+    preflight / round-eval do not — so copy ``output_dir`` (the original
+    ``<repo_root>_logs`` dir) to ``<worktree>_logs``.
+
+    Returns the mirrored path (for later cleanup), or ``None`` on failure.
+    """
+    logs_dir = Path(str(worktree_dir) + "_logs")
+    try:
+        shutil.copytree(output_dir, logs_dir, dirs_exist_ok=True)
+        return logs_dir
+    except (OSError, shutil.Error) as exc:
+        logger.warning("mirror_sanitized_logs: could not mirror %s -> %s: %s", output_dir, logs_dir, exc)
+        return None
+
+
 def cleanup_eval_worktree(repo_root: str, eval_dir: Path) -> None:
-    """Remove the temporary evaluation worktree."""
+    """Remove the temporary evaluation worktree (and its mirrored _logs)."""
     repo = Path(repo_root).resolve()
     is_git = (repo / ".git").exists() or (repo / ".git").is_file()
     if is_git:
@@ -198,6 +249,10 @@ def cleanup_eval_worktree(repo_root: str, eval_dir: Path) -> None:
         )
     if eval_dir.exists():
         shutil.rmtree(eval_dir, ignore_errors=True)
+    # Remove the mirrored ``<worktree>_logs`` sibling if present.
+    logs_sibling = Path(str(eval_dir) + "_logs")
+    if logs_sibling.exists():
+        shutil.rmtree(logs_sibling, ignore_errors=True)
 
 
 def build_eval_env(
@@ -365,26 +420,11 @@ def preflight_commandment_contract(
 
         preflight_dir = (Path(output_dir) / "_preflight_worktree").resolve()
         create_worktree(repo_root_path, preflight_dir)
-
-        # The COMMANDMENT references the sanitized harness via
-        # ``${GEAK_WORK_DIR}_logs/...`` (repo_root rewritten to GEAK_WORK_DIR
-        # in tools.py). Per-agent worktrees get a matching ``<worktree>_logs``
-        # sibling, but the bare worktree created here does not — so mirror the
-        # sanitized scripts into ``<preflight_dir>_logs`` so those references
-        # resolve. ``output_dir`` is the original ``<repo_root>_logs`` dir.
-        preflight_logs_dir = Path(str(preflight_dir) + "_logs")
-        try:
-            shutil.copytree(output_dir, preflight_logs_dir, dirs_exist_ok=True)
-        except (OSError, shutil.Error) as exc:
-            logger.warning(
-                "preflight_commandment_contract: could not mirror %s -> %s: %s",
-                output_dir,
-                preflight_logs_dir,
-                exc,
-            )
+        # Mirror the original _logs dir so ``${GEAK_WORK_DIR}_logs/...`` references
+        # in the COMMANDMENT resolve inside the worktree (see mirror_sanitized_logs).
+        mirror_sanitized_logs(output_dir, preflight_dir)
     else:
         preflight_dir = repo_root_path
-        preflight_logs_dir = None
 
     try:
         env = build_eval_env(preflight_dir, str(repo_root_path), harness_path, gpu_ids)
@@ -434,6 +474,22 @@ def preflight_commandment_contract(
                 time.sleep(5)
 
         stderr_tail = _format_stderr_tail(last_result.stderr)
+
+        # A transient/environmental GPU error (e.g. a momentary "No HIP GPUs"
+        # under heavy worker oversubscription) is not a contract break. The
+        # preflight is only an upfront smoke test, so skip it rather than abort
+        # the whole task — the per-round eval will still catch real failures.
+        transient = _stderr_indicates_transient_gpu_error(last_result.stderr)
+        if transient is not None:
+            logger.warning(
+                "preflight_commandment_contract: skipped after %d attempts due to transient "
+                "GPU error %r (not a contract break); proceeding to optimization:\n%s",
+                max_attempts,
+                transient,
+                stderr_tail,
+            )
+            return
+
         broken = _stderr_indicates_broken_contract(last_result.stderr)
         detail = (
             f"contract-broken signature {broken!r}; stderr tail:\n{stderr_tail}"
@@ -450,8 +506,6 @@ def preflight_commandment_contract(
     finally:
         if preflight_dir != repo_root_path:
             cleanup_eval_worktree(repo_root, preflight_dir)
-            if preflight_logs_dir is not None:
-                shutil.rmtree(preflight_logs_dir, ignore_errors=True)
 
 
 def recapture_commandment_baseline(

--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -84,6 +84,19 @@ _CONTRACT_BROKEN_PATTERNS: tuple[str, ...] = (
 )
 
 
+def _resolve_task_kind(task_files_dir: Path, label: str) -> str:
+    """Look up ``kind`` from the task file whose label matches *label*."""
+    if not task_files_dir.is_dir():
+        return "planned"
+    for tf in task_files_dir.iterdir():
+        if tf.suffix == ".md" and label in tf.stem:
+            from minisweagent.run.task_file import read_task_file
+
+            meta, _ = read_task_file(tf)
+            return meta.get("kind", "planned")
+    return "planned"
+
+
 def _stderr_indicates_broken_contract(stderr: str) -> str | None:
     """Return the first contract-broken signature found in *stderr*, or None."""
     if not stderr:
@@ -981,7 +994,7 @@ def write_eval_results(
         fb_output_path = output_dir / f"round_{round_num}_full_benchmark.txt"
         fb_output_path.write_text(fb_raw["stdout"])
 
-    from minisweagent.run.pipeline_types import FullBenchmarkResult, RoundEvaluation
+    from minisweagent.run.pipeline_types import FullBenchmarkResult, PerTaskOutcome, RoundEvaluation
 
     fb_typed = None
     if isinstance(fb_raw, dict):
@@ -993,10 +1006,6 @@ def write_eval_results(
         elif not fb_raw.get("success", True) and fb_raw.get("returncode", 0) != 0:
             failure = f"benchmark failed (exit code {fb_raw.get('returncode')})"
         elif fb_raw.get("failure_reason"):
-            # Set by ``_compute_verified_speedup`` when latency parsing failed
-            # despite a clean exit; without this propagation a return-code-0
-            # benchmark with unparseable output looked like "everything passed
-            # but no verified speedup" with no diagnostic.
             failure = str(fb_raw["failure_reason"])
         fb_typed = FullBenchmarkResult(
             verified_speedup=fb_raw.get("verified_speedup"),
@@ -1005,12 +1014,16 @@ def write_eval_results(
             failure_reason=failure,
         )
 
+    pt_raw = round_eval.get("per_task", [])
+    per_task = [PerTaskOutcome.from_dict(o) for o in pt_raw] if pt_raw else []
+
     return RoundEvaluation(
         round=round_num,
         best_patch=round_eval.get("best_patch", ""),
         best_task=round_eval.get("best_task", ""),
         benchmark_speedup=round_eval.get("benchmark_speedup", 1.0),
         full_benchmark=fb_typed,
+        per_task=per_task,
     )
 
 
@@ -1035,6 +1048,7 @@ def evaluate_round_best(
         return None
 
     # --- Collect candidates ---
+    task_files_dir = output_dir / "tasks" / f"round_{round_num}"
     candidates: list[dict[str, Any]] = []
     for task_dir in sorted(results_dir.iterdir()):
         if not task_dir.is_dir() or task_dir.name == "worktrees":
@@ -1076,6 +1090,7 @@ def evaluate_round_best(
                 "patch_file": patch_file,
                 "speedup": speedup,
                 "kernel_time_ms": kernel_time,
+                "kind": _resolve_task_kind(task_files_dir, task_dir.name),
                 "per_shape_speedups": br.get("per_shape_speedups") or {},
                 "baseline_shape_latency_ms": br.get("baseline_shape_latency_ms") or {},
                 "candidate_shape_latency_ms": br.get("candidate_shape_latency_ms") or {},
@@ -1159,6 +1174,11 @@ def evaluate_round_best(
         round_eval["baseline_shape_latency_ms"] = best["baseline_shape_latency_ms"]
     if best.get("candidate_shape_latency_ms"):
         round_eval["candidate_shape_latency_ms"] = best["candidate_shape_latency_ms"]
+
+    round_eval["per_task"] = [
+        {"label": c["task"], "kind": c.get("kind", "planned"), "speedup": c["speedup"]}
+        for c in candidates
+    ]
 
     # --- GEAK_AGENT_SELECT_PATCH: trust agent-reported speedup, skip eval ---
     if os.environ.get("GEAK_AGENT_SELECT_PATCH", "").strip() == "1":

--- a/src/minisweagent/run/preprocess/commandment.py
+++ b/src/minisweagent/run/preprocess/commandment.py
@@ -48,6 +48,13 @@ from minisweagent.run.preprocess.validate_commandment import (
     format_validation_message,
     validate_commandment,
 )
+from minisweagent.run.section_builders import (
+    build_benchmark_body,
+    build_correctness_body,
+    build_full_benchmark_body,
+    build_profile_body,
+    warmup_block,
+)
 
 _MAX_FIX_RETRIES = 3
 
@@ -127,19 +134,6 @@ def generate_commandment(
     return _validate_and_fix(content, harness_path=str(harness_path))
 
 
-def _warmup_block(command: str, warmup_runs: int) -> str:
-    """Build the warmup section for the PROFILE block.
-
-    Returns a single command for 1 run, or a bash for-loop for multiple runs
-    (avoids emitting duplicate identical lines).
-    """
-    if warmup_runs <= 0:
-        return ""
-    if warmup_runs == 1:
-        return command
-    return f"for _i in $(seq 1 {warmup_runs}); do {command}; done"
-
-
 def _detect_build_command(repo_root: Path) -> str:
     """Return the appropriate build command for a C++ repo."""
     if (repo_root / "setup.py").exists() or (repo_root / "pyproject.toml").exists():
@@ -169,10 +163,7 @@ def _generate_simple(
       * ``GEAK_GPU_DEVICE`` -- GPU device ID
     """
     harness_abs = str(harness_path.resolve())
-    warmup_block = _warmup_block(
-        f"${{GEAK_WORK_DIR}}/run.sh {harness_abs} --profile > /dev/null 2>&1 || true",
-        warmup_runs,
-    )
+    base_cmd = f"${{GEAK_WORK_DIR}}/run.sh {harness_abs}"
 
     if kernel_language in ("cpp", "hip"):
         build_cmd = _detect_build_command(repo_root)
@@ -199,17 +190,16 @@ def _generate_simple(
 {setup_section}
 
 ## CORRECTNESS
-${{GEAK_WORK_DIR}}/run.sh {harness_abs} --correctness
+{build_correctness_body(base_cmd)}
 
 ## PROFILE
-{warmup_block}
-kernel-profile "${{GEAK_WORK_DIR}}/run.sh {harness_abs} --profile" --gpu-devices ${{GEAK_GPU_DEVICE}} --replays {profile_replays} --json -o ${{GEAK_WORK_DIR}}/profile.json
+{build_profile_body(base_cmd, warmup_runs=warmup_runs, profile_replays=profile_replays)}
 
 ## BENCHMARK
-${{GEAK_WORK_DIR}}/run.sh {harness_abs} --full-benchmark ${{GEAK_BENCHMARK_EXTRA_ARGS:-}}
+{build_benchmark_body(base_cmd)}
 
 ## FULL_BENCHMARK
-${{GEAK_WORK_DIR}}/run.sh {harness_abs} --full-benchmark ${{GEAK_BENCHMARK_EXTRA_ARGS:-}}
+{build_full_benchmark_body(base_cmd)}
 """
 
 
@@ -244,11 +234,6 @@ def _generate_inner_kernel(
     # Copy candidate to the correct import path
     copy_cmd = f"cp ${{GEAK_WORK_DIR}}/{kernel_path.name} ${{GEAK_WORK_DIR}}/{rel_dir}/{basename}"
 
-    warmup_block = _warmup_block(
-        "${GEAK_WORK_DIR}/run_harness.sh --profile > /dev/null 2>&1 || true",  # harness path is baked into run_harness.sh
-        warmup_runs,
-    )
-
     setup_lines = [
         f"mkdir -p {mkdir_path}",
         copy_cmd,
@@ -265,23 +250,23 @@ def _generate_inner_kernel(
     )
 
     setup_block = "\n".join(setup_lines)
+    base_cmd = "${GEAK_WORK_DIR}/run_harness.sh"
 
     return f"""\
 ## SETUP
 {setup_block}
 
 ## CORRECTNESS
-${{GEAK_WORK_DIR}}/run_harness.sh --correctness
+{build_correctness_body(base_cmd)}
 
 ## PROFILE
-{warmup_block}
-kernel-profile "${{GEAK_WORK_DIR}}/run_harness.sh --profile" --gpu-devices ${{GEAK_GPU_DEVICE}} --replays {profile_replays} --json -o ${{GEAK_WORK_DIR}}/profile.json
+{build_profile_body(base_cmd, warmup_runs=warmup_runs, profile_replays=profile_replays)}
 
 ## BENCHMARK
-${{GEAK_WORK_DIR}}/run_harness.sh --full-benchmark ${{GEAK_BENCHMARK_EXTRA_ARGS:-}}
+{build_benchmark_body(base_cmd)}
 
 ## FULL_BENCHMARK
-${{GEAK_WORK_DIR}}/run_harness.sh --full-benchmark ${{GEAK_BENCHMARK_EXTRA_ARGS:-}}
+{build_full_benchmark_body(base_cmd)}
 """
 
 
@@ -399,12 +384,12 @@ def generate_commandment_from_commands(
 
     # PROFILE: use correctness command for profiling if no separate profile command
     profile_target = correctness_cmd or performance_cmd or "echo 'no profile target'"
-    warmup_block = _warmup_block(
+    warmup_blk = warmup_block(
         f"cd ${{GEAK_WORK_DIR}} && {profile_target} > /dev/null 2>&1 || true",
         warmup_runs,
     )
     profile_section = (
-        f"{warmup_block}\n"
+        f"{warmup_blk}\n"
         f'kernel-profile "cd ${{GEAK_WORK_DIR}} && {profile_target}" '
         f"--gpu-devices ${{GEAK_GPU_DEVICE}} --replays {profile_replays} "
         f"--json -o ${{GEAK_WORK_DIR}}/profile.json"

--- a/src/minisweagent/run/preprocess/config/mini_kernel_pytorch_to_flydsl.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_kernel_pytorch_to_flydsl.yaml
@@ -109,7 +109,7 @@ agent:
 
 model:
   model_class: amd_llm
-  model_name: claude-opus-4.6
+  model_name: claude-opus-4.7
   api_key: null
   model_kwargs:
     temperature: 0.0

--- a/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
+++ b/src/minisweagent/run/preprocess/config/mini_unit_test_agent.yaml
@@ -405,8 +405,8 @@ env:
 
 model:
   model_class: amd_llm
-  # claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
-  model_name: claude-opus-4.6
+  # claude-opus-4.7, claude-opus-4.6, claude-sonnet-4.5, gpt-5.1, gpt-5, gpt-5-codex
+  model_name: claude-opus-4.7
   api_key: ""
   # model_kwargs:
   #   temperature: 0.0

--- a/src/minisweagent/run/preprocess/eval_contract_adapter.py
+++ b/src/minisweagent/run/preprocess/eval_contract_adapter.py
@@ -308,7 +308,11 @@ def materialize_shell_contract_harness(
             group.add_argument("--benchmark", action="store_true")
             group.add_argument("--full-benchmark", action="store_true")
             args = parser.parse_args()
-            cwd = REPO_ROOT
+            # Honour GEAK_WORK_DIR when present so the wrapper runs inside the
+            # caller's worktree (preflight, agent worktree) rather than always
+            # the repo root baked at synthesis time. Falls back to REPO_ROOT
+            # when no work-dir override is set.
+            cwd = os.environ.get("GEAK_WORK_DIR") or REPO_ROOT
 
             if args.correctness:
                 rc, captured = _run_shell(CORRECTNESS_CMD, cwd)

--- a/src/minisweagent/run/preprocess/harness_utils.py
+++ b/src/minisweagent/run/preprocess/harness_utils.py
@@ -163,14 +163,13 @@ def load_geak_model(
     from minisweagent.config import get_config_path
     from minisweagent.models import get_model
 
-    resolved_name = model_name or os.environ.get("GEAK_MODEL") or "claude-opus-4.6"
     cfg_path = get_config_path(config_spec)
     model_config: dict[str, Any] = {}
     if cfg_path.exists():
         full_cfg = yaml.safe_load(cfg_path.read_text()) or {}
         model_config = full_cfg.get("model", {})
 
-    return get_model(resolved_name, config=model_config)
+    return get_model(model_name, config=model_config)
 
 
 def geak_model_factory(
@@ -184,7 +183,6 @@ def geak_model_factory(
     from minisweagent.config import get_config_path
     from minisweagent.models import get_model
 
-    resolved_name = model_name or os.environ.get("GEAK_MODEL") or "claude-opus-4.6"
     cfg_path = get_config_path(config_spec)
     model_config: dict[str, Any] = {}
     if cfg_path.exists():
@@ -192,7 +190,7 @@ def geak_model_factory(
         model_config = full_cfg.get("model", {})
 
     def _factory():
-        return get_model(resolved_name, config=copy.deepcopy(model_config))
+        return get_model(model_name, config=copy.deepcopy(model_config))
 
     return _factory
 

--- a/src/minisweagent/run/preprocess/profiler_runner.py
+++ b/src/minisweagent/run/preprocess/profiler_runner.py
@@ -21,6 +21,7 @@ Two non-obvious requirements:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import multiprocessing as mp
 import os
@@ -29,7 +30,7 @@ import signal
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from minisweagent.run.state import PreprocessState
+    from minisweagent.run.state import PreprocessState, ProcessRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ def _profile_in_subproc(
 
 
 def run_profiler_with_handle(
-    state: PreprocessState,
+    state: PreprocessState | None = None,
     *,
     perf_cmd: str,
     backend: str = "metrix",
@@ -115,16 +116,16 @@ def run_profiler_with_handle(
     num_replays: int = 3,
     quick: bool = False,
     timeout_s: float | None = None,
+    registry: ProcessRegistry | None = None,
 ) -> dict | None:
     """Run profile_kernel in a child process; return its result or ``None``.
 
-    ``state.registry`` tracks the process so the watchdog or SIGINT handler
-    can ``terminate_all()`` it. The function returns ``None`` if the profile
-    was terminated, raised, or produced no result.
+    The process is tracked via *registry* (or ``state.registry``) so the
+    watchdog / SIGINT handler can ``terminate_all()`` it. Returns ``None``
+    if the profile was terminated, raised, or produced no result.
     """
-    # Use the spawn context to avoid inheriting the parent's CUDA/HIP state,
-    # threadpools, and import side effects -- a forked child can deadlock
-    # CUDA's runtime, and several profiler backends are sensitive to that.
+    _registry = registry or (state.registry if state else None)
+
     ctx = mp.get_context("spawn")
     q: mp.Queue = ctx.Queue()
     proc = ctx.Process(
@@ -134,7 +135,8 @@ def run_profiler_with_handle(
         daemon=False,
     )
 
-    with state.registry.track_mp(proc):
+    _ctx_mgr = _registry.track_mp(proc) if _registry else contextlib.nullcontext()
+    with _ctx_mgr:
         proc.start()
         try:
             proc.join(timeout=timeout_s)

--- a/src/minisweagent/run/preprocess_v3/baseline.py
+++ b/src/minisweagent/run/preprocess_v3/baseline.py
@@ -70,6 +70,11 @@ _CORRECTNESS_GATE_TIMEOUT_S = int(
     )
 )
 
+#: Short timeout for the correctness gate that runs before baseline collection.
+#: Goal: fail in ~5 s on a broken kernel rather than spending ~5 min running
+#: the full benchmark loop. Override via ``GEAK_CORRECTNESS_GATE_TIMEOUT``.
+_CORRECTNESS_GATE_TIMEOUT_S = int(os.environ.get("GEAK_CORRECTNESS_GATE_TIMEOUT", "120"))
+
 
 @dataclass(frozen=True)
 class BaselineMetrics:

--- a/src/minisweagent/run/preprocess_v3/tools.py
+++ b/src/minisweagent/run/preprocess_v3/tools.py
@@ -50,7 +50,6 @@ import inspect
 import json
 import logging
 import os
-import shlex
 import shutil
 import time
 from collections.abc import Callable
@@ -70,13 +69,6 @@ from minisweagent.run.preprocess_v3.commandment import (
     render_commandment,
     render_commandment_from_sections,
 )
-from minisweagent.run.section_builders import (
-    build_benchmark_body,
-    build_correctness_body,
-    build_full_benchmark_body,
-    build_profile_body,
-    strip_mode_flags,
-)
 from minisweagent.run.preprocess_v3.discovery import DiscoveryContext, run_legacy_discovery
 from minisweagent.run.preprocess_v3.explore import CodebaseContext, explore_codebase
 from minisweagent.run.preprocess_v3.harness_kb import load_harness_kb
@@ -86,6 +78,13 @@ from minisweagent.run.preprocess_v3.orchestrator import (
 )
 from minisweagent.run.preprocess_v3.registry import SubagentRegistry, SubagentSpec
 from minisweagent.run.preprocess_v3.translate import TranslationResult, translate_to_flydsl
+from minisweagent.run.section_builders import (
+    build_benchmark_body,
+    build_correctness_body,
+    build_full_benchmark_body,
+    build_profile_body,
+    strip_mode_flags,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/minisweagent/run/preprocess_v3/tools.py
+++ b/src/minisweagent/run/preprocess_v3/tools.py
@@ -1396,6 +1396,7 @@ def _make_tool_commandment_from_user_command(
         # standard GEAK harness flag, synthesize a 4-mode wrapper harness using
         # the legacy eval_contract_adapter so collect_baseline / collect_profile
         # have a real harness_path to point at.
+        synthesized: str | None = None
         if not original_harness_path:
             synthesized = _try_synthesize_shell_contract_harness(
                 cmd,
@@ -1440,8 +1441,20 @@ def _make_tool_commandment_from_user_command(
         warnings: list[str] = []
         modes_emitted: list[str] = []
 
-        harness_from_cmd = _extract_harness_from_command(cmd)
-        use_run_sh = harness_from_cmd is not None
+        # When we synthesized a shell-contract wrapper above, route the
+        # section bodies through IT — the wrapper accepts the 4-mode flags
+        # (--correctness, --benchmark, --full-benchmark, --profile) and
+        # internally dispatches the user's subcommand-style runner. Without
+        # this branch, `build_correctness_body` would bolt --correctness
+        # onto the user's opaque compound command (e.g. ending in
+        # `task_runner.py performance --correctness`), which the bare
+        # subcommand-style runner rejects with "unrecognized arguments".
+        if synthesized:
+            harness_from_cmd: str | None = synthesized
+            use_run_sh = True
+        else:
+            harness_from_cmd = _extract_harness_from_command(cmd)
+            use_run_sh = harness_from_cmd is not None
 
         if use_run_sh:
             # `_extract_harness_from_command` only matches `python|python3 <path>`

--- a/src/minisweagent/run/preprocess_v3/tools.py
+++ b/src/minisweagent/run/preprocess_v3/tools.py
@@ -1444,7 +1444,11 @@ def _make_tool_commandment_from_user_command(
         use_run_sh = harness_from_cmd is not None
 
         if use_run_sh:
-            base_cmd = f"${{GEAK_WORK_DIR}}/run.sh {harness_from_cmd}"
+            # `_extract_harness_from_command` only matches `python|python3 <path>`
+            # invocations and returns just the path. The run.sh template execs
+            # its args via `bash -lc "$*"`, which would try to exec the .py
+            # directly (Permission denied, rc=126) without an interpreter prefix.
+            base_cmd = f"${{GEAK_WORK_DIR}}/run.sh python3 {harness_from_cmd}"
         elif cmd.startswith("cd ${GEAK_WORK_DIR}"):
             base_cmd = strip_mode_flags(cmd)
         else:

--- a/src/minisweagent/run/preprocess_v3/tools.py
+++ b/src/minisweagent/run/preprocess_v3/tools.py
@@ -70,6 +70,13 @@ from minisweagent.run.preprocess_v3.commandment import (
     render_commandment,
     render_commandment_from_sections,
 )
+from minisweagent.run.section_builders import (
+    build_benchmark_body,
+    build_correctness_body,
+    build_full_benchmark_body,
+    build_profile_body,
+    strip_mode_flags,
+)
 from minisweagent.run.preprocess_v3.discovery import DiscoveryContext, run_legacy_discovery
 from minisweagent.run.preprocess_v3.explore import CodebaseContext, explore_codebase
 from minisweagent.run.preprocess_v3.harness_kb import load_harness_kb
@@ -106,45 +113,6 @@ _MODE_TO_FLAG: dict[str, str] = {
     "benchmark": "--benchmark",
     "full_benchmark": "--full-benchmark",
 }
-
-
-def _substitute_mode_flag(cmd: str, target_mode: str) -> str:
-    """Ensure *cmd* contains *target_mode*'s harness flag.
-
-    Three cases:
-    1. *cmd* already has the right flag → return unchanged.
-    2. *cmd* has a different known flag → replace it.
-    3. *cmd* has no known flag at all → return unchanged (safe fallback).
-    """
-    dst_flag = _MODE_TO_FLAG.get(target_mode)
-    if not dst_flag:
-        return cmd
-    if dst_flag in cmd:
-        return cmd
-    for other_mode, other_flag in _MODE_TO_FLAG.items():
-        if other_mode != target_mode and other_flag in cmd:
-            return cmd.replace(other_flag, dst_flag)
-    return cmd
-
-
-_DEFAULT_PROFILE_REPLAYS = 5
-
-
-def _build_profile_section(profile_cmd: str) -> str:
-    """Wrap a ``--profile`` harness invocation with warmup + ``kernel-profile``.
-
-    Matches the PROFILE section that Path B's ``render_commandment`` produces:
-    one warmup pass (suppressed stdout), then ``kernel-profile`` wrapping the
-    same command to capture hardware counters and write ``profile.json``.
-    """
-    warmup = f"{profile_cmd} > /dev/null 2>&1 || true"
-    kernel_profile = (
-        f'kernel-profile "{profile_cmd}"'
-        f" --gpu-devices ${{GEAK_GPU_DEVICE}}"
-        f" --replays {_DEFAULT_PROFILE_REPLAYS}"
-        f" --json -o ${{GEAK_WORK_DIR}}/profile.json"
-    )
-    return f"{warmup}\n{kernel_profile}"
 
 
 def _extract_harness_from_command(cmd: str) -> str | None:
@@ -1472,25 +1440,31 @@ def _make_tool_commandment_from_user_command(
         warnings: list[str] = []
         modes_emitted: list[str] = []
 
-        # Invoke through run.sh so every Path-A section uses the same
-        # PYTHONPATH/HIP_VISIBLE_DEVICES/worktree contract as legacy
-        # COMMANDMENT generation while still supporting compound shell
-        # commands such as "compile && correctness && performance".
-        wrapped_cmd = f"${{GEAK_WORK_DIR}}/run.sh {shlex.quote(cmd)}"
+        harness_from_cmd = _extract_harness_from_command(cmd)
+        use_run_sh = harness_from_cmd is not None
+
+        if use_run_sh:
+            base_cmd = f"${{GEAK_WORK_DIR}}/run.sh {harness_from_cmd}"
+        elif cmd.startswith("cd ${GEAK_WORK_DIR}"):
+            base_cmd = strip_mode_flags(cmd)
+        else:
+            base_cmd = strip_mode_flags(f"cd ${{GEAK_WORK_DIR}} && {cmd}")
+
+        section_builders: dict[str, Callable[[str], str]] = {
+            "correctness": build_correctness_body,
+            "profile": build_profile_body,
+            "benchmark": build_benchmark_body,
+            "full_benchmark": build_full_benchmark_body,
+        }
         for mode in PATH_A_MODES:
+            body = section_builders[mode](base_cmd)
             if mode in modes_covered_tup:
-                mode_cmd = _substitute_mode_flag(wrapped_cmd, mode)
-                if mode == "profile":
-                    mode_cmd = _build_profile_section(mode_cmd)
-                sections[mode] = mode_cmd
+                sections[mode] = body
                 modes_emitted.append(mode)
             elif mode in inferred_modes_tup:
                 src = source_mode or "<unspecified>"
-                inferred_cmd = _substitute_mode_flag(wrapped_cmd, mode)
-                if mode == "profile":
-                    inferred_cmd = _build_profile_section(inferred_cmd)
                 marker_line = f"# PATH_A_PARTIAL_COVERAGE: {mode} inferred from {src}"
-                sections[mode] = f"{marker_line}\n{inferred_cmd}"
+                sections[mode] = f"{marker_line}\n{body}"
                 warnings.append(f"PATH_A_PARTIAL_COVERAGE: {mode} inferred from {src}")
                 modes_emitted.append(mode)
             else:

--- a/src/minisweagent/run/section_builders.py
+++ b/src/minisweagent/run/section_builders.py
@@ -1,0 +1,71 @@
+"""Shared COMMANDMENT section body builders.
+
+Both Path A (``commandment_from_user_command``) and Path B
+(``_generate_simple`` / ``_generate_inner_kernel``) call these helpers
+to produce the body strings for each COMMANDMENT section, ensuring
+structural parity across paths.
+
+This module is deliberately dependency-free (stdlib only) so it can be
+imported from both ``preprocess/`` and ``preprocess_v3/`` without
+creating circular imports.
+"""
+
+from __future__ import annotations
+
+import re
+
+_MODE_FLAG_PATTERN = re.compile(r"\s+--(?:full-benchmark|benchmark|correctness|profile)\b")
+
+
+def strip_mode_flags(cmd: str) -> str:
+    """Remove all known harness mode flags from *cmd*.
+
+    Uses regex with longest-first alternation so ``--full-benchmark`` is
+    matched whole before ``--benchmark`` gets a chance.
+    """
+    return _MODE_FLAG_PATTERN.sub("", cmd).strip()
+
+
+def warmup_block(command: str, warmup_runs: int) -> str:
+    """Build the warmup sub-section for the PROFILE block."""
+    if warmup_runs <= 0:
+        return ""
+    if warmup_runs == 1:
+        return command
+    return f"for _i in $(seq 1 {warmup_runs}); do {command}; done"
+
+
+def build_correctness_body(base_cmd: str) -> str:
+    """Generate the CORRECTNESS section body."""
+    return f"{base_cmd} --correctness"
+
+
+def build_profile_body(
+    base_cmd: str,
+    *,
+    warmup_runs: int = 2,
+    profile_replays: int = 3,
+) -> str:
+    """Generate the PROFILE section body (warmup + kernel-profile)."""
+    profile_cmd = f"{base_cmd} --profile"
+    warmup = warmup_block(
+        f"{profile_cmd} > /dev/null 2>&1 || true",
+        warmup_runs,
+    )
+    kernel_profile = (
+        f'kernel-profile "{profile_cmd}"'
+        f" --gpu-devices ${{GEAK_GPU_DEVICE}}"
+        f" --replays {profile_replays}"
+        f" --json -o ${{GEAK_WORK_DIR}}/profile.json"
+    )
+    return f"{warmup}\n{kernel_profile}" if warmup else kernel_profile
+
+
+def build_benchmark_body(base_cmd: str) -> str:
+    """Generate the BENCHMARK section body (uses ``--full-benchmark``)."""
+    return f"{base_cmd} --full-benchmark ${{GEAK_BENCHMARK_EXTRA_ARGS:-}}"
+
+
+def build_full_benchmark_body(base_cmd: str) -> str:
+    """Generate the FULL_BENCHMARK section body (uses ``--full-benchmark``)."""
+    return f"{base_cmd} --full-benchmark ${{GEAK_BENCHMARK_EXTRA_ARGS:-}}"

--- a/src/minisweagent/run/unified.py
+++ b/src/minisweagent/run/unified.py
@@ -93,6 +93,7 @@ class PipelineContext:
     # test sweep to validate preprocessing without paying the 30-90 minute
     # optimization round loop cost per kernel-scenario.
     preprocess_only: bool = False
+    gpu_manager: Any = None
 
 
 # ── Tool resolution ───────────────────────────────────────────────────
@@ -185,6 +186,7 @@ def _build_postprocess_ctx(pipeline_ctx: PipelineContext) -> dict[str, Any]:
         "registry": pipeline_ctx.registry,
         "user_instructions": pipeline_ctx.user_prompt,
         "rag_enabled": pipeline_ctx.rag_enabled,
+        "gpu_manager": pipeline_ctx.gpu_manager,
     }
 
 
@@ -602,6 +604,8 @@ def _run_unified_loop(ctx: PipelineContext, mode: Mode) -> Any:
             deadline=ctx.deadline,
             soft_stop=ctx.soft_stop,
             registry=ctx.registry,
+            gpu_manager=ctx.gpu_manager,
+            num_parallel=n_workers,
         )
 
         # 5. EVALUATE — FULL_BENCHMARK verification (all modes)

--- a/src/minisweagent/run/unified.py
+++ b/src/minisweagent/run/unified.py
@@ -94,6 +94,7 @@ class PipelineContext:
     # optimization round loop cost per kernel-scenario.
     preprocess_only: bool = False
     gpu_manager: Any = None
+    llm_semaphore: Any = None
 
 
 # ── Tool resolution ───────────────────────────────────────────────────
@@ -606,6 +607,7 @@ def _run_unified_loop(ctx: PipelineContext, mode: Mode) -> Any:
             registry=ctx.registry,
             gpu_manager=ctx.gpu_manager,
             num_parallel=n_workers,
+            llm_semaphore=ctx.llm_semaphore,
         )
 
         # 5. EVALUATE — FULL_BENCHMARK verification (all modes)

--- a/src/minisweagent/run/unified.py
+++ b/src/minisweagent/run/unified.py
@@ -582,7 +582,7 @@ def _run_unified_loop(ctx: PipelineContext, mode: Mode) -> Any:
         )
 
         # 2. SELECT — pick N tasks from pool
-        plan = dispatcher.select(pool, mode, n_workers)
+        plan = dispatcher.select(pool, mode, n_workers, round_evals=round_evals)
 
         # 3. WRITE — .md task files for traceability
         task_files = write_dispatch_plan_as_task_files(

--- a/src/minisweagent/run/utils/config_editor.py
+++ b/src/minisweagent/run/utils/config_editor.py
@@ -58,9 +58,14 @@ def parse_edit_command(command: str) -> tuple[str | None, Any]:
         return None, None
 
     # Parse value based on field type
-    if field_name == "num_parallel":
+    if field_name in ("num_parallel", "max_concurrent_llm"):
         try:
             value = int(value)
+        except ValueError:
+            return None, None
+    elif field_name == "gpu_oversubscribe":
+        try:
+            value = float(value)
         except ValueError:
             return None, None
     elif value.lower() in ("none", "null", ""):
@@ -79,7 +84,9 @@ def display_edit_help() -> str:
   --metric=DESCRIPTION     - Set metric description
   --num_parallel=NUMBER    - Set number of parallel agents
   --gpu_ids=IDS            - Set GPU IDs (e.g., "0,1,2,3")
-  
+  --gpu_oversubscribe=FLOAT - Agent-to-GPU multiplier (e.g., 2.0)
+  --max_concurrent_llm=NUM - Cap concurrent LLM requests
+
 [bold green]Other Commands:[/bold green]
   y or Enter               - Proceed with current configuration
   q                        - Abort
@@ -119,6 +126,8 @@ def display_config_with_sources(merged_config: dict, console):
         ("metric", merged_config.get("metric") or "Auto-extract from test output"),
         ("num_parallel", str(merged_config.get("num_parallel") or "1 (default)")),
         ("gpu_ids", merged_config.get("gpu_ids") or "0 (default)"),
+        ("gpu_oversubscribe", str(merged_config.get("gpu_oversubscribe") or "1.0 (default)")),
+        ("max_concurrent_llm", str(merged_config.get("max_concurrent_llm") or "num_parallel (default)")),
         ("patch_output_dir", merged_config.get("_patch_output_dir", "optimization_logs")),
     ]
 
@@ -368,6 +377,8 @@ def load_and_merge_configs(
         "num_parallel": {},
         "gpu_ids": {},
         "patch_output": {},
+        "gpu_oversubscribe": {},
+        "max_concurrent_llm": {},
     }
 
     # Step 1: Collect values from all sources
@@ -406,6 +417,13 @@ def load_and_merge_configs(
             config_sources["gpu_ids"]["yaml"] = str(gpu_ids_value)
     if parallel_config.get("patch_output_dir"):
         config_sources["patch_output"]["yaml"] = Path(parallel_config["patch_output_dir"])
+
+    # gpu_oversubscribe and max_concurrent_llm live under config["parallel"]
+    _parallel_section = config.get("parallel") or {}
+    if _parallel_section.get("gpu_oversubscribe") is not None:
+        config_sources["gpu_oversubscribe"]["yaml"] = float(_parallel_section["gpu_oversubscribe"])
+    if _parallel_section.get("max_concurrent_llm") is not None:
+        config_sources["max_concurrent_llm"]["yaml"] = int(_parallel_section["max_concurrent_llm"])
 
     # Step 2: Auto-detect from task content (highest priority if present)
     parsed_config = None
@@ -446,6 +464,10 @@ def load_and_merge_configs(
                 config_sources["gpu_ids"]["prompt"] = parsed_config["gpu_ids"]
             if parsed_config.get("kernel_name"):
                 kernel_name = parsed_config["kernel_name"]
+            if parsed_config.get("gpu_oversubscribe") is not None:
+                config_sources["gpu_oversubscribe"]["prompt"] = parsed_config["gpu_oversubscribe"]
+            if parsed_config.get("max_concurrent_llm") is not None:
+                config_sources["max_concurrent_llm"]["prompt"] = parsed_config["max_concurrent_llm"]
 
     # Step 3: Merge configurations with priority: prompt > cli > yaml
     # Apply highest priority source for each field
@@ -480,6 +502,8 @@ def load_and_merge_configs(
     num_parallel_value, num_parallel_source = get_highest_priority(config_sources["num_parallel"])
     gpu_ids_value, gpu_ids_source = get_highest_priority(config_sources["gpu_ids"])
     patch_output_value, patch_output_source = get_highest_priority(config_sources["patch_output"])
+    gpu_oversubscribe_value, gpu_oversubscribe_source = get_highest_priority(config_sources["gpu_oversubscribe"])
+    max_concurrent_llm_value, max_concurrent_llm_source = get_highest_priority(config_sources["max_concurrent_llm"])
 
     # Generate patch output directory if not provided
     if not patch_output_value:
@@ -494,6 +518,8 @@ def load_and_merge_configs(
         "metric": metric_value,
         "num_parallel": num_parallel_value,
         "gpu_ids": gpu_ids_value,
+        "gpu_oversubscribe": gpu_oversubscribe_value,
+        "max_concurrent_llm": max_concurrent_llm_value,
         "_patch_output_dir": str(patch_output_value),
         "_sources": {
             "repo": repo_source,
@@ -502,6 +528,8 @@ def load_and_merge_configs(
             "num_parallel": num_parallel_source,
             "gpu_ids": gpu_ids_source,
             "patch_output": patch_output_source,
+            "gpu_oversubscribe": gpu_oversubscribe_source,
+            "max_concurrent_llm": max_concurrent_llm_source,
         },
         "_conflicts": conflicts,
     }

--- a/src/minisweagent/run/utils/config_editor.py
+++ b/src/minisweagent/run/utils/config_editor.py
@@ -43,7 +43,16 @@ def parse_edit_command(command: str) -> tuple[str | None, Any]:
     value = value.strip()
 
     # Validate field name
-    valid_fields = {"kernel_name", "repo", "test_command", "metric", "num_parallel", "gpu_ids"}
+    valid_fields = {
+        "kernel_name",
+        "repo",
+        "test_command",
+        "metric",
+        "num_parallel",
+        "gpu_ids",
+        "gpu_oversubscribe",
+        "max_concurrent_llm",
+    }
 
     if field_name not in valid_fields:
         return None, None

--- a/src/minisweagent/run/utils/generated_artifacts.py
+++ b/src/minisweagent/run/utils/generated_artifacts.py
@@ -8,8 +8,11 @@ evaluation when they leak into patch capture.
 
 from __future__ import annotations
 
+import hashlib
+import os
 import re
 import subprocess
+import tempfile
 from collections.abc import Callable
 from fnmatch import fnmatch
 from pathlib import Path, PurePosixPath
@@ -255,14 +258,84 @@ _JIT_CACHE_PATH_SEGMENTS: frozenset[str] = frozenset(
         "triton_cache",
         "torch_compile_cache",
         ".aiter_jit",
+        "__pycache__",
+    }
+)
+
+# Directory-segment *prefixes* that identify a JIT runtime cache even when the
+# cache dir carries a suffix. Triton honours a per-process ``TRITON_CACHE_DIR``
+# that a worktree-local harness can point at a dir such as ``.triton_cache_geak``
+# (or ``triton_cache_slot0``); exact-equality matching against the segment set
+# above silently misses those. That gap let ~680 KB of
+# ``.triton_cache_geak/<hash>/fused_moe_kernel.{hsaco,amdgcn,llir,ttir,ttgir,
+# source,json}`` ride along inside the reactor's per-round patch, which then
+# failed to re-apply on a clean checkout and collapsed GEAK's internal A/B
+# speedup to 1.0x (so the KEEP gate never fired hands-off).
+#
+# Kept toolchain-agnostic on purpose: the prefixes cover the cache dirs that do
+# NOT literally contain "cache" (``.triton``, ``.aiter``/``.aiter_jit``,
+# ``torchinductor_<user>``); the substrings below catch every ``*cache*`` dir
+# (``triton_cache``, ``torch_compile_cache``, ``.cache``, ``__pycache__`` ...).
+_JIT_CACHE_SEGMENT_PREFIXES: tuple[str, ...] = (
+    ".triton",        # .triton, .triton_cache_geak, triton_cache_slotN
+    ".aiter",         # .aiter, .aiter_jit, .aiter_cpp_itfs
+    "torch_compile",  # torch_compile_cache
+    "torchinductor",  # torchinductor_<user> (torch._inductor runtime cache)
+    "flydsl_cache",
+)
+
+# Directory-segment *substrings*: any path component containing one of these is
+# treated as a runtime/compile cache dir. ``cache`` catches the long tail of
+# toolchain cache dirs (``triton_cache``, ``torch_compile_cache``, ``.cache``,
+# ``__pycache__``, ``*_cache``) without enumerating each one. Applied to
+# *directory* components only (never the leaf file), so source files such as
+# ``cache_utils.py`` / ``triton_cache_config.py`` are never misclassified.
+_JIT_CACHE_SEGMENT_SUBSTRINGS: tuple[str, ...] = ("cache",)
+
+# Extensions that are *always* JIT/AOT compile outputs (Triton IR dumps and GPU
+# code objects / object files), never hand-written source. Belt-and-suspenders
+# so an unrecognised cache-dir name still cannot smuggle compiled blobs into a
+# source patch.
+_JIT_COMPILE_OUTPUT_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".hsaco",  # AMD GPU code object (compiled binary)
+        ".amdgcn",  # AMDGCN assembly dump
+        ".llir",  # LLVM IR dump
+        ".ttir",  # Triton IR dump
+        ".ttgir",  # Triton GPU IR dump
+        ".cubin",  # NVIDIA CUDA binary
+        ".ptx",  # NVIDIA PTX assembly
+        ".spv",  # SPIR-V binary
+        ".o",  # object file (compiled)
+        ".so",  # shared object (compiled)
     }
 )
 
 _JIT_NESTED_BUILD_DIRS: frozenset[str] = frozenset({"build", "__pycache__"})
 
 
+def _segment_is_jit_cache_dir(segment: str) -> bool:
+    """True when a single path segment names a JIT runtime cache directory."""
+
+    if segment in _JIT_CACHE_PATH_SEGMENTS:
+        return True
+    if any(segment.startswith(prefix) for prefix in _JIT_CACHE_SEGMENT_PREFIXES):
+        return True
+    return any(sub in segment for sub in _JIT_CACHE_SEGMENT_SUBSTRINGS)
+
+
 def is_jit_cache_artifact(rel_path: str | None) -> bool:
-    """Return True when *rel_path* lives inside a known JIT runtime cache."""
+    """Return True when *rel_path* is a JIT/compile cache artifact.
+
+    A path is a cache artifact when any of its *directory* components names a JIT
+    runtime cache (exact match in ``_JIT_CACHE_PATH_SEGMENTS``, a suffixed cache
+    dir matched by ``_JIT_CACHE_SEGMENT_PREFIXES``, or a ``*cache*`` dir matched
+    by ``_JIT_CACHE_SEGMENT_SUBSTRINGS``), when it sits under a
+    ``jit/{build,__pycache__}`` tree, or when its extension is an unambiguous
+    compile output (``_JIT_COMPILE_OUTPUT_SUFFIXES``). Prefix/substring matching
+    is restricted to *directory* components so source files such as
+    ``triton_cache_config.py`` / ``cache_utils.py`` are never misclassified.
+    """
 
     if not rel_path:
         return False
@@ -271,13 +344,24 @@ def is_jit_cache_artifact(rel_path: str | None) -> bool:
         rel = rel[2:]
     if not rel:
         return False
-    parts = PurePosixPath(rel).parts
-    for seg in parts:
-        if seg in _JIT_CACHE_PATH_SEGMENTS:
+    pure = PurePosixPath(rel)
+    parts = pure.parts
+
+    # Any directory component that is a JIT cache dir taints the whole path.
+    for seg in parts[:-1]:
+        if _segment_is_jit_cache_dir(seg):
             return True
+    # The leaf only counts on an exact cache-dir name (e.g. a bare ".triton"
+    # entry), to avoid flagging source files whose name merely starts with a
+    # cache prefix.
+    if parts and parts[-1] in _JIT_CACHE_PATH_SEGMENTS:
+        return True
     for i in range(len(parts) - 1):
         if parts[i] == "jit" and parts[i + 1] in _JIT_NESTED_BUILD_DIRS:
             return True
+    # Unambiguous compile outputs by extension (covers unknown cache dirs).
+    if pure.suffix in _JIT_COMPILE_OUTPUT_SUFFIXES:
+        return True
     return False
 
 
@@ -288,9 +372,156 @@ def strip_jit_cache_sections(patch_text: str) -> tuple[str, list[str]]:
 
 
 def jit_cache_diff_basename_excludes() -> list[str]:
-    """Return JIT-cache directory basenames for ``diff -ruN --exclude=PATTERN``."""
+    """Return JIT-cache exclude patterns for ``diff -ruN`` / ``git diff``.
 
-    return sorted(_JIT_CACHE_PATH_SEGMENTS)
+    Includes exact cache-dir basenames, prefix globs for suffixed cache dirs
+    (e.g. ``.triton_cache_geak``), substring globs for any ``*cache*`` dir, and
+    compile-output extension globs so the cache trees are skipped before the
+    patch is even rendered.
+    """
+
+    patterns: set[str] = set(_JIT_CACHE_PATH_SEGMENTS)
+    patterns.update(f"{prefix}*" for prefix in _JIT_CACHE_SEGMENT_PREFIXES)
+    patterns.update(f"*{sub}*" for sub in _JIT_CACHE_SEGMENT_SUBSTRINGS)
+    patterns.update(f"*{suffix}" for suffix in _JIT_COMPILE_OUTPUT_SUFFIXES)
+    return sorted(patterns)
+
+
+def jit_cache_env(
+    work_dir: str | Path | None,
+    *,
+    base: str | Path | None = None,
+) -> dict[str, str]:
+    """Return env vars that relocate JIT/compile caches OUTSIDE *work_dir*.
+
+    This is the PRIMARY, toolchain-agnostic half of the "no JIT artifacts in the
+    round patch" fix. GEAK runs each optimization round inside a git worktree
+    (*work_dir*) and captures the per-round patch with ``git diff`` *inside that
+    worktree*. If a runtime compiler (Triton, torch inductor, ...) writes its
+    cache under the worktree, the compiled blobs (``*.hsaco`` / IR dumps) get
+    swept into the patch; re-applying that patch for the reactor's A/B then either
+    aborts the atomic ``git apply`` (the blobs already exist in the freshly
+    seeded worktree) or writes stale blobs that mask the patched kernel -- so the
+    measured speedup collapses to 1.0x and a genuinely-good kernel (the
+    fused_moe +1.68x) never clears the KEEP gate.
+
+    Pointing the caches at a dedicated dir OUTSIDE the diffed tree keeps the
+    captured patch source-only and lets the A/B compile the patched source fresh
+    and see the real speedup. The location is:
+
+    * **outside** *work_dir* (so ``git diff`` in the worktree never sees it);
+    * **stable per worktree** (a slot reuses its own compile cache across rounds
+      -- no needless recompiles; Triton is content-addressed by source so this is
+      always correct);
+    * **unique per worktree** (parallel slots never collide / contend).
+
+    Sets ``TRITON_CACHE_DIR`` (Triton) and ``GEAK_JIT_CACHE_DIR`` (a generic root
+    the sanitized harness and other toolchains -- aiter, inductor -- hang their
+    caches off of; see the harness-sanitizer R5 rule). Returns ``{}`` when
+    *work_dir* is falsy. ``base`` overrides the parent dir (test hook / explicit
+    out-of-tree root); it defaults to ``$TMPDIR/geak_jit_cache``.
+    """
+    if not work_dir:
+        return {}
+    wt = Path(work_dir).resolve()
+    if base is not None:
+        root = Path(base)
+    else:
+        root = Path(tempfile.gettempdir()) / "geak_jit_cache"
+    slot = hashlib.sha1(str(wt).encode("utf-8")).hexdigest()[:16]
+    cache_root = root / slot
+    return {
+        "GEAK_JIT_CACHE_DIR": str(cache_root),
+        "TRITON_CACHE_DIR": str(cache_root / "triton"),
+    }
+
+
+def _section_is_pure_addition(section_lines: list[str]) -> bool:
+    """True when a diff section creates a brand-new file (``new file mode``)."""
+
+    for line in section_lines[1:6]:
+        if line.startswith("new file mode"):
+            return True
+        if line.startswith("@@"):
+            break
+    return False
+
+
+def strip_already_present_additions(patch_text: str, base_dir: str | Path) -> tuple[str, list[str]]:
+    """Drop ``diff --git`` sections that *add* a file already present in *base_dir*.
+
+    ``create_worktree`` seeds every fresh worktree with the repo's untracked,
+    non-ignored files (see ``task_file._copy_untracked_files``). When the
+    captured patch *also* records those same files as new-file additions (because
+    ``git add -N`` listed them at capture time), re-applying the patch onto such a
+    worktree aborts atomically with ``error: <path>: already exists in working
+    directory`` -- taking the legitimate source modification down with it and
+    leaving GEAK's A/B at 1.0x. Such additions are no-ops (an identical file is
+    already there), so dropping them is safe and lets the real edit apply.
+
+    Only *pure additions* (``new file mode``) whose target already exists under
+    *base_dir* are removed. Modifications, deletions, and additions of genuinely
+    new (agent-authored) files are preserved verbatim.
+
+    Returns ``(sanitized_patch_text, removed_paths)``.
+    """
+
+    if not patch_text.strip():
+        return patch_text, []
+
+    base = Path(base_dir)
+    lines = patch_text.splitlines(keepends=True)
+    preamble: list[str] = []
+    sections: list[list[str]] = []
+    current: list[str] | None = None
+    for line in lines:
+        if line.startswith("diff --git "):
+            if current is not None:
+                sections.append(current)
+            current = [line]
+        elif current is None:
+            preamble.append(line)
+        else:
+            current.append(line)
+    if current is not None:
+        sections.append(current)
+    if not sections:
+        return patch_text, []
+
+    kept: list[str] = list(preamble)
+    removed: list[str] = []
+    for section in sections:
+        parsed = _parse_git_diff_paths(section[0])
+        if parsed is not None and _section_is_pure_addition(section):
+            a_path, b_path = parsed
+            target = b_path or a_path
+            try:
+                present = bool(target) and (base / target).exists()
+            except OSError:
+                present = False
+            if present:
+                removed.append(target)
+                continue
+        kept.extend(section)
+    return "".join(kept), removed
+
+
+def sanitize_patch_for_apply(patch_text: str, cwd: str | Path) -> tuple[str, list[str]]:
+    """Strip patch sections that can never carry an applicable source edit.
+
+    Combines, in order: JIT/compile-cache stripping, removal of new-file
+    additions already present in *cwd* (the destination worktree), and
+    generated-helper stripping. Returns ``(sanitized_text, removed_paths)``.
+    """
+
+    removed_all: list[str] = []
+    text, removed = strip_jit_cache_sections(patch_text)
+    removed_all.extend(removed)
+    text, removed = strip_already_present_additions(text, cwd)
+    removed_all.extend(removed)
+    text, removed = strip_generated_helper_sections(text)
+    removed_all.extend(removed)
+    return text, removed_all
 
 
 # Conflict-marker regexes. We reject patches whose 3-way merge result contains
@@ -535,7 +766,16 @@ def apply_patch_with_generated_helper_fallback(
         if norm_result.returncode == 0:
             return norm_result, []
 
-    sanitized_patch, removed_paths = strip_generated_helper_sections(patch_text)
+    # Strip sections that can never carry an applicable source edit, then retry:
+    #   (1) JIT/compile-cache artifacts (Triton TRITON_CACHE_DIR blobs, IR dumps);
+    #   (2) new-file additions whose target already exists in this worktree --
+    #       create_worktree seeds the worktree with the repo's untracked,
+    #       non-ignored files, so re-adding them aborts the *atomic* apply with
+    #       "already exists in working directory", killing the real edit too;
+    #   (3) generated helper artifacts (legacy behaviour).
+    # This is what lets the reactor's clean-checkout re-apply land the genuine
+    # kernel edit so the A/B measures the true speedup instead of 1.0x.
+    sanitized_patch, removed_paths = sanitize_patch_for_apply(patch_text, cwd)
     if not removed_paths:
         three_way = _try_three_way_with_alternates(
             patch_text=patch_text,

--- a/src/minisweagent/run/utils/gpu_manager.py
+++ b/src/minisweagent/run/utils/gpu_manager.py
@@ -19,6 +19,7 @@ associated subprocess.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import queue
@@ -29,6 +30,7 @@ import uuid
 from collections.abc import Callable
 from concurrent.futures import Future, InvalidStateError, ThreadPoolExecutor
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Generic, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -85,6 +87,9 @@ class GPUManager:
         Defaults to ``0.8 * os.cpu_count()``.
     reaper_interval_s:
         Seconds between lease-reaper sweeps.  ``0`` disables.
+    event_log_path:
+        Path to a JSONL file for per-job lifecycle events.
+        ``None`` disables file logging (events still go to ``logger.debug``).
     """
 
     def __init__(
@@ -95,6 +100,7 @@ class GPUManager:
         stats_log_interval_s: float = 30.0,
         cpu_pressure_threshold: float | None = None,
         reaper_interval_s: float = 30.0,
+        event_log_path: str | Path | None = None,
     ) -> None:
         if not gpu_ids:
             raise ValueError("gpu_ids must be non-empty")
@@ -125,8 +131,18 @@ class GPUManager:
         self._queue_depth = 0
         self._max_queue_depth = 0
 
+        self._total_succeeded = 0
+        self._total_failed = 0
+        self._total_reaped = 0
+        self._total_cancelled = 0
+
         self._active_leases: dict[str, LeaseState] = {}
         self._leases_lock = threading.Lock()
+
+        self._event_log_file = (
+            open(event_log_path, "a", encoding="utf-8") if event_log_path else None
+        )
+        self._event_log_lock = threading.Lock()
 
         self._dispatcher = threading.Thread(
             target=self._dispatch_loop, name="gpu-manager-dispatch", daemon=True,
@@ -159,6 +175,7 @@ class GPUManager:
             self._total_submitted += 1
             self._queue_depth += 1
             self._max_queue_depth = max(self._max_queue_depth, self._queue_depth)
+        self._emit_event("queued", job_label=job.label, num_gpus=job.num_gpus)
         self._job_queue.put((job, fut))
         return fut
 
@@ -187,6 +204,9 @@ class GPUManager:
         self._dispatcher.join(timeout=10)
         self._executor.shutdown(wait=True)
         logger.info("GPUManager shut down. Final stats: %s", self.stats)
+        if self._event_log_file is not None:
+            self._event_log_file.close()
+            self._event_log_file = None
 
     @property
     def stats(self) -> dict[str, Any]:
@@ -205,6 +225,10 @@ class GPUManager:
                 "max_queue_depth": self._max_queue_depth,
                 "total_jobs_submitted": self._total_submitted,
                 "total_jobs_completed": self._total_completed,
+                "total_succeeded": self._total_succeeded,
+                "total_failed": self._total_failed,
+                "total_reaped": self._total_reaped,
+                "total_cancelled": self._total_cancelled,
                 "manager_uptime_s": round(now - self._start_time, 2),
             }
 
@@ -265,6 +289,10 @@ class GPUManager:
                     for g in assigned:
                         self._busy_start[g] = now
 
+                self._emit_event(
+                    "leased", lease_id=lease.lease_id, job_label=job.label,
+                    gpu_ids=list(assigned), deadline=deadline,
+                )
                 env_overrides = self._build_env_overrides(assigned)
 
                 worker_fut = self._executor.submit(
@@ -302,7 +330,9 @@ class GPUManager:
                 logger.info("Job %s: cancelled before execution, skipping", job.label)
                 reason = "cancelled"
                 return
+            self._emit_event("started", lease_id=lease.lease_id, job_label=job.label)
             result = job.fn(list(lease.gpu_ids), env_overrides)
+            self._emit_event("completed", lease_id=lease.lease_id, job_label=job.label)
             try:
                 fut.set_result(result)
             except InvalidStateError:
@@ -310,6 +340,8 @@ class GPUManager:
                 reason = "cancelled"
         except Exception as exc:
             reason = "failed"
+            self._emit_event("failed", lease_id=lease.lease_id, job_label=job.label,
+                             error=str(exc))
             try:
                 fut.set_exception(exc)
             except InvalidStateError:
@@ -333,6 +365,14 @@ class GPUManager:
         with self._stats_lock:
             self._in_flight = max(0, self._in_flight - 1)
             self._total_completed += 1
+            if reason == "completed":
+                self._total_succeeded += 1
+            elif reason == "failed":
+                self._total_failed += 1
+            elif reason == "reaped":
+                self._total_reaped += 1
+            elif reason == "cancelled":
+                self._total_cancelled += 1
             for g in gpus:
                 if g in self._busy_start:
                     self._busy_total[g] += now - self._busy_start.pop(g)
@@ -340,6 +380,8 @@ class GPUManager:
         with self._cond:
             self._free.update(gpus)
             self._cond.notify_all()
+
+        self._emit_event("released", lease_id=lease_id, reason=reason, gpu_ids=gpus)
 
     # kept for backward compat with tests that call it directly
     def _release_gpus(self, gpus: list[int]) -> None:
@@ -432,6 +474,20 @@ class GPUManager:
             os.killpg(pgid, signal.SIGKILL)
         except (ProcessLookupError, OSError):
             pass
+
+    # ------------------------------------------------------------------
+    # Event logging
+    # ------------------------------------------------------------------
+
+    def _emit_event(self, event: str, **fields: Any) -> None:
+        now = time.monotonic()
+        record = {"event": event, "t": round(now - self._start_time, 3), **fields}
+        logger.debug("gpu_event: %s", record)
+        if self._event_log_file is not None:
+            line = json.dumps(record, default=str)
+            with self._event_log_lock:
+                self._event_log_file.write(line + "\n")
+                self._event_log_file.flush()
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/minisweagent/run/utils/gpu_manager.py
+++ b/src/minisweagent/run/utils/gpu_manager.py
@@ -29,7 +29,7 @@ import time
 import uuid
 from collections.abc import Callable
 from concurrent.futures import Future, InvalidStateError, ThreadPoolExecutor
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generic, TypeVar
 
@@ -109,9 +109,7 @@ class GPUManager:
         self._registry = registry
         self._stats_log_interval_s = stats_log_interval_s
         self._cpu_pressure_threshold = (
-            cpu_pressure_threshold
-            if cpu_pressure_threshold is not None
-            else 0.8 * os.cpu_count()
+            cpu_pressure_threshold if cpu_pressure_threshold is not None else 0.8 * os.cpu_count()
         )
         self._reaper_interval_s = reaper_interval_s
 
@@ -139,25 +137,29 @@ class GPUManager:
         self._active_leases: dict[str, LeaseState] = {}
         self._leases_lock = threading.Lock()
 
-        self._event_log_file = (
-            open(event_log_path, "a", encoding="utf-8") if event_log_path else None
-        )
+        self._event_log_file = open(event_log_path, "a", encoding="utf-8") if event_log_path else None
         self._event_log_lock = threading.Lock()
 
         self._dispatcher = threading.Thread(
-            target=self._dispatch_loop, name="gpu-manager-dispatch", daemon=True,
+            target=self._dispatch_loop,
+            name="gpu-manager-dispatch",
+            daemon=True,
         )
         self._dispatcher.start()
 
         if stats_log_interval_s > 0:
             self._stats_logger = threading.Thread(
-                target=self._stats_log_loop, name="gpu-manager-stats", daemon=True,
+                target=self._stats_log_loop,
+                name="gpu-manager-stats",
+                daemon=True,
             )
             self._stats_logger.start()
 
         if reaper_interval_s > 0:
             self._reaper = threading.Thread(
-                target=self._reaper_loop, name="gpu-lease-reaper", daemon=True,
+                target=self._reaper_loop,
+                name="gpu-lease-reaper",
+                daemon=True,
             )
             self._reaper.start()
 
@@ -290,13 +292,21 @@ class GPUManager:
                         self._busy_start[g] = now
 
                 self._emit_event(
-                    "leased", lease_id=lease.lease_id, job_label=job.label,
-                    gpu_ids=list(assigned), deadline=deadline,
+                    "leased",
+                    lease_id=lease.lease_id,
+                    job_label=job.label,
+                    gpu_ids=list(assigned),
+                    deadline=deadline,
                 )
                 env_overrides = self._build_env_overrides(assigned)
 
                 worker_fut = self._executor.submit(
-                    self._run_job, job, lease, state, env_overrides, fut,
+                    self._run_job,
+                    job,
+                    lease,
+                    state,
+                    env_overrides,
+                    fut,
                 )
                 if self._registry is not None:
                     try:
@@ -340,8 +350,7 @@ class GPUManager:
                 reason = "cancelled"
         except Exception as exc:
             reason = "failed"
-            self._emit_event("failed", lease_id=lease.lease_id, job_label=job.label,
-                             error=str(exc))
+            self._emit_event("failed", lease_id=lease.lease_id, job_label=job.label, error=str(exc))
             try:
                 fut.set_exception(exc)
             except InvalidStateError:
@@ -409,14 +418,14 @@ class GPUManager:
 
             with self._leases_lock:
                 expired = [
-                    (lid, s) for lid, s in self._active_leases.items()
+                    (lid, s)
+                    for lid, s in self._active_leases.items()
                     if not s.released and s.lease.deadline is not None and now > s.lease.deadline
                 ]
 
             for lease_id, state in expired:
                 logger.warning(
-                    "Lease %s expired (job: %s, ran %.0fs, limit was %.0fs). "
-                    "Killing subprocess and releasing GPUs %s.",
+                    "Lease %s expired (job: %s, ran %.0fs, limit was %.0fs). Killing subprocess and releasing GPUs %s.",
                     lease_id,
                     state.lease.job_label,
                     now - state.lease.acquired_at,
@@ -430,7 +439,8 @@ class GPUManager:
             with self._leases_lock:
                 cutoff = time.monotonic() - 300
                 self._active_leases = {
-                    k: v for k, v in self._active_leases.items()
+                    k: v
+                    for k, v in self._active_leases.items()
                     if not v.released or (v.released_at is not None and v.released_at > cutoff)
                 }
 
@@ -439,7 +449,8 @@ class GPUManager:
         now = time.monotonic()
         with self._leases_lock:
             expired = [
-                (lid, s) for lid, s in self._active_leases.items()
+                (lid, s)
+                for lid, s in self._active_leases.items()
                 if not s.released and s.lease.deadline is not None and now > s.lease.deadline
             ]
         for lease_id, state in expired:
@@ -448,7 +459,8 @@ class GPUManager:
         with self._leases_lock:
             cutoff = time.monotonic() - 300
             self._active_leases = {
-                k: v for k, v in self._active_leases.items()
+                k: v
+                for k, v in self._active_leases.items()
                 if not v.released or (v.released_at is not None and v.released_at > cutoff)
             }
 

--- a/src/minisweagent/run/utils/gpu_manager.py
+++ b/src/minisweagent/run/utils/gpu_manager.py
@@ -83,8 +83,10 @@ class GPUManager:
     stats_log_interval_s:
         Seconds between periodic INFO log lines.  ``0`` disables.
     cpu_pressure_threshold:
-        Max 1-minute load average before the dispatcher pauses.
-        Defaults to ``0.8 * os.cpu_count()``.
+        Max **per-core** load average (``loadavg / cpu_count``) before the
+        dispatcher pauses.  Defaults to ``0.8`` (i.e. ~80% saturated).
+        Internal knob — not surfaced through YAML config on purpose, since
+        raw loadavg thresholds are a footgun across heterogeneous hosts.
     reaper_interval_s:
         Seconds between lease-reaper sweeps.  ``0`` disables.
     event_log_path:
@@ -109,7 +111,7 @@ class GPUManager:
         self._registry = registry
         self._stats_log_interval_s = stats_log_interval_s
         self._cpu_pressure_threshold = (
-            cpu_pressure_threshold if cpu_pressure_threshold is not None else 0.8 * os.cpu_count()
+            cpu_pressure_threshold if cpu_pressure_threshold is not None else 0.8
         )
         self._reaper_interval_s = reaper_interval_s
 
@@ -251,9 +253,14 @@ class GPUManager:
                         self._queue_depth = max(0, self._queue_depth - 1)
                     continue
 
-                # CPU pressure gate — wait before acquiring GPUs
+                # CPU pressure gate — wait before acquiring GPUs.
+                # Compares **per-core** load (loadavg / cpu_count) against the
+                # threshold so the gate behaves the same on a 4-core dev box
+                # and a 256-core server. Raw loadavg is meaningless without
+                # normalizing by cpu_count.
                 try:
-                    while os.getloadavg()[0] > self._cpu_pressure_threshold:
+                    cpus = max(1, os.cpu_count() or 1)
+                    while (os.getloadavg()[0] / cpus) > self._cpu_pressure_threshold:
                         if self._closed:
                             fut.cancel()
                             return

--- a/src/minisweagent/run/utils/gpu_manager.py
+++ b/src/minisweagent/run/utils/gpu_manager.py
@@ -10,17 +10,25 @@ then reserves them atomically and hands the job to a worker.  Workers
 return GPUs via a done-callback.  This avoids the deadlock a fixed-size
 worker pool would create when a multi-GPU job sits in the queue while
 every worker holds zero GPUs.
+
+GPU ownership is tracked via leases.  Each lease records which GPUs are
+held, when they were acquired, and an optional execution deadline.  A
+background reaper thread reclaims GPUs from expired leases and kills the
+associated subprocess.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import queue
+import signal
 import threading
 import time
+import uuid
 from collections.abc import Callable
-from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass
+from concurrent.futures import Future, InvalidStateError, ThreadPoolExecutor
+from dataclasses import dataclass, field
 from typing import Any, Generic, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -35,11 +43,34 @@ class GpuJob(Generic[T]):
     fn: Callable[[list[int], dict[str, str]], T]
     num_gpus: int = 1
     timeout: float | None = None
+    queue_timeout: float | None = None
     label: str = ""
 
 
+@dataclass(frozen=True)
+class GpuLease:
+    """Immutable record of a GPU assignment."""
+
+    lease_id: str
+    job_label: str
+    gpu_ids: tuple[int, ...]
+    acquired_at: float
+    deadline: float | None
+
+
+@dataclass
+class LeaseState:
+    """Mutable tracking wrapper around a lease."""
+
+    lease: GpuLease
+    popen_pid: int | None = None
+    released: bool = False
+    released_at: float | None = None
+    release_reason: str | None = None
+
+
 class GPUManager:
-    """Centralized GPU pool with FIFO scheduling.
+    """Centralized GPU pool with FIFO scheduling and lease-based ownership.
 
     Parameters
     ----------
@@ -49,6 +80,11 @@ class GPUManager:
         A ``ProcessRegistry`` instance for SIGINT cleanup of futures.
     stats_log_interval_s:
         Seconds between periodic INFO log lines.  ``0`` disables.
+    cpu_pressure_threshold:
+        Max 1-minute load average before the dispatcher pauses.
+        Defaults to ``0.8 * os.cpu_count()``.
+    reaper_interval_s:
+        Seconds between lease-reaper sweeps.  ``0`` disables.
     """
 
     def __init__(
@@ -57,6 +93,8 @@ class GPUManager:
         registry: Any = None,
         *,
         stats_log_interval_s: float = 30.0,
+        cpu_pressure_threshold: float | None = None,
+        reaper_interval_s: float = 30.0,
     ) -> None:
         if not gpu_ids:
             raise ValueError("gpu_ids must be non-empty")
@@ -64,6 +102,12 @@ class GPUManager:
         self._gpu_ids = list(gpu_ids)
         self._registry = registry
         self._stats_log_interval_s = stats_log_interval_s
+        self._cpu_pressure_threshold = (
+            cpu_pressure_threshold
+            if cpu_pressure_threshold is not None
+            else 0.8 * os.cpu_count()
+        )
+        self._reaper_interval_s = reaper_interval_s
 
         self._free: set[int] = set(gpu_ids)
         self._cond = threading.Condition(threading.Lock())
@@ -81,12 +125,25 @@ class GPUManager:
         self._queue_depth = 0
         self._max_queue_depth = 0
 
-        self._dispatcher = threading.Thread(target=self._dispatch_loop, name="gpu-manager-dispatch", daemon=True)
+        self._active_leases: dict[str, LeaseState] = {}
+        self._leases_lock = threading.Lock()
+
+        self._dispatcher = threading.Thread(
+            target=self._dispatch_loop, name="gpu-manager-dispatch", daemon=True,
+        )
         self._dispatcher.start()
 
         if stats_log_interval_s > 0:
-            self._stats_logger = threading.Thread(target=self._stats_log_loop, name="gpu-manager-stats", daemon=True)
+            self._stats_logger = threading.Thread(
+                target=self._stats_log_loop, name="gpu-manager-stats", daemon=True,
+            )
             self._stats_logger.start()
+
+        if reaper_interval_s > 0:
+            self._reaper = threading.Thread(
+                target=self._reaper_loop, name="gpu-lease-reaper", daemon=True,
+            )
+            self._reaper.start()
 
     def submit(self, job: GpuJob) -> Future:
         """Enqueue a job and return a ``Future`` for its result."""
@@ -107,7 +164,7 @@ class GPUManager:
 
     def run(self, job: GpuJob) -> Any:
         """Submit a job and block until it completes."""
-        return self.submit(job).result(timeout=job.timeout)
+        return self.submit(job).result(timeout=job.queue_timeout)
 
     def shutdown(self, *, cancel_pending: bool = False) -> None:
         """Stop accepting jobs and drain the dispatcher."""
@@ -156,62 +213,135 @@ class GPUManager:
     # ------------------------------------------------------------------
 
     def _dispatch_loop(self) -> None:
-        while True:
-            item = self._job_queue.get()
-            if item is None:
-                return
-            job, fut = item
+        try:
+            while True:
+                item = self._job_queue.get()
+                if item is None:
+                    return
+                job, fut = item
 
-            if fut.cancelled():
+                if fut.cancelled():
+                    with self._stats_lock:
+                        self._queue_depth = max(0, self._queue_depth - 1)
+                    continue
+
+                # CPU pressure gate — wait before acquiring GPUs
+                try:
+                    while os.getloadavg()[0] > self._cpu_pressure_threshold:
+                        if self._closed:
+                            fut.cancel()
+                            return
+                        time.sleep(1.0)
+                except OSError:
+                    pass
+
+                with self._cond:
+                    while len(self._free) < job.num_gpus:
+                        if self._closed:
+                            fut.cancel()
+                            with self._stats_lock:
+                                self._queue_depth = max(0, self._queue_depth - 1)
+                            return
+                        self._cond.wait(timeout=1.0)
+
+                    assigned = [self._free.pop() for _ in range(job.num_gpus)]
+
+                now = time.monotonic()
+                deadline = (now + job.timeout) if job.timeout else None
+                lease = GpuLease(
+                    lease_id=str(uuid.uuid4()),
+                    job_label=job.label,
+                    gpu_ids=tuple(assigned),
+                    acquired_at=now,
+                    deadline=deadline,
+                )
+                state = LeaseState(lease=lease)
+                with self._leases_lock:
+                    self._active_leases[lease.lease_id] = state
+
                 with self._stats_lock:
                     self._queue_depth = max(0, self._queue_depth - 1)
-                continue
+                    self._in_flight += 1
+                    for g in assigned:
+                        self._busy_start[g] = now
 
-            with self._cond:
-                while len(self._free) < job.num_gpus:
-                    if self._closed:
-                        fut.cancel()
+                env_overrides = self._build_env_overrides(assigned)
+
+                worker_fut = self._executor.submit(
+                    self._run_job, job, lease, state, env_overrides, fut,
+                )
+                if self._registry is not None:
+                    try:
+                        with self._registry.lock:
+                            self._registry.register_future(worker_fut)
+                    except Exception:
+                        logger.debug("Failed to register worker future with registry", exc_info=True)
+        finally:
+            # B9 fix: drain remaining jobs on ANY exit path
+            while True:
+                try:
+                    item = self._job_queue.get_nowait()
+                    if item is not None:
+                        item[1].cancel()
                         with self._stats_lock:
                             self._queue_depth = max(0, self._queue_depth - 1)
-                        return
-                    self._cond.wait(timeout=1.0)
-
-                assigned = []
-                for _ in range(job.num_gpus):
-                    assigned.append(self._free.pop())
-
-            now = time.monotonic()
-            with self._stats_lock:
-                self._queue_depth = max(0, self._queue_depth - 1)
-                self._in_flight += 1
-                for g in assigned:
-                    self._busy_start[g] = now
-
-            env_overrides = self._build_env_overrides(assigned)
-
-            worker_fut = self._executor.submit(self._run_job, job, assigned, env_overrides, fut)
-            if self._registry is not None:
-                try:
-                    with self._registry.lock:
-                        self._registry.register_future(worker_fut)
-                except Exception:
-                    logger.debug("Failed to register worker future with registry", exc_info=True)
+                except queue.Empty:
+                    break
 
     def _run_job(
         self,
         job: GpuJob,
-        assigned: list[int],
+        lease: GpuLease,
+        state: LeaseState,
         env_overrides: dict[str, str],
         fut: Future,
     ) -> None:
+        reason = "completed"
         try:
-            result = job.fn(assigned, env_overrides)
-            fut.set_result(result)
+            if fut.cancelled():
+                logger.info("Job %s: cancelled before execution, skipping", job.label)
+                reason = "cancelled"
+                return
+            result = job.fn(list(lease.gpu_ids), env_overrides)
+            try:
+                fut.set_result(result)
+            except InvalidStateError:
+                logger.warning("Job %s: future already cancelled, discarding result", job.label)
+                reason = "cancelled"
         except Exception as exc:
-            fut.set_exception(exc)
+            reason = "failed"
+            try:
+                fut.set_exception(exc)
+            except InvalidStateError:
+                logger.warning("Job %s: future already cancelled, discarding exception", job.label)
+                reason = "cancelled"
         finally:
-            self._release_gpus(assigned)
+            self._release_lease(lease.lease_id, reason=reason)
 
+    def _release_lease(self, lease_id: str, reason: str) -> None:
+        with self._leases_lock:
+            state = self._active_leases.get(lease_id)
+            if state is None or state.released:
+                logger.warning("Lease %s: already released or unknown, skipping", lease_id)
+                return
+            state.released = True
+            state.released_at = time.monotonic()
+            state.release_reason = reason
+            gpus = list(state.lease.gpu_ids)
+
+        now = time.monotonic()
+        with self._stats_lock:
+            self._in_flight = max(0, self._in_flight - 1)
+            self._total_completed += 1
+            for g in gpus:
+                if g in self._busy_start:
+                    self._busy_total[g] += now - self._busy_start.pop(g)
+
+        with self._cond:
+            self._free.update(gpus)
+            self._cond.notify_all()
+
+    # kept for backward compat with tests that call it directly
     def _release_gpus(self, gpus: list[int]) -> None:
         now = time.monotonic()
         with self._stats_lock:
@@ -223,6 +353,89 @@ class GPUManager:
         with self._cond:
             self._free.update(gpus)
             self._cond.notify_all()
+
+    # ------------------------------------------------------------------
+    # Lease reaper
+    # ------------------------------------------------------------------
+
+    def _reaper_loop(self) -> None:
+        while not self._closed:
+            time.sleep(self._reaper_interval_s)
+            if self._closed:
+                return
+            now = time.monotonic()
+
+            with self._leases_lock:
+                expired = [
+                    (lid, s) for lid, s in self._active_leases.items()
+                    if not s.released and s.lease.deadline is not None and now > s.lease.deadline
+                ]
+
+            for lease_id, state in expired:
+                logger.warning(
+                    "Lease %s expired (job: %s, ran %.0fs, limit was %.0fs). "
+                    "Killing subprocess and releasing GPUs %s.",
+                    lease_id,
+                    state.lease.job_label,
+                    now - state.lease.acquired_at,
+                    state.lease.deadline - state.lease.acquired_at,
+                    list(state.lease.gpu_ids),
+                )
+                self._kill_lease_subprocess(state)
+                self._release_lease(lease_id, reason="reaped")
+
+            # Prune old completed leases to bound memory
+            with self._leases_lock:
+                cutoff = time.monotonic() - 300
+                self._active_leases = {
+                    k: v for k, v in self._active_leases.items()
+                    if not v.released or (v.released_at is not None and v.released_at > cutoff)
+                }
+
+    def _reaper_loop_once_for_test(self) -> None:
+        """Run a single reaper iteration (for testing)."""
+        now = time.monotonic()
+        with self._leases_lock:
+            expired = [
+                (lid, s) for lid, s in self._active_leases.items()
+                if not s.released and s.lease.deadline is not None and now > s.lease.deadline
+            ]
+        for lease_id, state in expired:
+            self._kill_lease_subprocess(state)
+            self._release_lease(lease_id, reason="reaped")
+        with self._leases_lock:
+            cutoff = time.monotonic() - 300
+            self._active_leases = {
+                k: v for k, v in self._active_leases.items()
+                if not v.released or (v.released_at is not None and v.released_at > cutoff)
+            }
+
+    def _kill_lease_subprocess(self, state: LeaseState) -> None:
+        if state.popen_pid is None:
+            return
+        try:
+            pgid = os.getpgid(state.popen_pid)
+        except (ProcessLookupError, OSError):
+            return
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            return
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            try:
+                os.kill(state.popen_pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.2)
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
 
     @staticmethod
     def _build_env_overrides(assigned: list[int]) -> dict[str, str]:

--- a/src/minisweagent/run/utils/gpu_manager.py
+++ b/src/minisweagent/run/utils/gpu_manager.py
@@ -1,0 +1,257 @@
+"""Centralized in-process GPU manager.
+
+Decouples sub-agent count from GPU count. Every GPU-bound subprocess is
+submitted as a ``GpuJob``; the manager holds the GPU only while the job
+runs and releases it on completion.
+
+Scheduling: single dispatcher thread + unbounded worker pool.  The
+dispatcher pops jobs from a FIFO queue, waits until enough GPUs are free,
+then reserves them atomically and hands the job to a worker.  Workers
+return GPUs via a done-callback.  This avoids the deadlock a fixed-size
+worker pool would create when a multi-GPU job sits in the queue while
+every worker holds zero GPUs.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+@dataclass
+class GpuJob(Generic[T]):
+    """A unit of GPU-bound work submitted to the manager."""
+
+    fn: Callable[[list[int], dict[str, str]], T]
+    num_gpus: int = 1
+    timeout: float | None = None
+    label: str = ""
+
+
+class GPUManager:
+    """Centralized GPU pool with FIFO scheduling.
+
+    Parameters
+    ----------
+    gpu_ids:
+        Physical GPU device IDs available (e.g. ``[0, 1, 2, 3]``).
+    registry:
+        A ``ProcessRegistry`` instance for SIGINT cleanup of futures.
+    stats_log_interval_s:
+        Seconds between periodic INFO log lines.  ``0`` disables.
+    """
+
+    def __init__(
+        self,
+        gpu_ids: list[int],
+        registry: Any = None,
+        *,
+        stats_log_interval_s: float = 30.0,
+    ) -> None:
+        if not gpu_ids:
+            raise ValueError("gpu_ids must be non-empty")
+
+        self._gpu_ids = list(gpu_ids)
+        self._registry = registry
+        self._stats_log_interval_s = stats_log_interval_s
+
+        self._free: set[int] = set(gpu_ids)
+        self._cond = threading.Condition(threading.Lock())
+        self._job_queue: queue.Queue[tuple[GpuJob, Future] | None] = queue.Queue()
+        self._executor = ThreadPoolExecutor(max_workers=None)
+        self._closed = False
+
+        self._start_time = time.monotonic()
+        self._busy_start: dict[int, float] = {}
+        self._busy_total: dict[int, float] = {g: 0.0 for g in gpu_ids}
+        self._stats_lock = threading.Lock()
+        self._total_submitted = 0
+        self._total_completed = 0
+        self._in_flight = 0
+        self._queue_depth = 0
+        self._max_queue_depth = 0
+
+        self._dispatcher = threading.Thread(target=self._dispatch_loop, name="gpu-manager-dispatch", daemon=True)
+        self._dispatcher.start()
+
+        if stats_log_interval_s > 0:
+            self._stats_logger = threading.Thread(target=self._stats_log_loop, name="gpu-manager-stats", daemon=True)
+            self._stats_logger.start()
+
+    def submit(self, job: GpuJob) -> Future:
+        """Enqueue a job and return a ``Future`` for its result."""
+        if self._closed:
+            raise RuntimeError("GPUManager is shut down; cannot submit new jobs")
+        if job.num_gpus > len(self._gpu_ids):
+            raise ValueError(
+                f"job '{job.label}' requests {job.num_gpus} GPU(s) but only {len(self._gpu_ids)} available"
+            )
+
+        fut: Future = Future()
+        with self._stats_lock:
+            self._total_submitted += 1
+            self._queue_depth += 1
+            self._max_queue_depth = max(self._max_queue_depth, self._queue_depth)
+        self._job_queue.put((job, fut))
+        return fut
+
+    def run(self, job: GpuJob) -> Any:
+        """Submit a job and block until it completes."""
+        return self.submit(job).result(timeout=job.timeout)
+
+    def shutdown(self, *, cancel_pending: bool = False) -> None:
+        """Stop accepting jobs and drain the dispatcher."""
+        self._closed = True
+        if cancel_pending:
+            drained: list[tuple[GpuJob, Future]] = []
+            while True:
+                try:
+                    item = self._job_queue.get_nowait()
+                    if item is not None:
+                        drained.append(item)
+                except queue.Empty:
+                    break
+            for _job, fut in drained:
+                fut.cancel()
+                with self._stats_lock:
+                    self._queue_depth = max(0, self._queue_depth - 1)
+
+        self._job_queue.put(None)
+        self._dispatcher.join(timeout=10)
+        self._executor.shutdown(wait=True)
+        logger.info("GPUManager shut down. Final stats: %s", self.stats)
+
+    @property
+    def stats(self) -> dict[str, Any]:
+        now = time.monotonic()
+        with self._stats_lock:
+            busy = {}
+            for g in self._gpu_ids:
+                total = self._busy_total[g]
+                if g in self._busy_start:
+                    total += now - self._busy_start[g]
+                busy[g] = round(total, 2)
+            return {
+                "busy_seconds_per_gpu": busy,
+                "queue_depth": self._queue_depth,
+                "in_flight": self._in_flight,
+                "max_queue_depth": self._max_queue_depth,
+                "total_jobs_submitted": self._total_submitted,
+                "total_jobs_completed": self._total_completed,
+                "manager_uptime_s": round(now - self._start_time, 2),
+            }
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _dispatch_loop(self) -> None:
+        while True:
+            item = self._job_queue.get()
+            if item is None:
+                return
+            job, fut = item
+
+            if fut.cancelled():
+                with self._stats_lock:
+                    self._queue_depth = max(0, self._queue_depth - 1)
+                continue
+
+            with self._cond:
+                while len(self._free) < job.num_gpus:
+                    if self._closed:
+                        fut.cancel()
+                        with self._stats_lock:
+                            self._queue_depth = max(0, self._queue_depth - 1)
+                        return
+                    self._cond.wait(timeout=1.0)
+
+                assigned = []
+                for _ in range(job.num_gpus):
+                    assigned.append(self._free.pop())
+
+            now = time.monotonic()
+            with self._stats_lock:
+                self._queue_depth = max(0, self._queue_depth - 1)
+                self._in_flight += 1
+                for g in assigned:
+                    self._busy_start[g] = now
+
+            env_overrides = self._build_env_overrides(assigned)
+
+            worker_fut = self._executor.submit(self._run_job, job, assigned, env_overrides, fut)
+            if self._registry is not None:
+                try:
+                    with self._registry.lock:
+                        self._registry.register_future(worker_fut)
+                except Exception:
+                    logger.debug("Failed to register worker future with registry", exc_info=True)
+
+    def _run_job(
+        self,
+        job: GpuJob,
+        assigned: list[int],
+        env_overrides: dict[str, str],
+        fut: Future,
+    ) -> None:
+        try:
+            result = job.fn(assigned, env_overrides)
+            fut.set_result(result)
+        except Exception as exc:
+            fut.set_exception(exc)
+        finally:
+            self._release_gpus(assigned)
+
+    def _release_gpus(self, gpus: list[int]) -> None:
+        now = time.monotonic()
+        with self._stats_lock:
+            self._in_flight = max(0, self._in_flight - 1)
+            self._total_completed += 1
+            for g in gpus:
+                if g in self._busy_start:
+                    self._busy_total[g] += now - self._busy_start.pop(g)
+        with self._cond:
+            self._free.update(gpus)
+            self._cond.notify_all()
+
+    @staticmethod
+    def _build_env_overrides(assigned: list[int]) -> dict[str, str]:
+        devs = ",".join(str(g) for g in assigned)
+        return {
+            "HIP_VISIBLE_DEVICES": devs,
+            "CUDA_VISIBLE_DEVICES": devs,
+            "GEAK_GPU_DEVICE": devs,
+        }
+
+    def _stats_log_loop(self) -> None:
+        while not self._closed:
+            time.sleep(self._stats_log_interval_s)
+            if self._closed:
+                return
+            s = self.stats
+            uptime = s["manager_uptime_s"]
+            parts = []
+            for g in self._gpu_ids:
+                busy = s["busy_seconds_per_gpu"].get(g, 0.0)
+                pct = int(100 * busy / uptime) if uptime > 0 else 0
+                parts.append(f"{g}:{pct}%")
+            util_str = ",".join(parts)
+            logger.info(
+                "gpu_manager.stats: util={%s} queue=%d in_flight=%d jobs=%d/%d uptime=%.0fs",
+                util_str,
+                s["queue_depth"],
+                s["in_flight"],
+                s["total_jobs_completed"],
+                s["total_jobs_submitted"],
+                uptime,
+            )

--- a/src/minisweagent/run/utils/gpu_manager.py
+++ b/src/minisweagent/run/utils/gpu_manager.py
@@ -110,9 +110,7 @@ class GPUManager:
         self._gpu_ids = list(gpu_ids)
         self._registry = registry
         self._stats_log_interval_s = stats_log_interval_s
-        self._cpu_pressure_threshold = (
-            cpu_pressure_threshold if cpu_pressure_threshold is not None else 0.8
-        )
+        self._cpu_pressure_threshold = cpu_pressure_threshold if cpu_pressure_threshold is not None else 0.8
         self._reaper_interval_s = reaper_interval_s
 
         self._free: set[int] = set(gpu_ids)

--- a/src/minisweagent/run/utils/gpu_manager.py
+++ b/src/minisweagent/run/utils/gpu_manager.py
@@ -246,7 +246,7 @@ class GPUManager:
                 pct = int(100 * busy / uptime) if uptime > 0 else 0
                 parts.append(f"{g}:{pct}%")
             util_str = ",".join(parts)
-            logger.info(
+            logger.debug(
                 "gpu_manager.stats: util={%s} queue=%d in_flight=%d jobs=%d/%d uptime=%.0fs",
                 util_str,
                 s["queue_depth"],

--- a/src/minisweagent/run/utils/parallel_helpers.py
+++ b/src/minisweagent/run/utils/parallel_helpers.py
@@ -529,6 +529,7 @@ def run_pool(
     soft_stop=None,
     registry=None,
     gpu_manager=None,
+    llm_semaphore=None,
 ) -> list[tuple[int, Any, Any, Any]]:
     """Run M tasks across N GPU slots with overflow queuing.
 
@@ -710,6 +711,8 @@ def run_pool(
                 agent._gpu_manager = gpu_manager
                 if hasattr(agent, "_setup_save_and_test_context"):
                     agent._setup_save_and_test_context()
+            if llm_semaphore is not None:
+                agent._llm_semaphore = llm_semaphore
 
             try:
                 from minisweagent.memory.integration import (  # pylint: disable=import-error,no-name-in-module

--- a/src/minisweagent/run/utils/parallel_helpers.py
+++ b/src/minisweagent/run/utils/parallel_helpers.py
@@ -528,6 +528,7 @@ def run_pool(
     deadline=None,
     soft_stop=None,
     registry=None,
+    gpu_manager=None,
 ) -> list[tuple[int, Any, Any, Any]]:
     """Run M tasks across N GPU slots with overflow queuing.
 
@@ -703,6 +704,10 @@ def run_pool(
             # Run-level ProcessRegistry -> save_and_test inner subprocess.run.
             if registry is not None:
                 agent._registry = registry
+                if hasattr(agent, "_setup_save_and_test_context"):
+                    agent._setup_save_and_test_context()
+            if gpu_manager is not None:
+                agent._gpu_manager = gpu_manager
                 if hasattr(agent, "_setup_save_and_test_context"):
                     agent._setup_save_and_test_context()
 

--- a/src/minisweagent/run/utils/parallel_helpers.py
+++ b/src/minisweagent/run/utils/parallel_helpers.py
@@ -10,7 +10,6 @@ import concurrent.futures
 import json
 import logging
 import os
-import queue as queue_mod
 import re
 import shutil
 import subprocess
@@ -560,14 +559,6 @@ def run_pool(
     worktree_base.mkdir(parents=True, exist_ok=True)
     repo_path_resolved = repo_path.resolve()
 
-    # Thread-safe GPU pool: each GPU ID can be acquired/released
-    gpu_queue = queue_mod.Queue()
-    for gid in gpu_ids:
-        gpu_queue.put(gid)
-
-    # Map gpu_id -> slot index for worktree naming
-    gpu_to_slot = {gid: idx for idx, gid in enumerate(gpu_ids)}
-
     # Sort tasks by priority (lower = runs first)
     sorted_tasks = sorted(enumerate(tasks), key=lambda t: t[1].priority)
     _label_counts: dict[str, int] = {}
@@ -577,283 +568,260 @@ def run_pool(
     _has_dup_labels = any(c > 1 for c in _label_counts.values())
 
     def execute_task(task_id: int, task) -> tuple[int, Any, Any, Any]:
-        """Execute a single task on dynamically-assigned GPU(s)."""
-        # Defense in depth: SoftStop may have fired between submission and
-        # the executor actually starting this thread.
+        """Execute a single task (GPU-independent; benchmarking uses GPUManager)."""
         if soft_stop is not None and soft_stop.is_set():
             logger.info("execute_task[%d]: SoftStop set before start; skipping", task_id)
             return task_id, None, "SoftStop", "skipped before start"
 
-        needed = getattr(task, "num_gpus", 1) or 1
-        needed = min(needed, n_slots)
-        acquired_gpus: list[int] = []
-        for _ in range(needed):
-            acquired_gpus.append(gpu_queue.get())  # blocks until a GPU is free
-        gpu_id = acquired_gpus[0]
-        slot_idx = gpu_to_slot[gpu_id]
-        hip_devices = ",".join(str(g) for g in acquired_gpus)
+        slot_idx = task_id
+
+        label = task.label or task.agent_class.__name__
+        if console:
+            with _stdout_lock:
+                console.print(f"[bold green]Task {task_id} ({label}): started (slot {slot_idx})[/bold green]")
+        logger.info("Task %d (%s): started (slot %d)", task_id, label, slot_idx)
+
+        # Create or reset worktree for this slot
+        wt_path = worktree_base / f"slot_{slot_idx}"
+        if is_git_repo:
+            starting_patch = task.config.get("starting_patch")
+            if starting_patch:
+                create_worktree_with_patch(repo_path, wt_path, starting_patch)
+            else:
+                create_worktree(repo_path, wt_path)
+        else:
+            create_copy_workdir(repo_path, wt_path)
+            bootstrap_git_repo(wt_path, console)
+        wt_path_str = str(wt_path.resolve())
+
+        # Each task gets its own patch dir named by label (persists across worktree resets)
+        if _has_dup_labels:
+            dir_name = f"{task.label}_{task_id}" if task.label else f"task_{task_id}"
+        else:
+            dir_name = task.label if task.label else f"task_{task_id}"
+        task_patch_dir = (base_patch_dir / dir_name).resolve()
+        task_patch_dir.mkdir(parents=True, exist_ok=True)
+
+        # Build agent config
+        cfg = agent_config.copy()
+        cfg.update(task.config)
+        cfg["patch_output_dir"] = str(task_patch_dir)
+        # Only set interactive-mode fields for agents that accept them
+        from minisweagent.agents.interactive import InteractiveAgent
+
+        if issubclass(task.agent_class, InteractiveAgent):
+            cfg.setdefault("mode", "yolo")
+            cfg.setdefault("confirm_exit", False)
+        if task.step_limit:
+            cfg["step_limit"] = task.step_limit
+        if task.cost_limit:
+            cfg["cost_limit"] = task.cost_limit
+
+        log_file = task_patch_dir / f"task_{task_id}.log"
+
+        if cfg.get("test_command"):
+            cfg["test_command"] = replace_paths(cfg["test_command"], repo_path, wt_path)
+
+        # Resolve task text
+        agent_task = task.task if task.task else base_task_content
+        agent_task = replace_paths(agent_task, repo_path, wt_path)
+
+        # Create model and environment (GPU-independent -- GPUManager
+        # assigns GPUs per-job at benchmark time via save_and_test).
+        parallel_model = model_factory()
+        base_env = env_factory()
+        env_config_dict = base_env.config.__dict__.copy() if hasattr(base_env, "config") else {}
+        env_config_dict["cwd"] = wt_path_str
+        patched_env = {
+            **(env_config_dict.get("env") or {}),
+            "GEAK_WORK_DIR": wt_path_str,
+            "GEAK_REPO_ROOT": str(repo_path.resolve()),
+        }
+        geak_harness = patched_env.get("GEAK_HARNESS")
+        if isinstance(geak_harness, str) and geak_harness:
+            patched_env["GEAK_HARNESS"] = replace_paths(geak_harness, repo_path, wt_path)
+        env_config_dict["env"] = patched_env
+        parallel_env = type(base_env)(**env_config_dict)
+
+        parallel_output = None
+        if output:
+            parallel_output = output.parent / f"{output.stem}_task_{task_id}{output.suffix}"
+
+        # region agent log
+        emit_debug_log(
+            "parallel_agent.py:execute_task:before_run",
+            "Launching parallel optimization worker",
+            {
+                "task_id": task_id,
+                "label": label,
+                "slot_idx": slot_idx,
+                "step_limit": cfg.get("step_limit"),
+                "geak_harness": patched_env.get("GEAK_HARNESS"),
+                "worktree": wt_path_str,
+                "patch_dir": str(task_patch_dir),
+                "patch_dir_entries": sorted(p.name for p in task_patch_dir.iterdir())[:10],
+                "parallel_output": str(parallel_output) if parallel_output else None,
+            },
+            hypothesis_id="H5",
+        )
+        # endregion
+
+        _wm_bm_path = cfg.pop("baseline_metrics", None)
+        _wm_bb_path = cfg.pop("benchmark_baseline", None)
+
+        agent = task.agent_class(parallel_model, parallel_env, **cfg)
+        if hasattr(agent, "base_repo_path"):
+            agent.base_repo_path = repo_path_resolved
+        if hasattr(agent, "log_file"):
+            agent.log_file = log_file
+        # Wall-clock soft-stop -> sub-agent step loop.
+        if soft_stop is not None:
+            agent._soft_stop = soft_stop
+        # Run-level ProcessRegistry -> save_and_test inner subprocess.run.
+        if registry is not None:
+            agent._registry = registry
+            if hasattr(agent, "_setup_save_and_test_context"):
+                agent._setup_save_and_test_context()
+        if gpu_manager is not None:
+            agent._gpu_manager = gpu_manager
+            if hasattr(agent, "_setup_save_and_test_context"):
+                agent._setup_save_and_test_context()
+        if llm_semaphore is not None:
+            agent._llm_semaphore = llm_semaphore
 
         try:
-            label = task.label or task.agent_class.__name__
-            if console:
-                with _stdout_lock:
-                    console.print(
-                        f"[bold green]Task {task_id} ({label}): "
-                        f"assigned to GPU(s) {hip_devices} (slot {slot_idx})[/bold green]"
-                    )
-            logger.info("Task %d (%s): assigned to GPU(s) %s (slot %d)", task_id, label, hip_devices, slot_idx)
-
-            # Create or reset worktree for this slot
-            wt_path = worktree_base / f"slot_{slot_idx}"
-            if is_git_repo:
-                starting_patch = task.config.get("starting_patch")
-                if starting_patch:
-                    create_worktree_with_patch(repo_path, wt_path, starting_patch)
-                else:
-                    create_worktree(repo_path, wt_path)
-            else:
-                create_copy_workdir(repo_path, wt_path)
-                bootstrap_git_repo(wt_path, console)
-            wt_path_str = str(wt_path.resolve())
-
-            # Each task gets its own patch dir named by label (persists across worktree resets)
-            if _has_dup_labels:
-                dir_name = f"{task.label}_{task_id}" if task.label else f"task_{task_id}"
-            else:
-                dir_name = task.label if task.label else f"task_{task_id}"
-            task_patch_dir = (base_patch_dir / dir_name).resolve()
-            task_patch_dir.mkdir(parents=True, exist_ok=True)
-
-            # Build agent config
-            cfg = agent_config.copy()
-            cfg.update(task.config)
-            cfg["patch_output_dir"] = str(task_patch_dir)
-            # Only set interactive-mode fields for agents that accept them
-            from minisweagent.agents.interactive import InteractiveAgent
-
-            if issubclass(task.agent_class, InteractiveAgent):
-                cfg.setdefault("mode", "yolo")
-                cfg.setdefault("confirm_exit", False)
-            if task.step_limit:
-                cfg["step_limit"] = task.step_limit
-            if task.cost_limit:
-                cfg["cost_limit"] = task.cost_limit
-
-            log_file = task_patch_dir / f"task_{task_id}.log"
-
-            if cfg.get("test_command"):
-                cfg["test_command"] = replace_paths(cfg["test_command"], repo_path, wt_path)
-
-            # Resolve task text
-            agent_task = task.task if task.task else base_task_content
-            agent_task = replace_paths(agent_task, repo_path, wt_path)
-
-            # Create model and environment with GPU assignment
-            parallel_model = model_factory()
-            base_env = env_factory()
-            env_config_dict = base_env.config.__dict__.copy() if hasattr(base_env, "config") else {}
-            env_config_dict["cwd"] = wt_path_str
-            # Create a NEW dict to avoid shared-reference race across threads
-            patched_env = {
-                **(env_config_dict.get("env") or {}),
-                "HIP_VISIBLE_DEVICES": hip_devices,
-                "GEAK_WORK_DIR": wt_path_str,
-                "GEAK_REPO_ROOT": str(repo_path.resolve()),
-                "GEAK_GPU_DEVICE": hip_devices,
-            }
-            geak_harness = patched_env.get("GEAK_HARNESS")
-            if isinstance(geak_harness, str) and geak_harness:
-                patched_env["GEAK_HARNESS"] = replace_paths(geak_harness, repo_path, wt_path)
-            env_config_dict["env"] = patched_env
-            parallel_env = type(base_env)(**env_config_dict)
-
-            parallel_output = None
-            if output:
-                parallel_output = output.parent / f"{output.stem}_task_{task_id}{output.suffix}"
-
-            # region agent log
-            emit_debug_log(
-                "parallel_agent.py:execute_task:before_run",
-                "Launching parallel optimization worker",
-                {
-                    "task_id": task_id,
-                    "label": label,
-                    "slot_idx": slot_idx,
-                    "gpu_devices": hip_devices,
-                    "step_limit": cfg.get("step_limit"),
-                    "geak_harness": patched_env.get("GEAK_HARNESS"),
-                    "worktree": wt_path_str,
-                    "patch_dir": str(task_patch_dir),
-                    "patch_dir_entries": sorted(p.name for p in task_patch_dir.iterdir())[:10],
-                    "parallel_output": str(parallel_output) if parallel_output else None,
-                },
-                hypothesis_id="H5",
+            from minisweagent.memory.integration import (  # pylint: disable=import-error,no-name-in-module
+                is_working_memory_enabled,
             )
-            # endregion
 
-            _wm_bm_path = cfg.pop("baseline_metrics", None)
-            _wm_bb_path = cfg.pop("benchmark_baseline", None)
-
-            agent = task.agent_class(parallel_model, parallel_env, **cfg)
-            if hasattr(agent, "base_repo_path"):
-                agent.base_repo_path = repo_path_resolved
-            if hasattr(agent, "log_file"):
-                agent.log_file = log_file
-            # Wall-clock soft-stop -> sub-agent step loop.
-            if soft_stop is not None:
-                agent._soft_stop = soft_stop
-            # Run-level ProcessRegistry -> save_and_test inner subprocess.run.
-            if registry is not None:
-                agent._registry = registry
-                if hasattr(agent, "_setup_save_and_test_context"):
-                    agent._setup_save_and_test_context()
-            if gpu_manager is not None:
-                agent._gpu_manager = gpu_manager
-                if hasattr(agent, "_setup_save_and_test_context"):
-                    agent._setup_save_and_test_context()
-            if llm_semaphore is not None:
-                agent._llm_semaphore = llm_semaphore
-
-            try:
-                from minisweagent.memory.integration import (  # pylint: disable=import-error,no-name-in-module
-                    is_working_memory_enabled,
+            if is_working_memory_enabled():
+                from minisweagent.memory.working_memory import (  # pylint: disable=import-error,no-name-in-module
+                    WorkingMemory,
                 )
 
-                if is_working_memory_enabled():
-                    from minisweagent.memory.working_memory import (  # pylint: disable=import-error,no-name-in-module
-                        WorkingMemory,
-                    )
-
-                    _wm_notebook_dir = None
-                    if _wm_bm_path:
-                        try:
-                            _wm_notebook_dir = str(Path(_wm_bm_path).resolve().parent / "_working_memory")
-                        except Exception as exc:
-                            logger.debug("WM notebook dir resolution failed: %s", exc)
-                            _wm_notebook_dir = None
-                    # Extract kernel name from baseline_metrics path
-                    _wm_kernel_cat = "unknown"
-                    if _wm_bm_path:
-                        _km = re.search(r"geak_eval_L\d+_(.+?)_\d{8}_\d{6}", _wm_bm_path)
-                        if _km:
-                            _wm_kernel_cat = _km.group(1)
-                    _wm = WorkingMemory(
-                        kernel_category=_wm_kernel_cat,
-                        max_steps=cfg.get("step_limit", int(os.environ.get("GEAK_AGENT_STEP_LIMIT", "100"))),
-                        notebook_dir=_wm_notebook_dir,
-                        notebook_writer_id=f"{task.label or f'task_{task_id}'}-slot-{slot_idx}",
-                    )
-                    _wm.load_baseline_from_artifacts(
-                        baseline_metrics_path=_wm_bm_path,
-                        benchmark_baseline_path=_wm_bb_path,
-                    )
-                    _wm.sync_notebook_baseline()
-                    # V2: Generate profiler diagnosis from baseline_metrics
-                    if _wm_bm_path and Path(_wm_bm_path).exists():
-                        try:
-                            _bm2 = json.loads(Path(_wm_bm_path).read_text())
-                            _top = _bm2.get("top_kernels", [])
-                            if len(_top) > 3:
-                                _target = _top[0] if _top else {}
-                                _target_pct = _target.get("pct_of_total", 0)
-                                _ext_pct = 100 - _target_pct
-                                _top_summary = "; ".join(
-                                    f"{k.get('name', '?')[:40]}: {k.get('duration_us', 0):.1f}us ({k.get('pct_of_total', 0):.0f}%)"
-                                    for k in _top[:3]
+                _wm_notebook_dir = None
+                if _wm_bm_path:
+                    try:
+                        _wm_notebook_dir = str(Path(_wm_bm_path).resolve().parent / "_working_memory")
+                    except Exception as exc:
+                        logger.debug("WM notebook dir resolution failed: %s", exc)
+                        _wm_notebook_dir = None
+                # Extract kernel name from baseline_metrics path
+                _wm_kernel_cat = "unknown"
+                if _wm_bm_path:
+                    _km = re.search(r"geak_eval_L\d+_(.+?)_\d{8}_\d{6}", _wm_bm_path)
+                    if _km:
+                        _wm_kernel_cat = _km.group(1)
+                _wm = WorkingMemory(
+                    kernel_category=_wm_kernel_cat,
+                    max_steps=cfg.get("step_limit", int(os.environ.get("GEAK_AGENT_STEP_LIMIT", "100"))),
+                    notebook_dir=_wm_notebook_dir,
+                    notebook_writer_id=f"{task.label or f'task_{task_id}'}-slot-{slot_idx}",
+                )
+                _wm.load_baseline_from_artifacts(
+                    baseline_metrics_path=_wm_bm_path,
+                    benchmark_baseline_path=_wm_bb_path,
+                )
+                _wm.sync_notebook_baseline()
+                # V2: Generate profiler diagnosis from baseline_metrics
+                if _wm_bm_path and Path(_wm_bm_path).exists():
+                    try:
+                        _bm2 = json.loads(Path(_wm_bm_path).read_text())
+                        _top = _bm2.get("top_kernels", [])
+                        if len(_top) > 3:
+                            _target = _top[0] if _top else {}
+                            _target_pct = _target.get("pct_of_total", 0)
+                            _ext_pct = 100 - _target_pct
+                            _top_summary = "; ".join(
+                                f"{k.get('name', '?')[:40]}: {k.get('duration_us', 0):.1f}us ({k.get('pct_of_total', 0):.0f}%)"
+                                for k in _top[:3]
+                            )
+                            if _ext_pct > 50:
+                                _wm.profiler_diagnosis = (
+                                    f"[ARCHITECTURE ALERT] Profiler shows {len(_top)} sub-kernels. "
+                                    f"Top 3: {_top_summary}. "
+                                    f"No single kernel dominates (largest is {_target_pct:.0f}%). "
+                                    "This usually means the entry point dispatches to UNFUSED external library calls. "
+                                    "FIRST ACTION: Check triton_op() for try/except that falls through to aiter or other libraries. "
+                                    "Bypass to use the local fused kernel. Also check for repeat_interleave or .contiguous() calls."
                                 )
-                                if _ext_pct > 50:
-                                    _wm.profiler_diagnosis = (
-                                        f"[ARCHITECTURE ALERT] Profiler shows {len(_top)} sub-kernels. "
-                                        f"Top 3: {_top_summary}. "
-                                        f"No single kernel dominates (largest is {_target_pct:.0f}%). "
-                                        "This usually means the entry point dispatches to UNFUSED external library calls. "
-                                        "FIRST ACTION: Check triton_op() for try/except that falls through to aiter or other libraries. "
-                                        "Bypass to use the local fused kernel. Also check for repeat_interleave or .contiguous() calls."
-                                    )
-                                elif _target_pct > 60:
-                                    _wm.profiler_diagnosis = (
-                                        f"[PROFILER] Target kernel ({_target.get('name', '?')[:40]}) dominates at {_target_pct:.0f}%. "
-                                        "Focus optimization on the kernel body itself."
-                                    )
-                        except Exception as exc:
-                            logger.debug("Profiler diagnosis from baseline_metrics failed: %s", exc)
-                    agent._working_memory = _wm
+                            elif _target_pct > 60:
+                                _wm.profiler_diagnosis = (
+                                    f"[PROFILER] Target kernel ({_target.get('name', '?')[:40]}) dominates at {_target_pct:.0f}%. "
+                                    "Focus optimization on the kernel body itself."
+                                )
+                    except Exception as exc:
+                        logger.debug("Profiler diagnosis from baseline_metrics failed: %s", exc)
+                agent._working_memory = _wm
+        except Exception as exc:
+            logger.debug("WorkingMemory init failed for task %d: %s", task_id, exc)
+
+        with open(log_file, "w", encoding="utf-8") as f:
+            f.write(f"Task {task_id} ({label}) Conversation Log\n")
+            f.write(f"Slot: {slot_idx} | Priority: {task.priority} | Language: {task.kernel_language}\n")
+            f.write("=" * 60 + "\n\n")
+
+        logger.info("[dim]Sub-agent %d (%s) started (slot %d)[/dim]", task_id, label, slot_idx)
+        _agent_t0 = time.monotonic()
+        exit_status, result, extra_info = None, None, None
+        with redirect_output_fn(log_file):
+            try:
+                exit_status, result = agent.run(agent_task, _is_parallel_mode=True)
+            except TerminatingException as e:
+                exit_status, result = type(e).__name__, str(e)
+                with open(log_file, "a", encoding="utf-8") as f:
+                    f.write(f"\n\n{exit_status}: {result}\n")
+            except Exception as e:
+                exit_status, result = type(e).__name__, str(e)
+                extra_info = {"traceback": traceback.format_exc()}
+                with open(log_file, "a", encoding="utf-8") as f:
+                    f.write(f"\n\nERROR: {exit_status}: {result}\n")
+                    f.write(f"Traceback:\n{extra_info['traceback']}\n")
+            finally:
+                if parallel_output and save_traj_fn:
+                    save_traj_fn(agent, parallel_output, exit_status=exit_status, result=result, extra_info=extra_info)
+        _agent_elapsed = time.monotonic() - _agent_t0
+        logger.info("Sub-agent %d (%s) finished in %.0fs (exit=%s)", task_id, label, _agent_elapsed, exit_status)
+
+        # Auto-extract final patch from worktree if agent didn't save any
+        if not list(task_patch_dir.glob("patch_*.patch")) and wt_path.exists():
+            try:
+                _diff = subprocess.run(
+                    ["git", "diff", "HEAD"],
+                    cwd=str(wt_path),
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if _diff.returncode == 0 and _diff.stdout.strip():
+                    (task_patch_dir / "patch_0.patch").write_text(_diff.stdout)
             except Exception as exc:
-                logger.debug("WorkingMemory init failed for task %d: %s", task_id, exc)
+                logger.debug("Auto-extract patch via git diff failed: %s", exc)
 
-            with open(log_file, "w", encoding="utf-8") as f:
-                f.write(f"Task {task_id} ({label}) Conversation Log\n")
-                f.write(f"GPU: {hip_devices} | Priority: {task.priority} | Language: {task.kernel_language}\n")
-                f.write("=" * 60 + "\n\n")
+        # region agent log
+        emit_debug_log(
+            "parallel_agent.py:execute_task:after_run",
+            "Parallel optimization worker returned from agent.run",
+            {
+                "task_id": task_id,
+                "label": label,
+                "slot_idx": slot_idx,
+                "exit_status": str(exit_status),
+                "result_preview": (str(result)[:300] if result is not None else None),
+                "has_traceback": bool(extra_info and extra_info.get("traceback")),
+                "patch_count": len(list(task_patch_dir.glob("*.patch"))),
+                "best_results_present": (task_patch_dir / "best_results.json").exists(),
+            },
+            hypothesis_id="H7",
+        )
+        # endregion
 
-            logger.info("[dim]Sub-agent %d (%s) started on GPU %s[/dim]", task_id, label, hip_devices)
-            _agent_t0 = time.monotonic()
-            exit_status, result, extra_info = None, None, None
-            with redirect_output_fn(log_file):
-                try:
-                    exit_status, result = agent.run(agent_task, _is_parallel_mode=True)
-                except TerminatingException as e:
-                    exit_status, result = type(e).__name__, str(e)
-                    with open(log_file, "a", encoding="utf-8") as f:
-                        f.write(f"\n\n{exit_status}: {result}\n")
-                except Exception as e:
-                    exit_status, result = type(e).__name__, str(e)
-                    extra_info = {"traceback": traceback.format_exc()}
-                    with open(log_file, "a", encoding="utf-8") as f:
-                        f.write(f"\n\nERROR: {exit_status}: {result}\n")
-                        f.write(f"Traceback:\n{extra_info['traceback']}\n")
-                finally:
-                    if parallel_output and save_traj_fn:
-                        save_traj_fn(
-                            agent, parallel_output, exit_status=exit_status, result=result, extra_info=extra_info
-                        )
-            _agent_elapsed = time.monotonic() - _agent_t0
-            logger.info("Sub-agent %d (%s) finished in %.0fs (exit=%s)", task_id, label, _agent_elapsed, exit_status)
+        if console:
+            with _stdout_lock:
+                console.print(f"[bold blue]Task {task_id} ({label}): completed (slot {slot_idx})[/bold blue]")
+        logger.info("Task %d (%s): completed (slot %d)", task_id, label, slot_idx)
 
-            # Auto-extract final patch from worktree if agent didn't save any
-            if not list(task_patch_dir.glob("patch_*.patch")) and wt_path.exists():
-                try:
-                    _diff = subprocess.run(
-                        ["git", "diff", "HEAD"],
-                        cwd=str(wt_path),
-                        capture_output=True,
-                        text=True,
-                        timeout=30,
-                    )
-                    if _diff.returncode == 0 and _diff.stdout.strip():
-                        (task_patch_dir / "patch_0.patch").write_text(_diff.stdout)
-                except Exception as exc:
-                    logger.debug("Auto-extract patch via git diff failed: %s", exc)
-
-            # region agent log
-            emit_debug_log(
-                "parallel_agent.py:execute_task:after_run",
-                "Parallel optimization worker returned from agent.run",
-                {
-                    "task_id": task_id,
-                    "label": label,
-                    "slot_idx": slot_idx,
-                    "gpu_devices": hip_devices,
-                    "exit_status": str(exit_status),
-                    "result_preview": (str(result)[:300] if result is not None else None),
-                    "has_traceback": bool(extra_info and extra_info.get("traceback")),
-                    "patch_count": len(list(task_patch_dir.glob("*.patch"))),
-                    "best_results_present": (task_patch_dir / "best_results.json").exists(),
-                },
-                hypothesis_id="H7",
-            )
-            # endregion
-
-            if console:
-                with _stdout_lock:
-                    console.print(f"[bold blue]Task {task_id} ({label}): completed on GPU(s) {hip_devices}[/bold blue]")
-            logger.info("Task %d (%s): completed on GPU(s) %s", task_id, label, hip_devices)
-
-            return task_id, agent, exit_status, result
-
-        finally:
-            for g in acquired_gpus:
-                gpu_queue.put(g)
+        return task_id, agent, exit_status, result
 
     # Progress reporting thread
     _progress_stop = threading.Event()
@@ -901,7 +869,7 @@ def run_pool(
     # ``shutdown(wait=False, cancel_futures=True)`` and return immediately so
     # the orchestrator can call finalize_run within finalize_grace_s.
     results: list = []
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=n_slots)
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=n_tasks)
     soft_stop_observed = False
     try:
         futures: dict[concurrent.futures.Future, int] = {}

--- a/src/minisweagent/run/utils/prompts.py
+++ b/src/minisweagent/run/utils/prompts.py
@@ -32,6 +32,8 @@ Extract the following information (return null if not found):
 9. output_dir: Directory path where output logs and artifacts should be saved (e.g., "outputs/topk_run", "/workspace/results")
 10. model: Model name or identifier to use (e.g., "claude-sonnet-4-20250514", "gpt-4o")
 11. config: Path to a YAML configuration file (e.g., "configs/my_setup.yaml", "/path/to/config.yaml")
+12. gpu_oversubscribe: GPU oversubscription multiplier (float, e.g. 2.0 means run 2x as many agents as GPUs). Only set if the user explicitly mentions oversubscription, agent-to-GPU ratio, or similar.
+13. max_concurrent_llm: Maximum concurrent LLM requests (integer). Only set if the user explicitly mentions limiting or capping LLM concurrency.
 
 Return ONLY a valid JSON object with these keys. Example:
 {{
@@ -45,7 +47,9 @@ Return ONLY a valid JSON object with these keys. Example:
   "gpu_ids": "0,1,2,3",
   "output_dir": "outputs/matmul_run",
   "model": null,
-  "config": null
+  "config": null,
+  "gpu_oversubscribe": null,
+  "max_concurrent_llm": null
 }}
 
 If any field cannot be determined from the task, set it to null.

--- a/src/minisweagent/run/utils/task_parser.py
+++ b/src/minisweagent/run/utils/task_parser.py
@@ -28,6 +28,8 @@ _EMPTY_TASK_INFO: dict = {
     "output_dir": None,
     "model": None,
     "config": None,
+    "gpu_oversubscribe": None,
+    "max_concurrent_llm": None,
 }
 
 _EMPTY_PIPELINE_PARAMS: dict = {
@@ -341,6 +343,8 @@ def _normalize_parsed_task_info(parsed: dict) -> dict:
         "output_dir": parsed.get("output_dir"),
         "model": parsed.get("model"),
         "config": parsed.get("config"),
+        "gpu_oversubscribe": None,
+        "max_concurrent_llm": None,
     }
 
     # Normalize repo path and preserve filesystem case (LLM often returns lowercase)
@@ -383,6 +387,18 @@ def _normalize_parsed_task_info(parsed: dict) -> dict:
         result["output_dir"] = _normalize_path(result["output_dir"])
     if result["config"]:
         result["config"] = _normalize_path(result["config"])
+
+    for field, coerce in (("gpu_oversubscribe", float), ("max_concurrent_llm", int)):
+        raw = parsed.get(field)
+        if raw is not None:
+            try:
+                val = coerce(raw)
+                if val > 0:
+                    result[field] = val
+                else:
+                    logger.debug("parse_task_info: %s=%r not positive; clearing.", field, raw)
+            except (ValueError, TypeError):
+                logger.debug("parse_task_info: invalid %s value %r; clearing.", field, raw)
 
     populated = sorted(k for k, v in result.items() if v is not None and v != "")
     logger.debug("parse_task_info: extracted non-empty fields: %s", populated)

--- a/src/minisweagent/tools/save_and_test.py
+++ b/src/minisweagent/tools/save_and_test.py
@@ -132,6 +132,7 @@ class SaveAndTestContext:
     # Without this, a 30-min benchmark started here would run past the
     # ``--mode quick`` budget because nothing else in the call stack tracks it.
     registry: "ProcessRegistry | None" = None
+    gpu_manager: Any = None
 
 
 def _tracked_subprocess_run(
@@ -597,6 +598,72 @@ class SaveAndTestTool:
         profile_env: dict[str, str],
         gpu_devices: str,
     ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+        ctx = self.context
+        if ctx and ctx.gpu_manager is not None:
+            raw_result = self._run_patch_profile_via_manager(
+                harness_path=harness_path,
+                gpu_devices=gpu_devices,
+                workdir=ctx.cwd if ctx else None,
+            )
+        else:
+            raw_result = self._run_patch_profile_direct(
+                harness_path=harness_path,
+                profile_env=profile_env,
+                gpu_devices=gpu_devices,
+            )
+
+        metrics: dict[str, Any] = {}
+        if raw_result:
+            try:
+                from minisweagent.run.preprocess.baseline import build_baseline_metrics
+
+                metrics = build_baseline_metrics(raw_result, include_all=True)
+            except Exception:
+                logger.debug("build_baseline_metrics failed; using empty metrics", exc_info=True)
+                metrics = {}
+        return raw_result, metrics
+
+    def _run_patch_profile_via_manager(
+        self,
+        *,
+        harness_path: Path,
+        gpu_devices: str,
+        workdir: str | None,
+    ) -> dict[str, Any] | None:
+        """Profile via GPUManager — runs in a clean subprocess, no os.environ mutation."""
+        from minisweagent.run.preprocess.profiler_runner import run_profiler_with_handle
+        from minisweagent.run.utils.gpu_manager import GpuJob
+
+        ctx = self.context
+
+        def _gpu_job(gpus: list[int], env_overrides: dict[str, str]) -> dict[str, Any] | None:
+            return run_profiler_with_handle(
+                perf_cmd=f"python {harness_path} --profile",
+                backend="metrix",
+                gpu_id=gpus[0],
+                workdir=workdir,
+                num_replays=3,
+                quick=True,
+                registry=ctx.registry if ctx else None,
+            )
+
+        return ctx.gpu_manager.run(
+            GpuJob(
+                fn=_gpu_job,
+                num_gpus=1,
+                timeout=float(ctx.timeout) if ctx else None,
+                label=f"profile:{Path(harness_path).stem}",
+            )
+        )
+
+    def _run_patch_profile_direct(
+        self,
+        *,
+        harness_path: Path,
+        profile_env: dict[str, str],
+        gpu_devices: str,
+    ) -> dict[str, Any] | None:
+        """Legacy in-process profile path (no gpu_manager available)."""
         from minisweagent.run.pipeline_helpers import _ensure_mcp_importable
 
         _ensure_mcp_importable()
@@ -614,17 +681,7 @@ class SaveAndTestTool:
             )
         finally:
             self._restore_process_env(previous, newly_added)
-
-        metrics: dict[str, Any] = {}
-        if raw_result:
-            try:
-                from minisweagent.run.preprocess.baseline import build_baseline_metrics
-
-                metrics = build_baseline_metrics(raw_result, include_all=True)
-            except Exception:
-                logger.debug("build_baseline_metrics failed; using empty metrics", exc_info=True)
-                metrics = {}
-        return raw_result, metrics
+        return raw_result
 
     def _save_profile_output(self, patch_name: str, profile_payload: dict[str, Any]) -> str | None:
         ctx = self.context
@@ -1101,17 +1158,42 @@ class SaveAndTestTool:
         test_command = self._ensure_test_script_exists(test_command)
         self._log(f"[SaveAndTest] Running: {test_command}")
 
+        if ctx.gpu_manager is not None:
+            return self._run_test_via_gpu_manager(test_command, test_env)
+        return self._run_test_direct(test_command, test_env)
+
+    def _run_test_via_gpu_manager(self, test_command: str, test_env: dict[str, str]) -> tuple[str, bool, int]:
+        """Run test through GPUManager — GPU acquired only for subprocess duration."""
+        from minisweagent.run.utils.gpu_manager import GpuJob
+
+        ctx = self.context
+
+        def _gpu_job(gpus: list[int], env_overrides: dict[str, str]) -> tuple[str, bool, int]:
+            merged_env = {**test_env, **env_overrides}
+            return self._run_test_subprocess(test_command, merged_env)
+
+        return ctx.gpu_manager.run(
+            GpuJob(
+                fn=_gpu_job,
+                num_gpus=1,
+                timeout=ctx.timeout,
+                label=f"save_and_test:{Path(ctx.cwd).name}",
+            ),
+        )
+
+    def _run_test_direct(self, test_command: str, test_env: dict[str, str]) -> tuple[str, bool, int]:
+        """Run test directly (legacy path when no GPUManager is available)."""
+        return self._run_test_subprocess(test_command, test_env)
+
+    def _run_test_subprocess(self, test_command: str, test_env: dict[str, str]) -> tuple[str, bool, int]:
+        """Execute test command as a subprocess and return (output, passed, returncode)."""
+        ctx = self.context
+
         with tempfile.NamedTemporaryFile(mode="w+", delete=False, suffix=".txt") as tmp:
             tmp_file = tmp.name
 
         try:
             wrapped_cmd = f"({test_command}) > {tmp_file} 2>&1; echo $? > {tmp_file}.exitcode"
-            # The test command is the long-running one (benchmarks routinely
-            # take 5-30 minutes). Track its Popen with the run-level registry
-            # so the budget watchdog can ``os.killpg`` it (and its GPU
-            # grandchildren) on a wall-clock timeout. Falls back to a plain
-            # ``subprocess.run``-equivalent when no registry is wired (tests,
-            # ad-hoc invocations).
             _tracked_subprocess_run(
                 wrapped_cmd,
                 registry=ctx.registry,

--- a/src/minisweagent/tools/save_and_test.py
+++ b/src/minisweagent/tools/save_and_test.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -27,6 +28,8 @@ from minisweagent.run.postprocess.benchmark_parsing import (
 from minisweagent.run.utils.generated_artifacts import (
     generated_helper_excludes,
     jit_cache_diff_basename_excludes,
+    jit_cache_env,
+    strip_already_present_additions,
     strip_jit_cache_sections,
 )
 
@@ -517,6 +520,15 @@ class SaveAndTestTool:
                     continue
                 test_env[str(key)] = str(value)
         test_env["PYTHONUNBUFFERED"] = "1"
+        # Layer 1 (primary) of the "no JIT artifacts in the round patch" fix:
+        # relocate Triton/JIT caches OUTSIDE the worktree (ctx.cwd) so the
+        # per-round ``git diff`` capture never sweeps compiled blobs into the
+        # patch (that broke the reactor's clean-checkout re-apply and pinned the
+        # A/B speedup at 1.0x, hiding real wins like fused_moe +1.68x). Set last
+        # so it overrides any stale in-worktree TRITON_CACHE_DIR inherited via
+        # env_vars; the sanitized harness (R5) defers to GEAK_JIT_CACHE_DIR.
+        if ctx and ctx.cwd:
+            test_env.update(jit_cache_env(ctx.cwd))
         return test_env
 
     @staticmethod
@@ -785,6 +797,59 @@ class SaveAndTestTool:
                 )
         return lines
 
+    def _source_pathspecs(self, cwd: str) -> list[str]:
+        """Return *cwd*-relative pathspecs for the agent's declared editable source.
+
+        Layer 3 (allowlist) of the "no JIT artifacts in the round patch" fix:
+        ``SaveAndTestContext.source_file_paths`` carries the files the agent is
+        allowed to modify. When known, the patch capture scopes its ``git diff``
+        to these so it can only ever record genuine source edits. Entries are
+        normalised to be relative to *cwd* (the worktree) -- accepting absolute
+        paths, paths relative to the worktree, and paths relative to
+        ``base_repo_path`` -- and filtered to those that actually exist in the
+        worktree. Returns ``[]`` when no editable set is configured (callers
+        then fall back to the blanket worktree diff).
+        """
+        ctx = self.context
+        raw = list(ctx.source_file_paths or []) if ctx else []
+        if not raw:
+            return []
+        cwd_path = Path(cwd).resolve()
+        base = Path(ctx.base_repo_path).resolve() if ctx and ctx.base_repo_path else None
+        out: list[str] = []
+        seen: set[str] = set()
+        for item in raw:
+            if not item:
+                continue
+            p = Path(str(item))
+            candidates: list[Path] = []
+            if p.is_absolute():
+                candidates.append(p)
+            else:
+                candidates.append(cwd_path / p)
+                if base is not None:
+                    candidates.append(base / p)
+            rel: str | None = None
+            for cand in candidates:
+                try:
+                    cand_res = cand.resolve()
+                except OSError:
+                    continue
+                for root in (cwd_path, base):
+                    if root is None:
+                        continue
+                    try:
+                        rel = str(cand_res.relative_to(root))
+                        break
+                    except ValueError:
+                        continue
+                if rel is not None:
+                    break
+            if rel and rel not in seen and (cwd_path / rel).exists():
+                seen.add(rel)
+                out.append(rel)
+        return out
+
     def _get_patch_content(self) -> str:
         """Get current changes as patch content."""
         ctx = self.context
@@ -832,9 +897,36 @@ class SaveAndTestTool:
                 # Build / compile caches
                 "__hip_fatbin/",
                 ".cache/",
+                # JIT runtime caches (TRITON_CACHE_DIR like .triton_cache_geak,
+                # .aiter_jit, flydsl_cache, ...) and compile outputs (*.hsaco,
+                # *.amdgcn, IR dumps). Pre-excluded so the diff never renders the
+                # ~680 KB of per-round JIT blobs that otherwise broke re-apply.
+                *jit_cache_diff_basename_excludes(),
                 *self._generated_helper_excludes(),
             ]
             exclude_args = " ".join(f"':(exclude){entry}'" for entry in excludes)
+
+            # Layer 3 (allowlist) of the patch-capture fix: when the agent's
+            # editable source set is known, scope the diff to it so the captured
+            # patch can ONLY contain genuine source edits -- never environmental
+            # noise (JIT caches, hipified copies, profiler dumps). Falls back to
+            # the blanket worktree diff below if the scoped capture is empty, so
+            # an edit outside the declared set is never silently dropped.
+            source_specs = self._source_pathspecs(cwd)
+            if source_specs:
+                spec_args = " ".join(shlex.quote(s) for s in source_specs)
+                scoped = subprocess.run(
+                    f"git add -N -- {spec_args} && git diff -- {spec_args} {exclude_args}",
+                    cwd=cwd,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    shell=True,
+                )
+                if scoped.returncode == 0 and scoped.stdout.strip():
+                    return self._sanitize_captured_patch(scoped.stdout)
+                # else: fall through to the blanket diff (don't lose real edits).
+
             result = subprocess.run(
                 f"git add -N . && git diff -- . {exclude_args}",
                 cwd=cwd,
@@ -844,7 +936,7 @@ class SaveAndTestTool:
                 shell=True,
             )
             if result.returncode == 0 and result.stdout.strip():
-                return self._strip_jit_cache_from_patch(result.stdout)
+                return self._sanitize_captured_patch(result.stdout)
             # Fall through to diff -ruN when git diff fails or returns empty.
 
         if ctx.base_repo_path and ctx.base_repo_path.exists():
@@ -927,6 +1019,41 @@ class SaveAndTestTool:
                 len(removed),
                 ", ".join(removed[:3]),
             )
+        return sanitized
+
+    def _sanitize_captured_patch(self, patch_text: str) -> str:
+        """Reduce a ``git diff`` capture to genuine source edits only.
+
+        Two scrubs, both keyed off the same root cause that pinned GEAK's A/B
+        speedup at 1.0x:
+
+        1. JIT/compile-cache sections (TRITON_CACHE_DIR blobs, IR dumps) -- the
+           ~680 KB of ``.triton_cache_geak/<hash>/fused_moe_kernel.*`` that broke
+           re-apply.
+        2. New-file additions for files that already exist in the base repo
+           (``base_repo_path``). ``git add -N .`` lists every untracked,
+           non-ignored file (quant configs, hipified ``*.hip``, profilers) as an
+           addition; ``create_worktree`` later seeds the eval worktree with those
+           same files, so re-adding them aborts the atomic apply with "already
+           exists". They are environmental, not agent-authored, so dropping them
+           leaves only the real edit (e.g. the ``get_default_config`` change).
+        """
+
+        if not patch_text:
+            return patch_text
+        sanitized = self._strip_jit_cache_from_patch(patch_text)
+
+        ctx = self.context
+        base = ctx.base_repo_path if ctx else None
+        if base is not None and Path(base).exists():
+            sanitized, removed = strip_already_present_additions(sanitized, base)
+            if removed:
+                logger.info(
+                    "save_and_test: dropped %d environmental addition(s) already present in "
+                    "base repo from captured patch (sample: %s)",
+                    len(removed),
+                    ", ".join(removed[:3]),
+                )
         return sanitized
 
     # Evaluation infrastructure files that agents must never modify.

--- a/src/minisweagent/tools/str_replace_editor.py
+++ b/src/minisweagent/tools/str_replace_editor.py
@@ -35,6 +35,25 @@ class str_replace_editor:
             return rewritten
         return path
 
+    @staticmethod
+    def _sandbox_path(path: str) -> str:
+        """Rewrite paths that point into the original repo to the agent's worktree.
+
+        Agents running in worktrees should never write to the original repo
+        (``GEAK_REPO_ROOT``). If the LLM passes an absolute path inside the
+        original repo, silently redirect it to the equivalent path inside
+        ``GEAK_WORK_DIR`` so the original stays pristine.
+        """
+        repo_root = os.environ.get("GEAK_REPO_ROOT", "")
+        work_dir = os.environ.get("GEAK_WORK_DIR", "")
+        if not repo_root or not work_dir or repo_root == work_dir:
+            return path
+        if path.startswith(repo_root + "/") or path == repo_root:
+            rewritten = work_dir + path[len(repo_root) :]
+            logger.debug("str_replace_editor: redirected %s -> %s", path, rewritten)
+            return rewritten
+        return path
+
     def __call__(
         self,
         *,

--- a/src/minisweagent/tools/str_replace_editor.py
+++ b/src/minisweagent/tools/str_replace_editor.py
@@ -35,25 +35,6 @@ class str_replace_editor:
             return rewritten
         return path
 
-    @staticmethod
-    def _sandbox_path(path: str) -> str:
-        """Rewrite paths that point into the original repo to the agent's worktree.
-
-        Agents running in worktrees should never write to the original repo
-        (``GEAK_REPO_ROOT``). If the LLM passes an absolute path inside the
-        original repo, silently redirect it to the equivalent path inside
-        ``GEAK_WORK_DIR`` so the original stays pristine.
-        """
-        repo_root = os.environ.get("GEAK_REPO_ROOT", "")
-        work_dir = os.environ.get("GEAK_WORK_DIR", "")
-        if not repo_root or not work_dir or repo_root == work_dir:
-            return path
-        if path.startswith(repo_root + "/") or path == repo_root:
-            rewritten = work_dir + path[len(repo_root) :]
-            logger.debug("str_replace_editor: redirected %s -> %s", path, rewritten)
-            return rewritten
-        return path
-
     def __call__(
         self,
         *,

--- a/subagents/preprocess/harness-sanitizer/SUBAGENT.yaml
+++ b/subagents/preprocess/harness-sanitizer/SUBAGENT.yaml
@@ -160,9 +160,31 @@ system_prompt: |
         `export PYTHONPATH="${REPO_SRC}:${PYTHONPATH:-}"`
       If it already sets PYTHONPATH with a hardcoded path, rewrite it.
 
-  R5. **JIT / build artifact paths**
-      Rewrite any hardcoded JIT cache or `.so` output paths to use
-      `$REPO_SRC` so each worktree builds independently.
+  R5. **JIT / build cache paths** — keep compile CACHES OUT of the worktree
+      Distinguish two cases:
+        (a) **In-place build outputs** — the `.so`/`.o` that a build step
+            (`setup.py build_ext --inplace`, `make`) produces next to the
+            source for the package to import: keep these under `$REPO_SRC`
+            so the worktree's *modified* source is what gets built and
+            loaded. (GEAK already excludes them from patch capture.)
+        (b) **Runtime / JIT compile caches** — Triton's `TRITON_CACHE_DIR`,
+            torch inductor, aiter runtime build dirs, etc.: these MUST live
+            OUTSIDE the worktree. NEVER point a JIT cache under `$REPO_SRC`
+            / `$GEAK_WORK_DIR`.
+      GEAK already exports `GEAK_JIT_CACHE_DIR` (a per-slot dir outside every
+      worktree) and a matching `TRITON_CACHE_DIR` into the environment, so the
+      best action is usually to LEAVE THEM ALONE. Only if a script *hardcodes*
+      a JIT cache path inside the repo, rewrite it to the out-of-worktree
+      location, e.g.:
+        `export TRITON_CACHE_DIR="${GEAK_JIT_CACHE_DIR:-${TMPDIR:-/tmp}/geak_jit_cache}/triton"`
+      and point any other JIT toolchain's cache env var at a subdir of
+      `$GEAK_JIT_CACHE_DIR`.
+      WHY this matters: GEAK captures the per-round patch with `git diff`
+      INSIDE the worktree. A JIT cache written there sweeps compiled blobs
+      (`*.hsaco` / IR dumps) into the patch, which breaks the reactor's clean
+      re-apply and collapses the measured A/B speedup to 1.0x — silently
+      discarding a genuinely-good kernel. Compilation still happens in
+      `$REPO_SRC` (R6); only the cache/IR output dirs move out.
 
   R6. **Compile step injection**
       If step 2 determined a compile step is missing, prepend it after

--- a/tests/models/test_init.py
+++ b/tests/models/test_init.py
@@ -33,8 +33,8 @@ class TestGetModelName:
     def test_returns_default_when_no_model_configured(self):
         """Test that a hardcoded default is returned when no model is configured anywhere."""
         with patch.dict(os.environ, {}, clear=True):
-            assert get_model_name(None, {}) == "claude-opus-4.6"
-            assert get_model_name(None, None) == "claude-opus-4.6"
+            assert get_model_name(None, {}) == "claude-opus-4.7"
+            assert get_model_name(None, None) == "claude-opus-4.7"
 
 
 class TestGetModelClass:

--- a/tests/run/test_adaptive_k.py
+++ b/tests/run/test_adaptive_k.py
@@ -20,14 +20,14 @@ Locks three things:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from minisweagent.run.dispatcher.selector import Dispatcher
-from minisweagent.run.postprocess.evaluation import _resolve_task_kind
-
+from minisweagent.run.postprocess.evaluation import _resolve_task_kind, evaluate_round_best
 
 # ---------------------------------------------------------------------------
 # _k_for_mode behavior
@@ -136,11 +136,12 @@ class TestKForModeMixedAdaptive:
 
     def test_extreme_planned_dominance_clamps_to_n_minus_1(self) -> None:
         # Even with planned >> fixed, the exploration floor reserves 1 slot
-        # for fixed → K never reaches N.
+        # for fixed → K never reaches N. (50.0 stays under MAX_PLAUSIBLE_SPEEDUP
+        # so it counts as a real planned peak rather than being clamped away.)
         evals = [
             {
                 "per_task": [
-                    {"kind": "planned", "speedup": 1000.0},
+                    {"kind": "planned", "speedup": 50.0},
                     {"kind": "fixed", "speedup": 1.0},
                 ]
             }
@@ -151,12 +152,13 @@ class TestKForModeMixedAdaptive:
 
     def test_extreme_fixed_dominance_clamps_to_one(self) -> None:
         # Even with fixed >> planned, the exploration floor reserves 1 slot
-        # for planned → K never reaches 0 (which would be fixed mode).
+        # for planned → K never reaches 0 (which would be fixed mode). (50.0
+        # stays under MAX_PLAUSIBLE_SPEEDUP so it counts as a real fixed peak.)
         evals = [
             {
                 "per_task": [
                     {"kind": "planned", "speedup": 1.0},
-                    {"kind": "fixed", "speedup": 1000.0},
+                    {"kind": "fixed", "speedup": 50.0},
                 ]
             }
         ]
@@ -207,6 +209,133 @@ class TestKForModeMixedAdaptive:
             },
         ]
         assert Dispatcher._k_for_mode("mixed", 4, round_evals=evals) == 3
+
+
+class TestKForModeMaxSeekingClampFailurePenalty:
+    """Regression tests for the max-seeking + clamp + failure-penalty rework.
+
+    The audit of the full 18-kernel run showed the old mean-based signal
+    converged planned-vs-fixed to parity (K pinned at N//2). These lock the
+    three properties that fix that: max-seeking (peak, not mean), the
+    plausibility clamp, and the success-rate failure penalty.
+    """
+
+    def test_max_seeking_beats_mean_parity(self) -> None:
+        # planned [5,1,1,1] and fixed [2,2,2,2] have the SAME mean (2.0): the
+        # old mean-based signal tied them at K=n//2=6. Max-seeking rewards
+        # planned's best (5.0) → K shifts decisively toward planned.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 5.0},
+                    {"kind": "planned", "speedup": 1.0},
+                    {"kind": "planned", "speedup": 1.0},
+                    {"kind": "planned", "speedup": 1.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                ]
+            }
+        ]
+        # planned_score = 5.0 * (4/4) = 5.0; fixed_score = 2.0 * (4/4) = 2.0
+        # K = round(12 * 5/7) = 9  (mean-based parity would have been 6)
+        k = Dispatcher._k_for_mode("mixed", 12, round_evals=evals)
+        assert k == 9
+        assert k > 12 // 2, "max-seeking must beat the mean-parity K=n//2"
+
+    def test_plausibility_clamp_drops_garbage_speedups(self) -> None:
+        # 1e6 and a >=100 value are timing-saturation / garbage and must be
+        # dropped. Without the clamp planned's 1e6 peak would pin K at n-1;
+        # with it, K is driven by the plausible 3.0 vs fixed 2.0 only.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 1e6},
+                    {"kind": "planned", "speedup": 120.0},
+                    {"kind": "planned", "speedup": 3.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                ]
+            }
+        ]
+        # planned: plausible peak 3.0, success_rate 1/3 → score 1.0
+        # fixed:   peak 2.0, success_rate 2/2 → score 2.0
+        # K = round(8 * 1.0/3.0) = 3   (NOT 7 = n-1)
+        k = Dispatcher._k_for_mode("mixed", 8, round_evals=evals)
+        assert k == 3
+        assert k < 8 - 1, "clamped garbage must not pin K at the planned ceiling"
+
+    def test_failure_penalty_demotes_low_success_rate_source(self) -> None:
+        # planned has a higher PEAK (5.0) than fixed (2.0) but only 1 of 6
+        # dispatched planned tasks produced a plausible result; the success-rate
+        # discount drops planned below fixed so K stays toward fixed.
+        per_task: list[dict[str, Any]] = [{"kind": "planned", "speedup": 5.0, "status": "ok"}]
+        per_task += [{"kind": "planned", "speedup": 0.0, "status": "failed"} for _ in range(5)]
+        per_task += [{"kind": "fixed", "speedup": 2.0, "status": "ok"} for _ in range(6)]
+        evals = [{"per_task": per_task}]
+        # planned_score = 5.0 * (1/6) = 0.833; fixed_score = 2.0 * (6/6) = 2.0
+        # K = round(8 * 0.833/2.833) = 2
+        k = Dispatcher._k_for_mode("mixed", 8, round_evals=evals)
+        assert k == 2
+        assert k < 8 // 2, "failure-prone planned must lose slots despite higher peak"
+
+    def test_all_failed_source_scores_neutral(self) -> None:
+        # planned dispatched 3 tasks, all failed (no plausible speed) → neutral
+        # score 1.0; fixed is strong → K clamps toward fixed but stays >= 1.
+        per_task: list[dict[str, Any]] = [
+            {"kind": "planned", "speedup": 0.0, "status": "failed"} for _ in range(3)
+        ]
+        per_task += [{"kind": "fixed", "speedup": 4.0, "status": "ok"} for _ in range(3)]
+        evals = [{"per_task": per_task}]
+        # planned_score = 1.0 (no plausible result); fixed_score = 4.0 * (3/3) = 4.0
+        # K = round(8 * 1.0/5.0) = 2
+        k = Dispatcher._k_for_mode("mixed", 8, round_evals=evals)
+        assert k == 2
+        assert k >= 1, "exploration floor keeps >= 1 planned slot even when all failed"
+
+    def test_parity_returns_half(self) -> None:
+        # Identical planned & fixed signals (same peak, same success rate) → n//2.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 2.0},
+                    {"kind": "planned", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                ]
+            }
+        ]
+        assert Dispatcher._k_for_mode("mixed", 8, round_evals=evals) == 8 // 2
+
+
+class TestEdgePathCarriesPerTask:
+    """Failure-path RoundEvaluations must carry per_task so partial-failure
+    rounds still feed adaptive-K (regression guard for the 'K pinned' bug)."""
+
+    def test_missing_commandment_path_carries_per_task(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        pp_dir = tmp_path / "pp"
+        pp_dir.mkdir()  # intentionally NO COMMANDMENT.md → triggers the edge path
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        task_a = results_dir / "task_a"
+        task_a.mkdir()
+        (task_a / "best_results.json").write_text(
+            json.dumps(
+                {"best_patch_speedup": 2.0, "best_patch_file": str(tmp_path / "a.patch")}
+            ),
+            encoding="utf-8",
+        )
+        ctx = {"output_dir": str(output_dir), "preprocess_dir": str(pp_dir)}
+
+        result = evaluate_round_best(ctx, round_num=1, results_dir=results_dir)
+
+        assert result is not None
+        per_task = result.to_dict().get("per_task")
+        assert per_task, "missing-COMMANDMENT path must carry per_task, not drop it"
+        assert any(o.get("label") == "task_a" for o in per_task)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run/test_adaptive_k.py
+++ b/tests/run/test_adaptive_k.py
@@ -1,0 +1,332 @@
+"""Tests for the adaptive-K dispatcher and the kind-resolution contract.
+
+Locks three things:
+
+1. ``Dispatcher._k_for_mode`` — the adaptive allocation algorithm: planned/fixed
+   passthroughs, mixed-mode round-1 fallback, proportional shift, exploration
+   floor (clamping to ``[1, n-1]``), one-sided history, zero-speedup fallback,
+   and the N=2 short-circuit.
+
+2. ``_resolve_task_kind`` — YAML lookup from the task .md frontmatter, including
+   substring label matching and the conservative ``"planned"`` default.
+
+3. The architectural contract that ``kind`` is dispatcher scheduling metadata
+   only and MUST NOT leak into agent ``cfg`` via the ``dispatch.py``
+   ``_passthrough_key`` loop. This is the regression guard for the bug where
+   passing ``kind`` through caused every worker to crash with
+   ``TypeError: AgentConfig.__init__() got an unexpected keyword argument
+   'kind'``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from minisweagent.run.dispatcher.selector import Dispatcher
+from minisweagent.run.postprocess.evaluation import _resolve_task_kind
+
+
+# ---------------------------------------------------------------------------
+# _k_for_mode behavior
+# ---------------------------------------------------------------------------
+
+
+class TestKForModeBasicModes:
+    """fixed/planned modes are pure passthroughs; mixed has the interesting math."""
+
+    @pytest.mark.parametrize("n", [1, 2, 3, 4, 8, 16])
+    def test_fixed_mode_returns_zero(self, n: int) -> None:
+        assert Dispatcher._k_for_mode("fixed", n) == 0
+
+    @pytest.mark.parametrize("n", [1, 2, 3, 4, 8, 16])
+    def test_planned_mode_returns_n(self, n: int) -> None:
+        assert Dispatcher._k_for_mode("planned", n) == n
+
+    def test_fixed_mode_ignores_round_evals(self) -> None:
+        evals = [{"per_task": [{"kind": "planned", "speedup": 99.0}]}]
+        assert Dispatcher._k_for_mode("fixed", 4, round_evals=evals) == 0
+
+    def test_planned_mode_ignores_round_evals(self) -> None:
+        evals = [{"per_task": [{"kind": "fixed", "speedup": 99.0}]}]
+        assert Dispatcher._k_for_mode("planned", 4, round_evals=evals) == 4
+
+
+class TestKForModeMixedFallback:
+    """Round 1 (or any round without per_task data) falls back to N//2."""
+
+    def test_mixed_no_round_evals_falls_back_to_half(self) -> None:
+        assert Dispatcher._k_for_mode("mixed", 4, round_evals=None) == 2
+
+    def test_mixed_empty_round_evals_falls_back_to_half(self) -> None:
+        assert Dispatcher._k_for_mode("mixed", 4, round_evals=[]) == 2
+
+    def test_mixed_n_equals_2_short_circuits_to_one(self) -> None:
+        # N<=2 is the documented "no adaptive shift" boundary: there's no
+        # interesting allocation to make with only 2 slots so we always
+        # do 1+1 regardless of history.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 5.0},
+                    {"kind": "fixed", "speedup": 1.0},
+                ]
+            }
+        ]
+        assert Dispatcher._k_for_mode("mixed", 2, round_evals=evals) == 1
+
+    def test_mixed_per_task_present_but_all_zero_speedups_falls_back(self) -> None:
+        # Zero/negative speedups are filtered out, leaving the algorithm with
+        # no usable history → N//2 fallback.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 0.0},
+                    {"kind": "planned", "speedup": -1.0},
+                    {"kind": "fixed", "speedup": 0.0},
+                ]
+            }
+        ]
+        assert Dispatcher._k_for_mode("mixed", 4, round_evals=evals) == 2
+
+    def test_mixed_per_task_missing_kind_or_speedup_is_ignored(self) -> None:
+        evals = [
+            {
+                "per_task": [
+                    {"speedup": 5.0},  # no kind
+                    {"kind": "planned"},  # no speedup
+                    {"kind": "other", "speedup": 5.0},  # neither planned nor fixed
+                ]
+            }
+        ]
+        assert Dispatcher._k_for_mode("mixed", 4, round_evals=evals) == 2
+
+
+class TestKForModeMixedAdaptive:
+    """The interesting case: per_task entries drive proportional K selection."""
+
+    def test_planned_dominant_shifts_k_up(self) -> None:
+        # planned avg = 2.0, fixed avg = 1.0 → K = round(4 * 2/3) = 3.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 2.0},
+                    {"kind": "planned", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 1.0},
+                    {"kind": "fixed", "speedup": 1.0},
+                ]
+            }
+        ]
+        assert Dispatcher._k_for_mode("mixed", 4, round_evals=evals) == 3
+
+    def test_fixed_dominant_shifts_k_down_clamped_at_one(self) -> None:
+        # planned avg = 1.0, fixed avg = 2.0 → K = round(4 * 1/3) = 1.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 1.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 2.0},
+                ]
+            }
+        ]
+        assert Dispatcher._k_for_mode("mixed", 4, round_evals=evals) == 1
+
+    def test_extreme_planned_dominance_clamps_to_n_minus_1(self) -> None:
+        # Even with planned >> fixed, the exploration floor reserves 1 slot
+        # for fixed → K never reaches N.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 1000.0},
+                    {"kind": "fixed", "speedup": 1.0},
+                ]
+            }
+        ]
+        k = Dispatcher._k_for_mode("mixed", 4, round_evals=evals)
+        assert k == 3
+        assert k <= 4 - 1, "exploration floor: at least 1 fixed slot must remain"
+
+    def test_extreme_fixed_dominance_clamps_to_one(self) -> None:
+        # Even with fixed >> planned, the exploration floor reserves 1 slot
+        # for planned → K never reaches 0 (which would be fixed mode).
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 1.0},
+                    {"kind": "fixed", "speedup": 1000.0},
+                ]
+            }
+        ]
+        k = Dispatcher._k_for_mode("mixed", 4, round_evals=evals)
+        assert k == 1
+        assert k >= 1, "exploration floor: at least 1 planned slot must remain"
+
+    def test_one_sided_history_only_planned_uses_default_for_other(self) -> None:
+        # planned avg = 3.0, fixed avg defaults to 1.0 → K = round(4 * 3/4) = 3.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 3.0},
+                    {"kind": "planned", "speedup": 3.0},
+                ]
+            }
+        ]
+        assert Dispatcher._k_for_mode("mixed", 4, round_evals=evals) == 3
+
+    def test_one_sided_history_only_fixed_uses_default_for_other(self) -> None:
+        # planned avg defaults to 1.0, fixed avg = 3.0 → K = round(4 * 1/4) = 1.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "fixed", "speedup": 3.0},
+                    {"kind": "fixed", "speedup": 3.0},
+                ]
+            }
+        ]
+        assert Dispatcher._k_for_mode("mixed", 4, round_evals=evals) == 1
+
+    def test_history_aggregates_across_multiple_rounds(self) -> None:
+        # Two rounds, planned 2.0 each, fixed 1.0 each → planned_avg=2.0,
+        # fixed_avg=1.0 → K=3. Same answer either way, but exercises the
+        # multi-round accumulation path.
+        evals = [
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 1.0},
+                ]
+            },
+            {
+                "per_task": [
+                    {"kind": "planned", "speedup": 2.0},
+                    {"kind": "fixed", "speedup": 1.0},
+                ]
+            },
+        ]
+        assert Dispatcher._k_for_mode("mixed", 4, round_evals=evals) == 3
+
+
+# ---------------------------------------------------------------------------
+# _resolve_task_kind YAML lookup
+# ---------------------------------------------------------------------------
+
+
+def _write_task_md(dir_: Path, fname: str, kind: str) -> Path:
+    """Write a minimal task .md file with YAML frontmatter and a body."""
+    path = dir_ / fname
+    path.write_text(
+        f"---\nkind: {kind}\nlabel: {Path(fname).stem}\npriority: 5\n---\n"
+        "task body — content does not matter for kind resolution\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestResolveTaskKind:
+    def test_returns_planned_for_planned_labeled_file(self, tmp_path: Path) -> None:
+        _write_task_md(tmp_path, "00_single-pass-online-softmax.md", "planned")
+        assert _resolve_task_kind(tmp_path, "single-pass-online-softmax") == "planned"
+
+    def test_returns_fixed_for_fixed_labeled_file(self, tmp_path: Path) -> None:
+        _write_task_md(tmp_path, "05_fixed-canonical.md", "fixed")
+        assert _resolve_task_kind(tmp_path, "fixed-canonical") == "fixed"
+
+    def test_returns_default_when_directory_does_not_exist(self, tmp_path: Path) -> None:
+        missing = tmp_path / "no_such_round_dir"
+        assert _resolve_task_kind(missing, "anything") == "planned"
+
+    def test_returns_default_when_no_matching_file(self, tmp_path: Path) -> None:
+        _write_task_md(tmp_path, "05_fixed-canonical.md", "fixed")
+        assert _resolve_task_kind(tmp_path, "totally-unrelated-label") == "planned"
+
+    def test_substring_label_match(self, tmp_path: Path) -> None:
+        # Numeric prefix and trailing kernel-name suffix should both match —
+        # the writer-produced file naming includes both, but the evaluator
+        # only knows the bare label from candidate metadata.
+        _write_task_md(tmp_path, "00_single-pass-online-softmax.md", "planned")
+        assert _resolve_task_kind(tmp_path, "single-pass-online") == "planned"
+
+    def test_only_md_files_are_inspected(self, tmp_path: Path) -> None:
+        # A non-.md file with a matching name must be ignored: the function
+        # only treats files with .md suffix as task files.
+        (tmp_path / "00_planned-thing.txt").write_text("kind: fixed\n", encoding="utf-8")
+        assert _resolve_task_kind(tmp_path, "planned-thing") == "planned"
+
+    def test_planned_and_fixed_in_same_dir_are_disambiguated_by_label(
+        self, tmp_path: Path
+    ) -> None:
+        _write_task_md(tmp_path, "00_alpha.md", "planned")
+        _write_task_md(tmp_path, "05_beta.md", "fixed")
+        assert _resolve_task_kind(tmp_path, "alpha") == "planned"
+        assert _resolve_task_kind(tmp_path, "beta") == "fixed"
+
+
+# ---------------------------------------------------------------------------
+# Architectural contract: kind MUST NOT leak into agent cfg
+# ---------------------------------------------------------------------------
+
+
+def _apply_dispatch_passthrough(meta: dict[str, Any]) -> dict[str, Any]:
+    """Mirror the cfg-construction passthrough loop from
+    ``minisweagent.run.dispatch.task_file_to_agent_task``.
+
+    This deliberately re-implements the ~3-line loop instead of running the
+    full dispatch flow so the contract is locked at the cfg-shape level — if
+    the source loop drifts to re-include ``kind`` (or any other dispatcher
+    metadata), this test will fail and force a documentation moment.
+    """
+    cfg: dict[str, Any] = {}
+    for _passthrough_key in ("baseline_metrics", "benchmark_baseline"):
+        if meta.get(_passthrough_key):
+            cfg[_passthrough_key] = meta[_passthrough_key]
+    return cfg
+
+
+class TestKindIsNotInAgentCfg:
+    """Regression guard for the AgentConfig(**cfg) crash bug."""
+
+    def test_kind_in_meta_does_not_leak_into_cfg(self) -> None:
+        meta = {
+            "kind": "planned",
+            "baseline_metrics": "/tmp/baseline.json",
+            "benchmark_baseline": "/tmp/bench.json",
+            "label": "single-pass-online-softmax",
+        }
+        cfg = _apply_dispatch_passthrough(meta)
+        assert "kind" not in cfg, (
+            "kind is dispatcher scheduling metadata and MUST NOT be passed to "
+            "AgentConfig via the cfg passthrough loop in dispatch.py — that path "
+            "previously caused every worker to crash with `AgentConfig.__init__() "
+            "got an unexpected keyword argument 'kind'` because AgentConfig has no "
+            "kind field. kind lives in the task .md YAML; the evaluator reads it "
+            "via _resolve_task_kind. Do not re-add it to the passthrough tuple."
+        )
+
+    def test_baseline_metrics_still_passes_through(self) -> None:
+        meta = {"kind": "planned", "baseline_metrics": "/tmp/baseline.json"}
+        cfg = _apply_dispatch_passthrough(meta)
+        assert cfg.get("baseline_metrics") == "/tmp/baseline.json"
+
+    def test_benchmark_baseline_still_passes_through(self) -> None:
+        meta = {"kind": "fixed", "benchmark_baseline": "/tmp/bench.json"}
+        cfg = _apply_dispatch_passthrough(meta)
+        assert cfg.get("benchmark_baseline") == "/tmp/bench.json"
+
+    def test_source_passthrough_loop_is_kind_free(self) -> None:
+        # Defensive: read the source line and assert it does not list "kind"
+        # in the passthrough tuple. This catches a drift even if someone
+        # bypasses the helper above by editing dispatch.py directly.
+        import minisweagent.run.dispatch as dispatch_mod
+
+        src = Path(dispatch_mod.__file__).read_text(encoding="utf-8")
+        passthrough_lines = [
+            line for line in src.splitlines() if "_passthrough_key in (" in line
+        ]
+        assert passthrough_lines, "passthrough loop not found in dispatch.py"
+        for line in passthrough_lines:
+            assert '"kind"' not in line and "'kind'" not in line, (
+                f"dispatch.py passthrough loop must not include 'kind': {line!r}"
+            )

--- a/tests/run/test_section_builders.py
+++ b/tests/run/test_section_builders.py
@@ -1,0 +1,191 @@
+"""Unit tests for :mod:`minisweagent.run.section_builders`."""
+
+from __future__ import annotations
+
+from minisweagent.run.section_builders import (
+    build_benchmark_body,
+    build_correctness_body,
+    build_full_benchmark_body,
+    build_profile_body,
+    strip_mode_flags,
+    warmup_block,
+)
+
+
+# ---------------------------------------------------------------------------
+# strip_mode_flags
+# ---------------------------------------------------------------------------
+
+
+class TestStripModeFlags:
+    def test_strips_correctness(self):
+        assert strip_mode_flags("cmd --correctness") == "cmd"
+
+    def test_strips_benchmark(self):
+        assert strip_mode_flags("cmd --benchmark") == "cmd"
+
+    def test_strips_full_benchmark_without_corruption(self):
+        result = strip_mode_flags("cmd --full-benchmark")
+        assert result == "cmd"
+        assert "--full-" not in result
+
+    def test_strips_profile(self):
+        assert strip_mode_flags("cmd --profile") == "cmd"
+
+    def test_no_flags_unchanged(self):
+        assert strip_mode_flags("python3 harness.py") == "python3 harness.py"
+
+    def test_multiple_flags(self):
+        result = strip_mode_flags("cmd --correctness --benchmark")
+        assert result == "cmd"
+
+    def test_preserves_other_flags(self):
+        result = strip_mode_flags("cmd --correctness --verbose")
+        assert result == "cmd --verbose"
+
+    def test_full_benchmark_with_extra_args(self):
+        result = strip_mode_flags("run.sh /path/harness.py --full-benchmark extra")
+        assert result == "run.sh /path/harness.py extra"
+
+
+# ---------------------------------------------------------------------------
+# warmup_block
+# ---------------------------------------------------------------------------
+
+
+class TestWarmupBlock:
+    def test_zero_runs_empty(self):
+        assert warmup_block("cmd", 0) == ""
+
+    def test_negative_runs_empty(self):
+        assert warmup_block("cmd", -1) == ""
+
+    def test_one_run_single_command(self):
+        assert warmup_block("cmd", 1) == "cmd"
+
+    def test_multiple_runs_for_loop(self):
+        result = warmup_block("cmd", 3)
+        assert "for _i in $(seq 1 3)" in result
+        assert "cmd" in result
+        assert result == "for _i in $(seq 1 3); do cmd; done"
+
+
+# ---------------------------------------------------------------------------
+# build_correctness_body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCorrectness:
+    def test_appends_correctness_flag(self):
+        result = build_correctness_body("${GEAK_WORK_DIR}/run.sh /path/harness.py")
+        assert result == "${GEAK_WORK_DIR}/run.sh /path/harness.py --correctness"
+
+    def test_run_harness_shape(self):
+        result = build_correctness_body("${GEAK_WORK_DIR}/run_harness.sh")
+        assert result == "${GEAK_WORK_DIR}/run_harness.sh --correctness"
+
+
+# ---------------------------------------------------------------------------
+# build_profile_body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildProfileBody:
+    def test_default_warmup_and_replays(self):
+        result = build_profile_body("cmd")
+        assert "--replays 3" in result
+        assert "kernel-profile" in result
+        assert "for _i in $(seq 1 2)" in result
+
+    def test_custom_warmup_and_replays(self):
+        result = build_profile_body("cmd", warmup_runs=5, profile_replays=10)
+        assert "--replays 10" in result
+        assert "for _i in $(seq 1 5)" in result
+
+    def test_zero_warmup_no_warmup_line(self):
+        result = build_profile_body("cmd", warmup_runs=0)
+        assert result.startswith("kernel-profile")
+        assert "> /dev/null" not in result.split("\n")[0]
+
+    def test_contains_profile_flag(self):
+        result = build_profile_body("cmd")
+        assert "--profile" in result
+
+    def test_kernel_profile_wrapping(self):
+        result = build_profile_body("${GEAK_WORK_DIR}/run.sh /harness.py")
+        assert 'kernel-profile "${GEAK_WORK_DIR}/run.sh /harness.py --profile"' in result
+
+    def test_output_path(self):
+        result = build_profile_body("cmd")
+        assert "${GEAK_WORK_DIR}/profile.json" in result
+
+    def test_gpu_device_variable(self):
+        result = build_profile_body("cmd")
+        assert "${GEAK_GPU_DEVICE}" in result
+
+    def test_run_harness_shape(self):
+        result = build_profile_body("${GEAK_WORK_DIR}/run_harness.sh")
+        assert 'kernel-profile "${GEAK_WORK_DIR}/run_harness.sh --profile"' in result
+
+
+# ---------------------------------------------------------------------------
+# build_benchmark_body / build_full_benchmark_body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBenchmarkBodies:
+    def test_benchmark_uses_full_benchmark_flag(self):
+        result = build_benchmark_body("cmd")
+        assert "--full-benchmark" in result
+
+    def test_benchmark_includes_extra_args(self):
+        result = build_benchmark_body("cmd")
+        assert "${GEAK_BENCHMARK_EXTRA_ARGS:-}" in result
+
+    def test_full_benchmark_uses_full_benchmark_flag(self):
+        result = build_full_benchmark_body("cmd")
+        assert "--full-benchmark" in result
+
+    def test_full_benchmark_includes_extra_args(self):
+        result = build_full_benchmark_body("cmd")
+        assert "${GEAK_BENCHMARK_EXTRA_ARGS:-}" in result
+
+    def test_both_produce_identical_output(self):
+        base = "${GEAK_WORK_DIR}/run.sh /path/harness.py"
+        assert build_benchmark_body(base) == build_full_benchmark_body(base)
+
+
+# ---------------------------------------------------------------------------
+# Builder base command shapes
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderBaseCommandShapes:
+    """Verify all builders produce valid output for both base_cmd shapes."""
+
+    _SIMPLE_CMD = "${GEAK_WORK_DIR}/run.sh /abs/path/test_harness.py"
+    _INNER_CMD = "${GEAK_WORK_DIR}/run_harness.sh"
+
+    def test_correctness_simple(self):
+        result = build_correctness_body(self._SIMPLE_CMD)
+        assert "/test_harness.py --correctness" in result
+
+    def test_correctness_inner(self):
+        result = build_correctness_body(self._INNER_CMD)
+        assert "run_harness.sh --correctness" in result
+
+    def test_profile_simple(self):
+        result = build_profile_body(self._SIMPLE_CMD)
+        assert "/test_harness.py --profile" in result
+
+    def test_profile_inner(self):
+        result = build_profile_body(self._INNER_CMD)
+        assert "run_harness.sh --profile" in result
+
+    def test_benchmark_simple(self):
+        result = build_benchmark_body(self._SIMPLE_CMD)
+        assert "/test_harness.py --full-benchmark" in result
+
+    def test_benchmark_inner(self):
+        result = build_benchmark_body(self._INNER_CMD)
+        assert "run_harness.sh --full-benchmark" in result

--- a/tests/run/test_task_parser.py
+++ b/tests/run/test_task_parser.py
@@ -597,3 +597,98 @@ class TestDisplayParsedConfig:
         assert "/tmp/out" in text
         assert "triton" in text
         assert "Resolved Configuration" in text
+
+
+class TestGpuOversubscribeAndMaxConcurrentLlm:
+    """Tests for gpu_oversubscribe and max_concurrent_llm extraction."""
+
+    class _Model:
+        def __init__(self, content: str) -> None:
+            self._content = content
+
+        def query(self, messages: list) -> dict:
+            return {"content": self._content}
+
+    def test_extracts_gpu_oversubscribe(self) -> None:
+        payload = {
+            "kernel_name": "k",
+            "kernel_url": None,
+            "kernel_type": "hip",
+            "repo": None,
+            "test_command": None,
+            "metric": None,
+            "num_parallel": None,
+            "gpu_ids": None,
+            "output_dir": None,
+            "model": None,
+            "config": None,
+            "gpu_oversubscribe": 2.0,
+            "max_concurrent_llm": None,
+        }
+        out = tp.parse_task_info("task", self._Model(json.dumps(payload)))
+        assert out["gpu_oversubscribe"] == 2.0
+        assert out["max_concurrent_llm"] is None
+
+    def test_extracts_max_concurrent_llm(self) -> None:
+        payload = {
+            "kernel_name": "k",
+            "kernel_url": None,
+            "kernel_type": "hip",
+            "repo": None,
+            "test_command": None,
+            "metric": None,
+            "num_parallel": None,
+            "gpu_ids": None,
+            "output_dir": None,
+            "model": None,
+            "config": None,
+            "gpu_oversubscribe": None,
+            "max_concurrent_llm": 8,
+        }
+        out = tp.parse_task_info("task", self._Model(json.dumps(payload)))
+        assert out["max_concurrent_llm"] == 8
+        assert out["gpu_oversubscribe"] is None
+
+    def test_null_values_preserved(self) -> None:
+        payload = {
+            "kernel_name": "k",
+            "kernel_url": None,
+            "kernel_type": "hip",
+            "repo": None,
+            "test_command": None,
+            "metric": None,
+            "num_parallel": None,
+            "gpu_ids": None,
+            "output_dir": None,
+            "model": None,
+            "config": None,
+            "gpu_oversubscribe": None,
+            "max_concurrent_llm": None,
+        }
+        out = tp.parse_task_info("task", self._Model(json.dumps(payload)))
+        assert out["gpu_oversubscribe"] is None
+        assert out["max_concurrent_llm"] is None
+
+    def test_invalid_values_cleared(self) -> None:
+        payload = {
+            "kernel_name": "k",
+            "kernel_url": None,
+            "kernel_type": "hip",
+            "repo": None,
+            "test_command": None,
+            "metric": None,
+            "num_parallel": None,
+            "gpu_ids": None,
+            "output_dir": None,
+            "model": None,
+            "config": None,
+            "gpu_oversubscribe": "not_a_number",
+            "max_concurrent_llm": -5,
+        }
+        out = tp.parse_task_info("task", self._Model(json.dumps(payload)))
+        assert out["gpu_oversubscribe"] is None
+        assert out["max_concurrent_llm"] is None
+
+    def test_empty_template_has_new_fields(self) -> None:
+        assert "gpu_oversubscribe" in tp._EMPTY_TASK_INFO
+        assert "max_concurrent_llm" in tp._EMPTY_TASK_INFO

--- a/tests/run/utils/test_generated_artifacts_jit_cache.py
+++ b/tests/run/utils/test_generated_artifacts_jit_cache.py
@@ -1,0 +1,163 @@
+"""Unit tests for the JIT/compile-cache artifact denylist + cache relocation.
+
+These pin the GEAK Layer-1/Layer-2 patch-capture fix:
+
+* ``is_jit_cache_artifact`` must recognise JIT runtime caches by exact dir
+  name, dir *prefix* (suffixed cache dirs like ``.triton_cache_geak``), dir
+  *substring* (any ``*cache*`` dir), nested ``jit/{build,__pycache__}`` trees,
+  and unambiguous compile-output extensions (``*.hsaco`` ... ``*.so``) -- while
+  NEVER misclassifying genuine source files (including aiter cpp_itfs ``.cuh``
+  source and files whose *name* merely contains "cache").
+* ``jit_cache_diff_basename_excludes`` must surface every one of those as a
+  ``diff``/``git diff`` exclude glob.
+* ``jit_cache_env`` must relocate Triton/JIT caches to a stable, per-worktree
+  dir OUTSIDE the worktree (the root cause of the 1.0x A/B self-score).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from minisweagent.run.utils.generated_artifacts import (
+    is_jit_cache_artifact,
+    jit_cache_diff_basename_excludes,
+    jit_cache_env,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_jit_cache_artifact — POSITIVE (must be flagged as cache / compile output)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        # Exact cache-dir names.
+        "flydsl_cache/abc.pkl",
+        "__pycache__/mod.cpython-312.pyc",
+        # Suffixed Triton cache dir (the literal regression: TRITON_CACHE_DIR
+        # pointed at a worktree-local .triton_cache_geak).
+        ".triton_cache_geak/HASH/fused_moe_kernel.hsaco",
+        ".triton_cache_geak/HASH/fused_moe_kernel.json",
+        "triton_cache_slot0/HASH/x.ttir",
+        # aiter caches by prefix.
+        ".aiter_jit/build/module_x/lib.so",
+        ".aiter/build/pa_ragged_HASH/lib.so",
+        # torch compile / inductor caches.
+        "torch_compile_cache/x/y.py",
+        "torchinductor_root/aaa/bbb.py",
+        # Any *cache* dir via substring.
+        "some_weird_cache/x.json",
+        "pkg/sub_cache_dir/payload.bin",
+        ".cache/triton/HASH/k.hsaco",
+        # Nested jit/build tree.
+        "aiter/jit/build/module_a/lib.so",
+        # Compile-output extensions anywhere (leaf-suffix rule).
+        "deep/dir/kernel.hsaco",
+        "deep/dir/kernel.amdgcn",
+        "deep/dir/kernel.llir",
+        "deep/dir/kernel.ttir",
+        "deep/dir/kernel.ttgir",
+        "deep/dir/kernel.ptx",
+        "deep/dir/kernel.cubin",
+        "deep/dir/kernel.spv",
+        "deep/dir/kernel.o",
+        "deep/dir/kernel.so",
+        # Leading ./ and / are tolerated.
+        "./.triton_cache_geak/HASH/k.hsaco",
+        "/abs/.triton/HASH/k.hsaco",
+    ],
+)
+def test_is_jit_cache_artifact_positive(rel_path: str) -> None:
+    assert is_jit_cache_artifact(rel_path) is True
+
+
+# ---------------------------------------------------------------------------
+# is_jit_cache_artifact — NEGATIVE (genuine source must survive capture)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        "fused_moe.py",
+        "python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py",
+        # aiter cpp_itfs SOURCE — the actual editable kernel; must NOT be stripped.
+        "aiter/csrc/cpp_itfs/pa/pa_kernels.cuh",
+        "aiter/csrc/cpp_itfs/pa/pa_ragged.cpp.jinja",
+        # Files whose NAME merely contains a cache prefix/substring (leaf only).
+        "triton_cache_config.py",
+        "utils/cache_utils.py",
+        "moe/caching.py",
+        # Ordinary kernel source extensions.
+        "kernel.cuh",
+        "kernel.cpp",
+        "kernel.cu",
+        "kernel.h",
+        "kernel.hip",
+        "",
+        None,
+    ],
+)
+def test_is_jit_cache_artifact_negative(rel_path) -> None:
+    assert is_jit_cache_artifact(rel_path) is False
+
+
+# ---------------------------------------------------------------------------
+# jit_cache_diff_basename_excludes
+# ---------------------------------------------------------------------------
+def test_diff_basename_excludes_cover_plan_patterns() -> None:
+    patterns = set(jit_cache_diff_basename_excludes())
+    # Prefix globs.
+    for expected in (".triton*", ".aiter*", "torch_compile*", "torchinductor*"):
+        assert expected in patterns, f"missing prefix glob {expected!r}"
+    # Substring glob.
+    assert "*cache*" in patterns
+    # Exact dir names.
+    assert "__pycache__" in patterns
+    assert "flydsl_cache" in patterns
+    # Compile-output extension globs (incl. the newly-added *.o / *.so).
+    for ext in ("*.hsaco", "*.amdgcn", "*.llir", "*.ttir", "*.ttgir",
+                "*.ptx", "*.cubin", "*.spv", "*.o", "*.so"):
+        assert ext in patterns, f"missing suffix glob {ext!r}"
+
+
+# ---------------------------------------------------------------------------
+# jit_cache_env — relocate caches OUTSIDE the worktree
+# ---------------------------------------------------------------------------
+def test_jit_cache_env_relocates_outside_worktree(tmp_path: Path) -> None:
+    wt = tmp_path / "worktrees" / "slot_0"
+    wt.mkdir(parents=True)
+    env = jit_cache_env(wt)
+
+    assert set(env) == {"GEAK_JIT_CACHE_DIR", "TRITON_CACHE_DIR"}
+    wt_resolved = str(wt.resolve())
+    # The crux: neither cache dir may live inside the diffed worktree.
+    assert not env["GEAK_JIT_CACHE_DIR"].startswith(wt_resolved)
+    assert not env["TRITON_CACHE_DIR"].startswith(wt_resolved)
+    # Triton cache nests under the generic root.
+    assert env["TRITON_CACHE_DIR"].startswith(env["GEAK_JIT_CACHE_DIR"])
+    assert env["TRITON_CACHE_DIR"].endswith("/triton")
+
+
+def test_jit_cache_env_is_deterministic_and_unique(tmp_path: Path) -> None:
+    wt_a = tmp_path / "a"
+    wt_b = tmp_path / "b"
+    wt_a.mkdir()
+    wt_b.mkdir()
+    # Stable per worktree (slot reuses its compile cache across rounds).
+    assert jit_cache_env(wt_a) == jit_cache_env(wt_a)
+    # Unique per worktree (parallel slots never collide).
+    assert jit_cache_env(wt_a)["TRITON_CACHE_DIR"] != jit_cache_env(wt_b)["TRITON_CACHE_DIR"]
+
+
+def test_jit_cache_env_base_override(tmp_path: Path) -> None:
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    base = tmp_path / "out_of_tree_root"
+    env = jit_cache_env(wt, base=base)
+    assert env["GEAK_JIT_CACHE_DIR"].startswith(str(base))
+
+
+@pytest.mark.parametrize("falsy", [None, "", 0])
+def test_jit_cache_env_empty_for_falsy_workdir(falsy) -> None:
+    assert jit_cache_env(falsy) == {}

--- a/tests/run/utils/test_gpu_manager.py
+++ b/tests/run/utils/test_gpu_manager.py
@@ -2,25 +2,26 @@
 
 from __future__ import annotations
 
+import os
 import threading
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from minisweagent.run.utils.gpu_manager import GpuJob, GPUManager
+from minisweagent.run.utils.gpu_manager import GpuJob, GpuLease, GPUManager, LeaseState
 
 
 @pytest.fixture
 def manager_2gpu():
-    mgr = GPUManager([0, 1], stats_log_interval_s=0)
+    mgr = GPUManager([0, 1], stats_log_interval_s=0, reaper_interval_s=0)
     yield mgr
     mgr.shutdown()
 
 
 @pytest.fixture
 def manager_4gpu():
-    mgr = GPUManager([0, 1, 2, 3], stats_log_interval_s=0)
+    mgr = GPUManager([0, 1, 2, 3], stats_log_interval_s=0, reaper_interval_s=0)
     yield mgr
     mgr.shutdown()
 
@@ -192,3 +193,196 @@ class TestEmptyOrInvalid:
     def test_empty_gpu_ids_raises(self):
         with pytest.raises(ValueError, match="non-empty"):
             GPUManager([])
+
+
+class TestCancelledFuture:
+    """B1: _run_job skips execution when future is already cancelled."""
+
+    def test_cancelled_future_skips_job_fn(self):
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        executed = threading.Event()
+
+        def _fn(gpus, env):
+            executed.set()
+            return "ran"
+
+        blocker = threading.Event()
+        mgr.submit(GpuJob(fn=lambda g, e: blocker.wait(timeout=5), label="blocker"))
+        time.sleep(0.05)
+
+        fut = mgr.submit(GpuJob(fn=_fn, label="to-cancel"))
+        time.sleep(0.05)
+        fut.cancel()
+        blocker.set()
+        time.sleep(0.3)
+
+        assert not executed.is_set(), "Job ran despite future being cancelled"
+        mgr.shutdown()
+
+
+class TestDispatcherDrain:
+    """B9: dispatcher drains remaining jobs on every exit path."""
+
+    def test_closed_return_drains_queue(self):
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        blocker = threading.Event()
+
+        mgr.submit(GpuJob(fn=lambda g, e: blocker.wait(timeout=5), label="blocker"))
+        time.sleep(0.05)
+
+        pending_futs = [
+            mgr.submit(GpuJob(fn=lambda g, e: "should-not-run", label=f"p{i}"))
+            for i in range(3)
+        ]
+
+        blocker.set()
+        mgr.shutdown(cancel_pending=True)
+
+        for fut in pending_futs:
+            assert fut.cancelled() or fut.done()
+
+
+class TestSplitTimeout:
+    """B2: queue_timeout is used for Future.result(), timeout sets lease deadline."""
+
+    def test_queue_timeout_none_waits_forever(self):
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        blocker = threading.Event()
+
+        mgr.submit(GpuJob(fn=lambda g, e: blocker.wait(timeout=5), label="blocker"))
+        time.sleep(0.05)
+
+        result_holder = []
+
+        def _run_in_thread():
+            try:
+                r = mgr.run(GpuJob(
+                    fn=lambda g, e: "queued-result",
+                    timeout=5.0,
+                    queue_timeout=None,
+                    label="waiter",
+                ))
+                result_holder.append(r)
+            except Exception as exc:
+                result_holder.append(exc)
+
+        t = threading.Thread(target=_run_in_thread)
+        t.start()
+        time.sleep(0.2)
+        blocker.set()
+        t.join(timeout=10)
+        mgr.shutdown()
+
+        assert result_holder and result_holder[0] == "queued-result"
+
+    def test_execution_timeout_sets_lease_deadline(self):
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        mgr.run(GpuJob(fn=lambda g, e: "ok", timeout=60.0, label="with-deadline"))
+
+        with mgr._leases_lock:
+            leases = list(mgr._active_leases.values())
+        assert len(leases) == 1
+        assert leases[0].lease.deadline is not None
+        assert leases[0].release_reason == "completed"
+        mgr.shutdown()
+
+
+class TestLeaseRelease:
+    """B3: double release is detected and rejected."""
+
+    def test_double_release_rejected(self):
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        mgr.run(GpuJob(fn=lambda g, e: "ok", label="lease-test"))
+
+        with mgr._leases_lock:
+            lease_id = list(mgr._active_leases.keys())[0]
+
+        stats_before = mgr.stats
+        mgr._release_lease(lease_id, reason="spurious")
+        stats_after = mgr.stats
+
+        assert stats_before["total_jobs_completed"] == stats_after["total_jobs_completed"]
+        assert stats_before["in_flight"] == stats_after["in_flight"]
+        mgr.shutdown()
+
+
+class TestLeaseReaper:
+    """B2/B8: reaper releases GPUs from expired leases."""
+
+    def test_reaper_releases_expired_lease(self):
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=1)
+        started = threading.Event()
+
+        def _slow(gpus, env):
+            started.set()
+            time.sleep(30)
+            return "should-be-reaped"
+
+        fut = mgr.submit(GpuJob(fn=_slow, timeout=0.5, label="slow-job"))
+        started.wait(timeout=5)
+        time.sleep(3)
+
+        assert 0 in mgr._free, "GPU should be returned to pool after reaping"
+        mgr.shutdown()
+
+    def test_lease_cleanup_removes_old_entries(self):
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+
+        for i in range(5):
+            mgr.run(GpuJob(fn=lambda g, e: "ok", label=f"j{i}"))
+
+        with mgr._leases_lock:
+            assert len(mgr._active_leases) == 5
+            for s in mgr._active_leases.values():
+                s.released_at = time.monotonic() - 400
+
+        mgr._reaper_loop_once_for_test()
+
+        with mgr._leases_lock:
+            assert len(mgr._active_leases) == 0
+        mgr.shutdown()
+
+
+class TestCPUPressureGate:
+    """B7: dispatcher waits when CPU load is high."""
+
+    def test_high_cpu_load_delays_dispatch(self):
+        import types
+        import minisweagent.run.utils.gpu_manager as gm_mod
+
+        call_count = 0
+        real_os = gm_mod.os
+
+        def mock_getloadavg():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return (9999.0, 9999.0, 9999.0)
+            return (0.1, 0.1, 0.1)
+
+        fake_os = types.SimpleNamespace(
+            getloadavg=mock_getloadavg,
+            cpu_count=os.cpu_count,
+            getpgid=os.getpgid,
+            kill=os.kill,
+            killpg=os.killpg,
+        )
+        gm_mod.os = fake_os
+        try:
+            mgr = GPUManager(
+                [0], stats_log_interval_s=0, reaper_interval_s=0,
+                cpu_pressure_threshold=1.0,
+            )
+            result = mgr.run(GpuJob(fn=lambda g, e: "dispatched", label="cpu-gate"))
+            assert result == "dispatched"
+            assert call_count >= 3
+            mgr.shutdown()
+        finally:
+            gm_mod.os = real_os
+
+    def test_getloadavg_oserror_skipped(self):
+        with patch("minisweagent.run.utils.gpu_manager.os.getloadavg", side_effect=OSError):
+            mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+            result = mgr.run(GpuJob(fn=lambda g, e: "ok", label="no-loadavg"))
+            assert result == "ok"
+            mgr.shutdown()

--- a/tests/run/utils/test_gpu_manager.py
+++ b/tests/run/utils/test_gpu_manager.py
@@ -1,0 +1,194 @@
+"""Tests for the centralized GPU manager."""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from minisweagent.run.utils.gpu_manager import GpuJob, GPUManager
+
+
+@pytest.fixture
+def manager_2gpu():
+    mgr = GPUManager([0, 1], stats_log_interval_s=0)
+    yield mgr
+    mgr.shutdown()
+
+
+@pytest.fixture
+def manager_4gpu():
+    mgr = GPUManager([0, 1, 2, 3], stats_log_interval_s=0)
+    yield mgr
+    mgr.shutdown()
+
+
+class TestBasicScheduling:
+    def test_single_job_runs_and_returns(self, manager_2gpu):
+        result = manager_2gpu.run(GpuJob(fn=lambda gpus, env: ("ok", gpus), label="test"))
+        assert result[0] == "ok"
+        assert len(result[1]) == 1
+        assert result[1][0] in {0, 1}
+
+    def test_env_overrides_contain_expected_keys(self, manager_2gpu):
+        captured = {}
+
+        def _fn(gpus, env):
+            captured.update(env)
+            return True
+
+        manager_2gpu.run(GpuJob(fn=_fn, label="env-check"))
+        assert "HIP_VISIBLE_DEVICES" in captured
+        assert "CUDA_VISIBLE_DEVICES" in captured
+        assert "GEAK_GPU_DEVICE" in captured
+
+    def test_many_jobs_no_gpu_collision(self, manager_2gpu):
+        active_gpus: set[int] = set()
+        collision = threading.Event()
+        lock = threading.Lock()
+
+        def _fn(gpus, env):
+            gpu = gpus[0]
+            with lock:
+                if gpu in active_gpus:
+                    collision.set()
+                active_gpus.add(gpu)
+            time.sleep(0.05)
+            with lock:
+                active_gpus.discard(gpu)
+            return gpu
+
+        futs = [manager_2gpu.submit(GpuJob(fn=_fn, label=f"j{i}")) for i in range(8)]
+        results = [f.result(timeout=10) for f in futs]
+        assert not collision.is_set(), "Two concurrent jobs shared a GPU"
+        assert len(results) == 8
+        assert set(results).issubset({0, 1})
+
+    def test_all_gpus_used(self, manager_2gpu):
+        used = set()
+        lock = threading.Lock()
+
+        def _fn(gpus, env):
+            with lock:
+                used.update(gpus)
+            time.sleep(0.02)
+            return True
+
+        futs = [manager_2gpu.submit(GpuJob(fn=_fn, label=f"j{i}")) for i in range(8)]
+        for f in futs:
+            f.result(timeout=10)
+        assert used == {0, 1}
+
+
+class TestMultiGpuAcquire:
+    def test_multi_gpu_job_gets_correct_count(self, manager_4gpu):
+        result = manager_4gpu.run(GpuJob(fn=lambda gpus, env: len(gpus), num_gpus=2, label="multi"))
+        assert result == 2
+
+    def test_multi_gpu_mixed_with_single(self, manager_4gpu):
+        results = []
+        lock = threading.Lock()
+
+        def _fn(gpus, env):
+            time.sleep(0.03)
+            with lock:
+                results.append(len(gpus))
+            return len(gpus)
+
+        futs = []
+        futs.append(manager_4gpu.submit(GpuJob(fn=_fn, num_gpus=2, label="multi")))
+        for i in range(4):
+            futs.append(manager_4gpu.submit(GpuJob(fn=_fn, num_gpus=1, label=f"s{i}")))
+        for f in futs:
+            f.result(timeout=10)
+        assert 2 in results
+        assert results.count(1) == 4
+
+    def test_num_gpus_exceeds_pool_raises(self, manager_2gpu):
+        with pytest.raises(ValueError, match="requests 3 GPU"):
+            manager_2gpu.submit(GpuJob(fn=lambda g, e: None, num_gpus=3, label="too-many"))
+
+
+class TestShutdown:
+    def test_submit_after_shutdown_raises(self, manager_2gpu):
+        manager_2gpu.shutdown()
+        with pytest.raises(RuntimeError, match="shut down"):
+            manager_2gpu.submit(GpuJob(fn=lambda g, e: None, label="late"))
+
+    def test_shutdown_cancel_pending(self):
+        mgr = GPUManager([0], stats_log_interval_s=0)
+        blocker = threading.Event()
+
+        def _block(gpus, env):
+            blocker.wait(timeout=5)
+            return "done"
+
+        fut_blocking = mgr.submit(GpuJob(fn=_block, label="blocker"))
+        time.sleep(0.1)
+        for i in range(3):
+            mgr.submit(GpuJob(fn=lambda g, e: "pending", label=f"p{i}"))
+        blocker.set()
+        mgr.shutdown(cancel_pending=True)
+        assert fut_blocking.result(timeout=5) == "done"
+
+
+class TestStats:
+    def test_stats_fields(self, manager_2gpu):
+        manager_2gpu.run(GpuJob(fn=lambda g, e: time.sleep(0.05), label="stat"))
+        s = manager_2gpu.stats
+        assert "busy_seconds_per_gpu" in s
+        assert "queue_depth" in s
+        assert "in_flight" in s
+        assert "max_queue_depth" in s
+        assert "total_jobs_submitted" in s
+        assert "total_jobs_completed" in s
+        assert "manager_uptime_s" in s
+        assert s["total_jobs_submitted"] == 1
+        assert s["total_jobs_completed"] == 1
+        assert s["in_flight"] == 0
+        assert s["queue_depth"] == 0
+
+    def test_busy_seconds_accumulate(self, manager_2gpu):
+        manager_2gpu.run(GpuJob(fn=lambda g, e: time.sleep(0.1), label="busy"))
+        s = manager_2gpu.stats
+        total_busy = sum(s["busy_seconds_per_gpu"].values())
+        assert total_busy >= 0.08
+
+
+class TestJobExceptions:
+    def test_job_exception_propagated(self, manager_2gpu):
+        def _fail(gpus, env):
+            raise ValueError("test error")
+
+        fut = manager_2gpu.submit(GpuJob(fn=_fail, label="fail"))
+        with pytest.raises(ValueError, match="test error"):
+            fut.result(timeout=5)
+
+    def test_gpu_released_after_exception(self, manager_2gpu):
+        def _fail(gpus, env):
+            raise RuntimeError("boom")
+
+        fut = manager_2gpu.submit(GpuJob(fn=_fail, label="fail"))
+        with pytest.raises(RuntimeError):
+            fut.result(timeout=5)
+
+        result = manager_2gpu.run(GpuJob(fn=lambda g, e: "ok", label="after-fail"))
+        assert result == "ok"
+
+
+class TestRegistryIntegration:
+    def test_futures_registered_with_registry(self):
+        registry = MagicMock()
+        registry.lock = threading.RLock()
+        mgr = GPUManager([0], registry=registry, stats_log_interval_s=0)
+        mgr.run(GpuJob(fn=lambda g, e: "ok", label="reg-test"))
+        assert registry.register_future.called
+        mgr.shutdown()
+
+
+class TestEmptyOrInvalid:
+    def test_empty_gpu_ids_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            GPUManager([])

--- a/tests/run/utils/test_gpu_manager.py
+++ b/tests/run/utils/test_gpu_manager.py
@@ -63,7 +63,7 @@ class TestBasicScheduling:
             return gpu
 
         futs = [manager_2gpu.submit(GpuJob(fn=_fn, label=f"j{i}")) for i in range(8)]
-        results = [f.result(timeout=10) for f in futs]
+        results = [f.result(timeout=30) for f in futs]
         assert not collision.is_set(), "Two concurrent jobs shared a GPU"
         assert len(results) == 8
         assert set(results).issubset({0, 1})
@@ -80,7 +80,7 @@ class TestBasicScheduling:
 
         futs = [manager_2gpu.submit(GpuJob(fn=_fn, label=f"j{i}")) for i in range(8)]
         for f in futs:
-            f.result(timeout=10)
+            f.result(timeout=30)
         assert used == {0, 1}
 
 
@@ -104,7 +104,7 @@ class TestMultiGpuAcquire:
         for i in range(4):
             futs.append(manager_4gpu.submit(GpuJob(fn=_fn, num_gpus=1, label=f"s{i}")))
         for f in futs:
-            f.result(timeout=10)
+            f.result(timeout=30)
         assert 2 in results
         assert results.count(1) == 4
 
@@ -120,20 +120,28 @@ class TestShutdown:
             manager_2gpu.submit(GpuJob(fn=lambda g, e: None, label="late"))
 
     def test_shutdown_cancel_pending(self):
-        mgr = GPUManager([0], stats_log_interval_s=0)
-        blocker = threading.Event()
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        blocker_started = threading.Event()
+        blocker_release = threading.Event()
 
         def _block(gpus, env):
-            blocker.wait(timeout=5)
+            blocker_started.set()
+            blocker_release.wait(timeout=10)
             return "done"
 
         fut_blocking = mgr.submit(GpuJob(fn=_block, label="blocker"))
-        time.sleep(0.1)
-        for i in range(3):
+        blocker_started.wait(timeout=5)
+
+        pending_futs = [
             mgr.submit(GpuJob(fn=lambda g, e: "pending", label=f"p{i}"))
-        blocker.set()
+            for i in range(3)
+        ]
+        blocker_release.set()
+        assert fut_blocking.result(timeout=10) == "done"
         mgr.shutdown(cancel_pending=True)
-        assert fut_blocking.result(timeout=5) == "done"
+
+        for fut in pending_futs:
+            assert fut.cancelled() or fut.done()
 
 
 class TestStats:
@@ -202,17 +210,22 @@ class TestCancelledFuture:
     def test_cancelled_future_skips_job_fn(self):
         mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
         executed = threading.Event()
+        blocker_started = threading.Event()
 
         def _fn(gpus, env):
             executed.set()
             return "ran"
 
         blocker = threading.Event()
-        mgr.submit(GpuJob(fn=lambda g, e: blocker.wait(timeout=5), label="blocker"))
-        time.sleep(0.05)
+
+        def _block(gpus, env):
+            blocker_started.set()
+            blocker.wait(timeout=5)
+
+        mgr.submit(GpuJob(fn=_block, label="blocker"))
+        blocker_started.wait(timeout=5)
 
         fut = mgr.submit(GpuJob(fn=_fn, label="to-cancel"))
-        time.sleep(0.05)
         fut.cancel()
         blocker.set()
         time.sleep(0.3)
@@ -226,10 +239,15 @@ class TestDispatcherDrain:
 
     def test_closed_return_drains_queue(self):
         mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        blocker_started = threading.Event()
         blocker = threading.Event()
 
-        mgr.submit(GpuJob(fn=lambda g, e: blocker.wait(timeout=5), label="blocker"))
-        time.sleep(0.05)
+        def _block(gpus, env):
+            blocker_started.set()
+            blocker.wait(timeout=5)
+
+        mgr.submit(GpuJob(fn=_block, label="blocker"))
+        blocker_started.wait(timeout=5)
 
         pending_futs = [
             mgr.submit(GpuJob(fn=lambda g, e: "should-not-run", label=f"p{i}"))
@@ -248,33 +266,39 @@ class TestSplitTimeout:
 
     def test_queue_timeout_none_waits_forever(self):
         mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        blocker_started = threading.Event()
         blocker = threading.Event()
 
-        mgr.submit(GpuJob(fn=lambda g, e: blocker.wait(timeout=5), label="blocker"))
-        time.sleep(0.05)
+        def _block(gpus, env):
+            blocker_started.set()
+            blocker.wait(timeout=10)
+
+        mgr.submit(GpuJob(fn=_block, label="blocker"))
+        blocker_started.wait(timeout=5)
 
         result_holder = []
 
         def _run_in_thread():
             try:
-                r = mgr.run(GpuJob(
-                    fn=lambda g, e: "queued-result",
-                    timeout=5.0,
-                    queue_timeout=None,
-                    label="waiter",
-                ))
+                r = mgr.run(
+                    GpuJob(
+                        fn=lambda g, e: "queued-result",
+                        timeout=5.0,
+                        queue_timeout=None,
+                        label="waiter",
+                    )
+                )
                 result_holder.append(r)
             except Exception as exc:
                 result_holder.append(exc)
 
         t = threading.Thread(target=_run_in_thread)
         t.start()
-        time.sleep(0.2)
         blocker.set()
         t.join(timeout=10)
-        mgr.shutdown()
 
         assert result_holder and result_holder[0] == "queued-result"
+        mgr.shutdown()
 
     def test_execution_timeout_sets_lease_deadline(self):
         mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
@@ -349,6 +373,7 @@ class TestCPUPressureGate:
 
     def test_high_cpu_load_delays_dispatch(self):
         import types
+
         import minisweagent.run.utils.gpu_manager as gm_mod
 
         call_count = 0
@@ -371,7 +396,9 @@ class TestCPUPressureGate:
         gm_mod.os = fake_os
         try:
             mgr = GPUManager(
-                [0], stats_log_interval_s=0, reaper_interval_s=0,
+                [0],
+                stats_log_interval_s=0,
+                reaper_interval_s=0,
                 cpu_pressure_threshold=1.0,
             )
             result = mgr.run(GpuJob(fn=lambda g, e: "dispatched", label="cpu-gate"))
@@ -395,7 +422,9 @@ class TestEventLogging:
     def test_lifecycle_events_written_to_file(self, tmp_path):
         log_file = tmp_path / "events.jsonl"
         mgr = GPUManager(
-            [0], stats_log_interval_s=0, reaper_interval_s=0,
+            [0],
+            stats_log_interval_s=0,
+            reaper_interval_s=0,
             event_log_path=str(log_file),
         )
         mgr.run(GpuJob(fn=lambda g, e: "ok", label="evt-test"))
@@ -408,7 +437,9 @@ class TestEventLogging:
     def test_failed_job_emits_failed_event(self, tmp_path):
         log_file = tmp_path / "events.jsonl"
         mgr = GPUManager(
-            [0], stats_log_interval_s=0, reaper_interval_s=0,
+            [0],
+            stats_log_interval_s=0,
+            reaper_interval_s=0,
             event_log_path=str(log_file),
         )
         fut = mgr.submit(GpuJob(fn=lambda g, e: (_ for _ in ()).throw(ValueError("boom")), label="fail-evt"))
@@ -444,7 +475,9 @@ class TestEventLogging:
     def test_event_log_fields(self, tmp_path):
         log_file = tmp_path / "events.jsonl"
         mgr = GPUManager(
-            [0], stats_log_interval_s=0, reaper_interval_s=0,
+            [0],
+            stats_log_interval_s=0,
+            reaper_interval_s=0,
             event_log_path=str(log_file),
         )
         mgr.run(GpuJob(fn=lambda g, e: "ok", label="field-test"))

--- a/tests/run/utils/test_gpu_manager.py
+++ b/tests/run/utils/test_gpu_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import threading
 import time
@@ -386,3 +387,84 @@ class TestCPUPressureGate:
             result = mgr.run(GpuJob(fn=lambda g, e: "ok", label="no-loadavg"))
             assert result == "ok"
             mgr.shutdown()
+
+
+class TestEventLogging:
+    """Phase 2: JSONL event logging and per-outcome counters."""
+
+    def test_lifecycle_events_written_to_file(self, tmp_path):
+        log_file = tmp_path / "events.jsonl"
+        mgr = GPUManager(
+            [0], stats_log_interval_s=0, reaper_interval_s=0,
+            event_log_path=str(log_file),
+        )
+        mgr.run(GpuJob(fn=lambda g, e: "ok", label="evt-test"))
+        mgr.shutdown()
+
+        lines = log_file.read_text().strip().splitlines()
+        events = [json.loads(line)["event"] for line in lines]
+        assert events == ["queued", "leased", "started", "completed", "released"]
+
+    def test_failed_job_emits_failed_event(self, tmp_path):
+        log_file = tmp_path / "events.jsonl"
+        mgr = GPUManager(
+            [0], stats_log_interval_s=0, reaper_interval_s=0,
+            event_log_path=str(log_file),
+        )
+        fut = mgr.submit(GpuJob(fn=lambda g, e: (_ for _ in ()).throw(ValueError("boom")), label="fail-evt"))
+        with pytest.raises(ValueError):
+            fut.result(timeout=5)
+        mgr.shutdown()
+
+        lines = log_file.read_text().strip().splitlines()
+        events = [json.loads(line)["event"] for line in lines]
+        assert "failed" in events
+        assert "released" in events
+
+    def test_per_outcome_counters(self):
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        mgr.run(GpuJob(fn=lambda g, e: "ok", label="s1"))
+        mgr.run(GpuJob(fn=lambda g, e: "ok", label="s2"))
+
+        def _fail(g, e):
+            raise RuntimeError("err")
+
+        fut = mgr.submit(GpuJob(fn=_fail, label="f1"))
+        with pytest.raises(RuntimeError):
+            fut.result(timeout=5)
+
+        s = mgr.stats
+        assert s["total_succeeded"] == 2
+        assert s["total_failed"] == 1
+        assert s["total_reaped"] == 0
+        assert s["total_cancelled"] == 0
+        assert s["total_jobs_completed"] == 3
+        mgr.shutdown()
+
+    def test_event_log_fields(self, tmp_path):
+        log_file = tmp_path / "events.jsonl"
+        mgr = GPUManager(
+            [0], stats_log_interval_s=0, reaper_interval_s=0,
+            event_log_path=str(log_file),
+        )
+        mgr.run(GpuJob(fn=lambda g, e: "ok", label="field-test"))
+        mgr.shutdown()
+
+        lines = log_file.read_text().strip().splitlines()
+        records = [json.loads(line) for line in lines]
+
+        leased = next(r for r in records if r["event"] == "leased")
+        assert "lease_id" in leased
+        assert "gpu_ids" in leased
+        assert leased["job_label"] == "field-test"
+
+        released = next(r for r in records if r["event"] == "released")
+        assert released["reason"] == "completed"
+        assert "t" in released
+
+    def test_no_event_log_file_still_works(self):
+        mgr = GPUManager([0], stats_log_interval_s=0, reaper_interval_s=0)
+        mgr.run(GpuJob(fn=lambda g, e: "ok", label="no-file"))
+        s = mgr.stats
+        assert s["total_succeeded"] == 1
+        mgr.shutdown()

--- a/tests/tools/test_save_and_test_capture_integration.py
+++ b/tests/tools/test_save_and_test_capture_integration.py
@@ -1,0 +1,131 @@
+"""End-to-end (real ``git``) capture test for the patch-capture fix.
+
+Reproduces the failure that pinned GEAK's A/B speedup at 1.0x: a worktree that
+holds the genuine ``get_default_config`` source edit PLUS the Triton JIT-cache
+blobs (``.triton_cache_geak/<hash>/fused_moe_kernel.{hsaco,ttir,json}``),
+``__pycache__``, and a stray ``.so`` that a round leaves behind. The captured
+round patch must contain ONLY the source edit and must re-apply cleanly on a
+fresh checkout of the baseline (the precondition for the reactor's A/B to ever
+see the real kernel speedup).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from minisweagent.tools.save_and_test import SaveAndTestContext, SaveAndTestTool
+
+_GIT = shutil.which("git")
+pytestmark = pytest.mark.skipif(_GIT is None, reason="git not available")
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", cwd=root)
+    _git("config", "user.email", "t@t.t", cwd=root)
+    _git("config", "user.name", "t", cwd=root)
+    src = root / "python" / "sglang" / "fused_moe.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("def get_default_config():\n    return {'BLOCK_SIZE_M': 64}\n")
+    _git("add", "-A", cwd=root)
+    _git("commit", "-qm", "baseline", cwd=root)
+    return src
+
+
+def _pollute_with_jit_artifacts(root: Path) -> None:
+    """Write exactly the kinds of artifacts that broke re-apply."""
+    cache = root / ".triton_cache_geak" / "DEADBEEF"
+    cache.mkdir(parents=True)
+    (cache / "fused_moe_kernel.hsaco").write_bytes(b"\x7fELF binary")
+    (cache / "fused_moe_kernel.ttir").write_text("triton ir dump\n")
+    (cache / "fused_moe_kernel.json").write_text("{}\n")
+    pyc = root / "python" / "sglang" / "__pycache__"
+    pyc.mkdir()
+    (pyc / "fused_moe.cpython-312.pyc").write_bytes(b"pyc")
+    so_dir = root / "build_x"
+    so_dir.mkdir()
+    (so_dir / "common_ops.so").write_bytes(b"\x7fELF so")
+    # a non-triton runtime cache dir caught by the *cache* substring rule
+    inductor = root / "torchinductor_root" / "abc"
+    inductor.mkdir(parents=True)
+    (inductor / "out.py").write_text("# inductor codegen\n")
+
+
+def _make_edit(src: Path) -> None:
+    src.write_text("def get_default_config():\n    return {'BLOCK_SIZE_M': 256}\n")
+
+
+def test_capture_is_source_only_and_reapplies_cleanly(tmp_path):
+    repo = tmp_path / "wt"
+    src = _init_repo(repo)
+    _make_edit(src)
+    _pollute_with_jit_artifacts(repo)
+
+    tool = SaveAndTestTool()
+    tool.set_context(
+        SaveAndTestContext(
+            cwd=str(repo),
+            test_command=None,
+            timeout=30,
+            patch_output_dir=None,
+            base_repo_path=None,
+        )
+    )
+    patch = tool._get_patch_content()
+
+    # The genuine edit is captured...
+    assert "python/sglang/fused_moe.py" in patch
+    assert "BLOCK_SIZE_M" in patch and "+    return {'BLOCK_SIZE_M': 256}" in patch
+    # ...and NONE of the JIT / compiled / cache artifacts are.
+    for forbidden in (
+        ".triton_cache_geak", ".hsaco", ".ttir", "fused_moe_kernel.json",
+        "__pycache__", ".pyc", "common_ops.so", "torchinductor_root",
+    ):
+        assert forbidden not in patch, f"captured patch leaked artifact: {forbidden}\n{patch}"
+
+    # Re-apply cleanly on a FRESH checkout of the baseline (the reactor's A/B).
+    fresh = tmp_path / "fresh"
+    _init_repo(fresh)
+    patch_file = tmp_path / "round.patch"
+    patch_file.write_text(patch)
+    # ``git apply --check`` is the atomic gate that previously aborted with
+    # "already exists in working directory" when cache blobs rode along.
+    proc = subprocess.run(
+        ["git", "apply", "--check", str(patch_file)],
+        cwd=fresh, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, f"patch did not re-apply cleanly: {proc.stderr}"
+    subprocess.run(["git", "apply", str(patch_file)], cwd=fresh, check=True)
+    assert "BLOCK_SIZE_M': 256" in (fresh / "python" / "sglang" / "fused_moe.py").read_text()
+
+
+def test_capture_scoped_to_source_is_source_only(tmp_path):
+    """With the editable set declared, the scoped capture is also artifact-free."""
+    repo = tmp_path / "wt"
+    src = _init_repo(repo)
+    _make_edit(src)
+    _pollute_with_jit_artifacts(repo)
+
+    tool = SaveAndTestTool()
+    tool.set_context(
+        SaveAndTestContext(
+            cwd=str(repo),
+            test_command=None,
+            timeout=30,
+            patch_output_dir=None,
+            base_repo_path=None,
+            source_file_paths=["python/sglang/fused_moe.py"],
+        )
+    )
+    patch = tool._get_patch_content()
+    assert "fused_moe.py" in patch and "BLOCK_SIZE_M" in patch
+    for forbidden in (".triton_cache_geak", ".hsaco", "__pycache__", "common_ops.so"):
+        assert forbidden not in patch

--- a/tests/tools/test_save_and_test_source_scoping.py
+++ b/tests/tools/test_save_and_test_source_scoping.py
@@ -1,0 +1,127 @@
+"""Tests for the GEAK Layer-1/Layer-3 patch-capture fix in ``save_and_test``.
+
+* Layer 3 (allowlist): when ``source_file_paths`` is configured, the round
+  patch capture scopes ``git diff`` to that editable set so it can only ever
+  record genuine source edits -- with a safe fall-back to the blanket worktree
+  diff so an edit outside the declared set is never silently dropped.
+* Layer 1 (relocate): ``_build_test_env`` injects an OUT-OF-WORKTREE
+  ``TRITON_CACHE_DIR`` / ``GEAK_JIT_CACHE_DIR`` (overriding any stale in-worktree
+  value) so the reactor's per-round ``git diff`` never sweeps compiled blobs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+from minisweagent.tools.save_and_test import SaveAndTestContext, SaveAndTestTool
+
+
+def _tool(tmp_path: Path, *, source_file_paths=None, base_repo=None, env_vars=None) -> SaveAndTestTool:
+    tool = SaveAndTestTool()
+    tool.set_context(
+        SaveAndTestContext(
+            cwd=str(tmp_path),
+            test_command=None,
+            timeout=10,
+            patch_output_dir=None,
+            base_repo_path=base_repo,
+            env_vars=env_vars,
+            source_file_paths=source_file_paths,
+        )
+    )
+    return tool
+
+
+def _cp(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args="git", returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_capture_scopes_to_declared_source(tmp_path):
+    base_repo = tmp_path / "base"
+    base_repo.mkdir()
+    (tmp_path / "fused_moe.py").write_text("new\n")
+    tool = _tool(tmp_path, source_file_paths=["fused_moe.py"], base_repo=base_repo)
+
+    patch = "diff --git a/fused_moe.py b/fused_moe.py\n@@ -1 +1 @@\n-old\n+new\n"
+    cmds: list = []
+
+    def _run(cmd, *a, **k):
+        cmds.append(cmd)
+        return _cp(patch)
+
+    with (
+        mock.patch.object(SaveAndTestTool, "_is_git_repo", return_value=True),
+        mock.patch("minisweagent.tools.save_and_test.subprocess.run", side_effect=_run),
+    ):
+        out = tool._get_patch_content()
+
+    assert len(cmds) == 1, "scoped capture should not need the blanket fallback"
+    assert "fused_moe.py" in cmds[0]
+    assert "git add -N -- " in cmds[0]
+    assert "git diff -- . " not in cmds[0], "must NOT use the blanket worktree diff"
+    assert "+new" in out
+
+
+def test_capture_falls_back_to_blanket_when_scoped_empty(tmp_path):
+    """A real edit outside the declared set must never be dropped."""
+    base_repo = tmp_path / "base"
+    base_repo.mkdir()
+    (tmp_path / "kernel.py").write_text("x\n")  # declared, but unchanged here
+    tool = _tool(tmp_path, source_file_paths=["kernel.py"], base_repo=base_repo)
+
+    blanket = "diff --git a/other.py b/other.py\n@@ -1 +1 @@\n-old\n+new\n"
+    side = [_cp("", 0), _cp(blanket, 0)]  # scoped empty -> blanket has the edit
+
+    with (
+        mock.patch.object(SaveAndTestTool, "_is_git_repo", return_value=True),
+        mock.patch("minisweagent.tools.save_and_test.subprocess.run", side_effect=side) as run,
+    ):
+        out = tool._get_patch_content()
+
+    assert run.call_count == 2, "must fall back to the blanket diff"
+    assert "+new" in out
+
+
+def test_no_source_paths_uses_blanket(tmp_path):
+    base_repo = tmp_path / "base"
+    base_repo.mkdir()
+    tool = _tool(tmp_path, source_file_paths=None, base_repo=base_repo)
+
+    blanket = "diff --git a/kernel.py b/kernel.py\n@@ -1 +1 @@\n-old\n+new\n"
+    cmds: list = []
+
+    def _run(cmd, *a, **k):
+        cmds.append(cmd)
+        return _cp(blanket)
+
+    with (
+        mock.patch.object(SaveAndTestTool, "_is_git_repo", return_value=True),
+        mock.patch("minisweagent.tools.save_and_test.subprocess.run", side_effect=_run),
+    ):
+        out = tool._get_patch_content()
+
+    assert len(cmds) == 1
+    assert "git diff -- . " in cmds[0], "blanket worktree diff when no editable set"
+    assert "+new" in out
+
+
+def test_build_test_env_relocates_triton_cache_outside_worktree(tmp_path):
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    tool = _tool(wt)
+    env = tool._build_test_env()
+    assert "TRITON_CACHE_DIR" in env and "GEAK_JIT_CACHE_DIR" in env
+    assert not env["TRITON_CACHE_DIR"].startswith(str(wt.resolve()))
+
+
+def test_build_test_env_overrides_stale_in_worktree_cache(tmp_path):
+    """A legacy in-worktree TRITON_CACHE_DIR (the root cause) must be overridden."""
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    stale = str(wt / ".triton_cache_geak")
+    tool = _tool(wt, env_vars={"TRITON_CACHE_DIR": stale})
+    env = tool._build_test_env()
+    assert env["TRITON_CACHE_DIR"] != stale
+    assert not env["TRITON_CACHE_DIR"].startswith(str(wt.resolve()))


### PR DESCRIPTION
Closes #266

## Summary
Makes GEAK's per-round patch capture contain **only source edits** — never JIT/compiled/cache artifacts — for any toolchain/workload, so the reactor's A/B re-apply recompiles the patched source and measures the **real** kernel speedup instead of a 1.0x artifact. This unblocks the hands-off pipeline: a genuinely-good kernel now clears the internal KEEP gate instead of being silently degraded to `NEEDS_REVIEW`.

## Root cause
The harness-sanitizer pointed `TRITON_CACHE_DIR` *inside* the worktree (rule R5 → `$REPO_SRC/.triton_cache_geak`), so per-round JIT blobs (`.triton_cache_geak/<hash>/fused_moe_kernel.{hsaco,amdgcn,llir,ttir,ttgir,json}`, ~680 KB) landed in `git diff` scope and rode into the captured patch. On the reactor's clean-checkout A/B re-apply those blobs masked recompilation (and/or broke the atomic apply), so both A and B ran the same build → `micro_speedup` ≈ 1.0x. `is_jit_cache_artifact` only matched cache dirs by **exact** name (`.triton`), so the **suffixed** `.triton_cache_geak` slipped through. (Distinct from #250/#256, which fix new-file capture on the `diff -ruN` fallback tier; this is artifact pollution on the primary `git diff` path.)

## Fix (generic, 3 layers)
1. **Relocate caches OUTSIDE the worktree (primary).** New `jit_cache_env(work_dir)` helper returns an out-of-worktree, per-worktree `GEAK_JIT_CACHE_DIR` + `TRITON_CACHE_DIR`; wired into the reactor test env (`save_and_test._build_test_env`), the eval env (`build_eval_env`), and the COMMANDMENT `run.sh` (triton + hip templates). Harness-sanitizer **R5 rewritten**: never point a JIT cache under `$REPO_SRC`; keep in-place build outputs (`.so` the package imports) where they are; default Triton/inductor/aiter caches to `$GEAK_JIT_CACHE_DIR`.
2. **Artifact denylist (defense).** `is_jit_cache_artifact` is now prefix/suffix/substring-aware: cache-dir prefixes (`.triton*`, `.aiter*`, `torch_compile*`, `torchinductor*`, `flydsl_cache`), any `*cache*` dir, `__pycache__`, and compile-output extensions (`*.hsaco/.amdgcn/.llir/.ttir/.ttgir/.cubin/.ptx/.spv/.o/.so`). Wired into the capture excludes + post-strip; `strip_already_present_additions` retained.
3. **Allowlist by edited source (belt).** When `source_file_paths` is known, the capture scopes `git diff` to that editable set (with a safe blanket-diff fallback so an edit outside the set is never dropped).

## Test plan
- New unit tests (all green): `test_generated_artifacts_jit_cache.py` (denylist prefix/suffix/substring matching + negatives for real source incl. `cpp_itfs/*.cuh` and `cache_utils.py`; `jit_cache_env` relocates outside the worktree, deterministic + unique per slot), `test_save_and_test_source_scoping.py` (scoped capture + blanket fallback + cache-env override of a stale in-worktree value), `test_save_and_test_capture_integration.py` (**real-git**: a worktree polluted with `.triton_cache_geak/*.hsaco`, `__pycache__`, `.so`, inductor dir yields a **source-only** patch that **re-applies cleanly** on a fresh checkout). Existing `test_save_and_test_diff_fallthrough.py` stays green. `53 passed` on this branch's base; full `tests/tools/ tests/run/utils/` sweep green.
- Rendered triton COMMANDMENT validated (`validate_commandment` passes; generated `run.sh` relocates the cache out of the worktree).

## End-to-end validation (fully hands-off, bf16 gpt-oss-120B, TP=4, prefill-heavy ISL=4096/OSL=64)
With this fix active in the full Hyperloom pipeline:
- GEAK's round patch is now **clean** (`collect_optimized_codes: dropped 16 JIT-cache path(s)`), so GEAK self-scored the **real `micro_speedup = 1.7098x`** (verified FULL_BENCHMARK 1.7080ms → 1.0282ms), **not 1.0x** → auto-**KEEP**.
- The candidate flowed hands-off to Hyperloom `integrate_handler` (apply + E2E re-baseline) → **+21.68% E2E** (746.15 → 907.94 tok/s/gpu, CONC=64), `optimization_stack` non-empty, no human apply.
- Provenance: integrated config md5 == GEAK `optimized_codes` (`a6749912…`); the win is the `get_default_config` `M>=4096` source edit; serve logs show the `get_default_config` path with **zero** `E=128,N=720` JSON loads.

Made with [Cursor](https://cursor.com)