### PR TITLE
feat(skills): enhance FlyDSL optimization skills

### DIFF
--- a/skills/flydsl/SKILL.md
+++ b/skills/flydsl/SKILL.md
@@ -72,8 +72,15 @@ optimizations in early patches**, then fall back to tuning in later patches.
 - **Memory-bound** → reduce data movement (fusion, LDS caching, vectorization)
 - **Compute-bound** → improve instruction throughput (MFMA selection, software pipelining)
 - **Latency-bound** (small shapes) → reduce kernel launch count (fusion)
+- **LDS-dominated symptoms** (`ds_read`, `ds_write`, `lgkmcnt`, `s_barrier`, swizzle, padding, shared-memory layout) → stay in this optimization workflow; the detailed guidance lives in `docs/flydsl_optimization.md`
+- **GEMM-like kernel** → use this workflow for broad prioritization, then switch
+  to `docs/flydsl_gemm_optimization.md` when the main questions are about GEMM
+  tile shapes, MFMA-loop structure, epilogue strategy, or GEMM-specific LDS
+  staging trade-offs. For generic LDS symptoms, start with
+  `docs/flydsl_optimization.md` first, even if the kernel is GEMM-like.
 
 Full optimization workflow and detailed strategies: `docs/flydsl_optimization.md`
+GEMM-specific follow-on guide: `docs/flydsl_gemm_optimization.md`
 
 ---
 
@@ -119,4 +126,5 @@ The `docs/` subdirectory contains detailed guides:
 
 - `flydsl_tile_programming.md` — Kernel skeletons, compute recipes, control flow, LDS, MFMA reference
 - `flydsl_optimization.md` — Optimization workflow, tier-by-tier strategies, correctness constraints, key APIs
+- `flydsl_gemm_optimization.md` — GEMM-specific tuning for tile strategy, LDS staging, MFMA-loop efficiency, and epilogue/store trade-offs
 - `flydsl_debug_kernel.md` — NaN/zeros debugging, mismatch triage, compilation errors, GPU hangs

--- a/skills/flydsl/docs/flydsl_gemm_optimization.md
+++ b/skills/flydsl/docs/flydsl_gemm_optimization.md
@@ -1,0 +1,217 @@
+---
+layer: "flydsl"
+category: "optimization"
+tags: ["flydsl", "optimization", "gemm", "mfma", "lds", "swizzle", "epilogue"]
+last_updated: 2026-06-01
+---
+
+# FlyDSL GEMM Optimization
+
+## Overview
+
+Use this document when a FlyDSL kernel is already clearly **GEMM-like** and the
+next question is no longer "what category is this kernel?" but "which GEMM
+optimization lever should I pull first?".
+
+This is a specialized follow-on to the generic `flydsl` optimization workflow.
+Start with `flydsl_optimization.md` when the bottleneck is still broad or
+ambiguous. Switch here when the optimization work centers on GEMM structure,
+MFMA-loop efficiency, LDS layout, or epilogue/store strategy.
+
+---
+
+## When to Use
+
+Use this guide when most of the optimization discussion is about:
+
+- `tile_m` / `tile_n` / `tile_k` selection
+- MFMA instruction shape and repeat layout
+- LDS ping-pong or multi-stage buffering
+- XOR swizzle or other bank-conflict avoidance
+- global-load / LDS-load / MFMA overlap
+- `sched_mfma` / `sched_vmem` / `sched_dsrd` / `sched_dswr` tuning
+- direct-store vs shuffle/reorder epilogue
+- arch VGPR pressure, occupancy, or spill risk
+- ATT trace or ISA evidence from the GEMM hot loop
+
+Do **not** start here for:
+
+- first-time kernel authoring from scratch
+- general correctness bugs
+- non-GEMM kernels where the bottleneck is still unclear
+
+---
+
+## Workflow
+
+### 1. Confirm the kernel is really GEMM-like
+
+Read the full device kernel and host launcher. Verify that the hot path is a
+tiled matmul or fused matmul-style loop rather than a generic reduction or
+copy-heavy kernel with only incidental MFMA use.
+
+Questions to answer first:
+
+- What are the logical `M`, `N`, and `K` dimensions?
+- How are blocks and waves partitioned across output tiles?
+- Which operands are read from global memory each iteration?
+- Which data is reused enough to justify LDS staging?
+- Is the epilogue simple direct store, or does it reorder output fragments?
+
+### 2. Classify the bottleneck before rewriting
+
+Use the strongest evidence you have:
+
+- runtime measurements: kernel time, shape sensitivity, achieved throughput
+- ATT trace if available: `vmcnt`, `lgkmcnt`, `s_barrier`, `ds_*`,
+  `buffer_load_*`, `v_mfma_*`
+- ISA dump if available: MFMA density, barrier count, memory-instruction mix
+
+Rule of thumb:
+
+- High `s_waitcnt vmcnt(0)` before MFMA -> global-load latency exposed
+- High `s_waitcnt lgkmcnt(0)` or `ds_*` stall -> LDS latency or bank conflicts
+- High `s_barrier` stall -> synchronization overhead
+- Low MFMA density / many bubbles -> schedule or loop-shape problem
+- Good MFMA density but poor overall speed -> tile shape, occupancy, or store path
+
+### 3. Prioritize high-impact structure first
+
+Tune in this order:
+
+1. **Tile strategy**
+2. **LDS staging and overlap**
+3. **MFMA-loop scheduling**
+4. **Epilogue/store strategy**
+5. **Final parameter tuning**
+
+Do not start by micro-tweaking constants if the kernel still has obvious
+pipeline, tiling, or memory-layout problems.
+
+---
+
+## Core Patterns
+
+### Tiling
+
+Check these constraints first:
+
+- `tile_m` is a multiple of the MFMA M dimension
+- `tile_n` is large enough to keep waves busy and maps cleanly to wave/workgroup partitioning
+- `tile_k * elem_bytes` aligns with the kernel's load and MFMA packing strategy
+- total per-stage LDS fits the target arch budget
+
+Use larger `tile_k` when compute can hide memory latency and LDS budget allows.
+Reduce `tile_k` when LDS usage, register pressure, or occupancy becomes the
+real limit.
+
+When shapes are irregular, prefer a tile choice that remains robust across the
+benchmarked range instead of overfitting to one hotspot shape.
+
+### LDS staging
+
+For GEMM kernels, ask whether one of these is true:
+
+- an operand tile is reread many times by MFMA -> stage it through LDS
+- global-load latency is exposed -> prefetch earlier
+- one LDS buffer is idle while compute runs -> consider ping-pong staging
+
+If the kernel already uses LDS, inspect whether the problem is:
+
+- **capacity**: too much LDS per workgroup
+- **layout**: bank conflicts from stride or access pattern
+- **timing**: `ds_write` too close to dependent `ds_read` / wait
+
+### Swizzle and bank conflicts
+
+Prefer XOR-style swizzle when:
+
+- the access pattern is regular
+- read/write transforms can stay consistent
+- LDS headroom is tight
+
+Prefer padding when:
+
+- swizzle would overcomplicate address math
+- LDS has enough headroom
+- a small stride change removes the conflict cleanly
+
+Always keep the read path and write path consistent. A swizzled store with an
+unswizzled load is a correctness bug, not a performance optimization.
+
+### Prefetch and scheduling
+
+Prefetch helps only when there is enough independent work to hide the latency.
+Good candidates:
+
+- next-tile global loads
+- address computation
+- independent MFMA groups
+- epilogue preparation that does not consume the not-yet-ready data
+
+If prefetch adds substantial carried state, re-check VGPR pressure and
+occupancy. Prefetch that causes spills often loses more than it wins.
+
+For scheduler hints, match them to the real loop body instead of copying fixed
+numbers from another kernel. The MFMA count, LDS-read count, and VMEM count per
+iteration should come from the current kernel's loop structure.
+
+### Epilogue choice
+
+Here, "epilogue" means the final stage that maps accumulator fragments to
+output-memory stores.
+
+Use direct store when it is already reasonably coalesced and simple.
+
+Consider a shuffle/reorder epilogue when:
+
+- output stores are poorly coalesced
+- tile shape creates fragmented writes
+- the extra LDS/barrier cost is smaller than the store inefficiency
+
+---
+
+## Quick Reference
+
+| Symptom | Likely issue | First action |
+|---|---|---|
+| High `s_waitcnt vmcnt(0)` before MFMA | global-load latency exposed | move next-tile loads earlier; revisit prefetch distance |
+| High `s_waitcnt lgkmcnt(0)` / `ds_*` stall | LDS latency or bank conflict | inspect LDS layout, swizzle, padding, write-read distance |
+| High `s_barrier` stall | too many sync points | reduce stage boundaries or merge dependent phases |
+| Low MFMA ratio in hot loop | schedule overhead or loop shape | count MFMA vs memory ops and simplify loop body |
+| Speed good on one shape, bad on nearby shapes | brittle tile choice | re-check tile divisibility, occupancy, and edge handling |
+| Throughput drops after adding prefetch | register pressure too high | reduce carried state or use a lighter staging strategy |
+
+---
+
+## Correctness Constraints
+
+Performance changes must preserve these constraints:
+
+- respect arch-specific LDS limits
+- keep tile packing and vector widths aligned with operand layout
+- verify accumulator/output type conversions do not introduce unexpected overflow
+- apply any swizzle or padding consistently to both producer and consumer paths
+- confirm edge masking still works for non-divisible shapes
+
+---
+
+## Common Mistakes
+
+- starting from scheduler constants before proving the bottleneck
+- copying tile sizes from another kernel without checking work decomposition
+- adding multi-stage LDS buffering that destroys occupancy
+- treating every LDS issue as a swizzle problem instead of checking wait distance
+- comparing only one benchmark shape and overfitting to it
+- assuming a trace or ISA pattern from another repository matches the current kernel
+
+---
+
+## Verification
+
+After each meaningful change:
+
+1. Re-run correctness checks first
+2. Re-measure the same GEMM shapes as the baseline
+3. If trace or ISA evidence is available, confirm the targeted stall actually moved
+4. Check that speedup is not coming from one shape while others regress

--- a/skills/flydsl/docs/flydsl_optimization.md
+++ b/skills/flydsl/docs/flydsl_optimization.md
@@ -15,6 +15,7 @@ Parameter tuning alone yields marginal gains. **Prioritize structural optimizati
 2. Read the **`@flyc.jit` host wrapper** — count how many kernels are launched per call and what data each receives. Multiple kernels sharing data = fusion opportunity
 3. Read **any imported helper modules** (e.g. `flydsl.utils`, `flydsl.expr`) — they contain reusable building blocks and may reveal optimization opportunities
 4. Read the **test harness** — know what shapes, dtypes, and modes are benchmarked
+5. If you plan to rewrite loops or memory paths, quickly review the relevant FlyDSL semantics for `range_constexpr()` vs `range(..., init=...)`, `buffer_ops`, and `SmemAllocator` before editing
 
 ## Step 2: Classify the Bottleneck
 
@@ -22,6 +23,7 @@ Parameter tuning alone yields marginal gains. **Prioritize structural optimizati
 - **Memory-bound** → reduce data movement (fusion, LDS caching, vectorization)
 - **Compute-bound** → improve instruction throughput (MFMA selection, software pipelining)
 - **Latency-bound** (small shapes) → reduce kernel launch count (fusion)
+- **GEMM-like kernel** → if the next optimization question is mainly about `tile_m` / `tile_n` / `tile_k`, 2-stage LDS ping-pong, XOR swizzle, epilogue strategy, or MFMA-loop ISA counts, use this skill for generic prioritization and then switch to `gemm-optimization`
 
 ## Step 3: Optimize — High Impact First
 
@@ -33,6 +35,13 @@ Parameter tuning alone yields marginal gains. **Prioritize structural optimizati
 - **Redundant work elimination**: identify repeated loads, recomputed indices, or overlapping branches, and hoist/cache them
 - **Algorithm replacement**: if the current algorithm has unnecessary passes over data, restructure to reduce pass count (e.g. online softmax vs two-pass, fused attention vs separate Q×K then softmax then ×V)
 
+#### FlyDSL refactor guardrails
+
+- Use `range_constexpr()` only for compile-time unrolling. If the optimization needs runtime-carried state, use `range(..., init=...)` so FlyDSL lowers the loop to `scf.for`
+- For `scf.for` rewrites, loop bounds must be `arith.index()` values, not Python ints, and `init` / `yield` values must be raw MLIR `ir.Value`s
+- Keep loop-carried state positionally aligned across `init`, per-iteration `state`, `yield`, and post-loop results so each slot keeps the same semantic meaning and MLIR type through the whole loop
+- If an `SmemPtr` view created inside a loop body is reused in the epilogue, clear `_view_cache` before reusing it outside the loop to avoid SSA dominance errors
+
 ### Tier 2: Memory hierarchy (medium impact)
 
 - **LDS utilization**: if the kernel reads the same global data multiple times across threads, stage through LDS for reuse. Use `SmemAllocator` / `SmemPtr` from `flydsl.utils.smem_allocator`
@@ -41,6 +50,30 @@ Parameter tuning alone yields marginal gains. **Prioritize structural optimizati
 - **Pre-load across passes**: if the kernel makes multiple passes, load data needed in later passes during earlier ones to avoid redundant HBM reads
 - **Data layout / coalescing**: ensure memory access patterns are coalesced; restructure loop ordering if needed
 - **Register pressure management**: balance between keeping data in registers vs spilling to LDS
+
+#### FlyDSL prefetch rewrite pattern
+
+- Use prefetch when the loop has enough independent MFMA/ALU work, or a later barrier-heavy phase, to hide the next global load. If the body is already dominated by loads, prefetch alone is unlikely to help.
+- Follow a real loop-carried structure: prologue preloads iteration 0, `scf.for` carries the prefetched values, the loop body unpacks current state and issues next-iteration loads immediately, and the epilogue consumes the final carried values.
+- Carry every value needed to materialize the next iteration together — not just tensor payloads, but also block-table entries, page IDs, scale values, and running accumulators.
+- Keep the swap/prefetch path simple: unpack from `state`, issue the next loads as early as legality allows, and leave the load-to-consume distance for compute or barrier wait to hide.
+- If a later phase already spends time in `gpu.barrier()` or reduce synchronization, hoist the next phase's global loads into that region when legality allows; barrier wait is often the easiest place to hide VMEM latency.
+- Re-check register budget before adding prefetch buffers. Prefetch only helps when the extra carried state does not cause spills or unacceptable occupancy loss.
+
+#### Diagnose LDS bottlenecks before rewriting
+
+- Diagnose from trace shape, not intuition: high stall on `ds_read_*` / `ds_write_*` themselves points to bank conflicts; high `s_waitcnt lgkmcnt(0)` or barrier immediately after `ds_write` points to exposed write-read latency; barrier-heavy reduce chains point to cross-wave serialization.
+- On gfx942, think in 32 LDS banks; on gfx950, think in 64. A stride/layout that fully aliases banks on gfx942 may only partially conflict on gfx950, so swizzle masks and padding choices must be arch-aware.
+- Prefer XOR swizzle when you need zero LDS overhead and can keep read/write address transforms consistent. Use padding when swizzle is awkward to integrate and LDS headroom is available.
+- If the hotspot is write-read latency, increase the distance between `ds_write` and the dependent `ds_read` / wait by moving independent address computation, global loads, or MFMA work between them.
+- If the hotspot is barrier/reduce serialization, reduce unnecessary `gpu.barrier()` stages, merge LDS reduce phases when possible, or switch to cheaper cross-lane / cross-wave primitives before adding more LDS traffic.
+
+#### FlyDSL memory rewrite contracts
+
+- `buffer_ops.buffer_load` / `buffer_store` offsets are in **elements**, not bytes. Recompute address units whenever the rewrite changes `dtype`, packing, or vector width
+- If packed FP8/INT4 data is reinterpreted through `dtype=T.i32`, divide byte addresses by the new element width before loading
+- New or resized LDS allocations must still go through `SmemAllocator`, and `allocator.finalize()` must still happen in the GPU module body
+- Any change that moves `SmemPtr` views across loop or region boundaries should re-check cached-view lifetime and SSA dominance
 
 ### Tier 3: Compute (medium impact)
 
@@ -52,6 +85,13 @@ Parameter tuning alone yields marginal gains. **Prioritize structural optimizati
 ### Tier 4: Parameter tuning (low impact)
 
 - Block size, tile dimensions, unroll factors, `known_block_size` hints
+
+#### Tune after structure stabilizes
+
+- Do structural fixes first: control-flow rewrite, memory-path rewrite, LDS strategy, MFMA selection, and correctness
+- Only after semantics and codegen stabilize should you tune block size, tile shape, unroll factors, `known_*` hints, or expose knobs to `@autotune`
+- Treat old tuning conclusions as stale after codegen-affecting refactors
+- When varying `Constexpr` values across recompiles, prefer passing raw `torch.Tensor` objects rather than reusing cached `flyc.from_dlpack()` wrappers
 
 ## Modification Rules
 
@@ -73,12 +113,18 @@ Always verify after each patch — violations often cause silent corruption:
 
 1. Run correctness tests first — never sacrifice correctness for speed
 2. Confirm speedup across **all** tested shapes, not just one
-3. If speedup is marginal, move to the next structural strategy rather than re-tuning the same approach
+3. For structural rewrites, dump IR/ISA with `FLYDSL_DUMP_IR=1` and inspect the relevant `.mlir` stage plus `final_isa.s`
+4. Verify the specific effect you wanted: `scf.for` survives tracing/lowering, wide loads/stores stay vectorized, the MFMA variant matches the target dtype/arch, and the final loop shape reflects the intended schedule
+5. If the generated form did not change, assume the optimization did not land yet, even if the Python source looks right
+6. If speedup is marginal, move to the next structural strategy rather than re-tuning the same approach
 
 ## Key FlyDSL APIs
 
 - Device kernel: `@flyc.kernel` | Host launcher: `@flyc.jit`
+- Control flow: `range_constexpr()` | `range(..., init=...)` | `arith.index()`
 - Intrinsics: `flydsl.expr.rocdl` — MFMA, exp2, rcp, sched_barrier, sched_mfma
 - Shared memory: `SmemAllocator` / `SmemPtr` from `flydsl.utils.smem_allocator`
 - Types: `T.f16`, `T.bf16`, `T.f32`, `T.i32`, `T.vec(...)` from `flydsl.expr.typing`
-- Buffer ops: `fx.rocdl.make_buffer_tensor`, `fx.make_copy_atom`
+- Buffer ops: `fx.rocdl.make_buffer_tensor`, `fx.make_copy_atom`, `buffer_ops.buffer_load` / `buffer_store` (offsets are in elements)
+- IR/ISA inspection: `FLYDSL_DUMP_IR=1`, `FLYDSL_DUMP_DIR=...`, `final_isa.s`
+- Autotune: `flydsl.autotune.autotune`, `Config`, `do_bench`

--- a/skills/flydsl/docs/flydsl_optimization.md
+++ b/skills/flydsl/docs/flydsl_optimization.md
@@ -23,7 +23,7 @@ Parameter tuning alone yields marginal gains. **Prioritize structural optimizati
 - **Memory-bound** → reduce data movement (fusion, LDS caching, vectorization)
 - **Compute-bound** → improve instruction throughput (MFMA selection, software pipelining)
 - **Latency-bound** (small shapes) → reduce kernel launch count (fusion)
-- **GEMM-like kernel** → if the next optimization question is mainly about `tile_m` / `tile_n` / `tile_k`, 2-stage LDS ping-pong, XOR swizzle, epilogue strategy, or MFMA-loop ISA counts, use this skill for generic prioritization and then switch to `gemm-optimization`
+- **GEMM-like kernel** → if the next optimization question is mainly about `tile_m` / `tile_n` / `tile_k`, GEMM-specific LDS staging, epilogue strategy, or MFMA-loop ISA counts, use this guide for generic prioritization and then switch to `flydsl_gemm_optimization.md`
 
 ## Step 3: Optimize — High Impact First
 
@@ -67,6 +67,91 @@ Parameter tuning alone yields marginal gains. **Prioritize structural optimizati
 - Prefer XOR swizzle when you need zero LDS overhead and can keep read/write address transforms consistent. Use padding when swizzle is awkward to integrate and LDS headroom is available.
 - If the hotspot is write-read latency, increase the distance between `ds_write` and the dependent `ds_read` / wait by moving independent address computation, global loads, or MFMA work between them.
 - If the hotspot is barrier/reduce serialization, reduce unnecessary `gpu.barrier()` stages, merge LDS reduce phases when possible, or switch to cheaper cross-lane / cross-wave primitives before adding more LDS traffic.
+
+#### LDS quick architecture reference
+
+| Arch | LDS size per CU | Banks | Full-conflict stride heuristic |
+|------|------------------|-------|-------------------------------|
+| `gfx942` | 64 KB | 32 | multiples of 128 bytes often fully alias banks |
+| `gfx950` | 160 KB | 64 | multiples of 256 bytes often fully alias banks |
+
+Two practical consequences:
+
+- the same layout may conflict badly on `gfx942` but only partially on `gfx950`
+- padding choices that are too expensive on `gfx942` may be acceptable on `gfx950`
+
+#### Classify the LDS problem precisely
+
+Use the trace or ISA shape to separate these cases:
+
+- **Bank conflicts**: `ds_read_*` / `ds_write_*` instructions themselves carry the stall
+- **Write-read latency exposed**: `s_waitcnt lgkmcnt(0)` spikes immediately after `ds_write`
+- **Cross-wave serialization**: `s_barrier` dominates a reduce or broadcast region
+
+Treat these metrics in two stages:
+
+- **Before the rewrite**: use them to classify which LDS problem dominates
+- **After the rewrite**: use the same metrics to verify that the targeted bottleneck actually moved
+
+Do not treat all three as the same issue. Each one wants a different fix.
+
+#### Swizzle vs padding
+
+Use **XOR swizzle** when:
+
+- the read and write paths both use a regular logical row/column mapping
+- you need to reduce bank conflicts without increasing LDS footprint
+- the address transform is still easy to audit for correctness
+
+Use **padding** when:
+
+- the swizzle math would make the code materially harder to maintain
+- a small stride change breaks the conflict pattern cleanly
+- LDS headroom is available on the target arch
+
+For either strategy, keep producer and consumer paths consistent. A swizzled
+store paired with a linear load is a correctness bug.
+
+#### Increase write-read distance before adding more structure
+
+If the stall is on `lgkmcnt` immediately after `ds_write`, first try reordering
+useful work between the write and the dependent read:
+
+- next-phase global loads
+- address calculation for the next iteration
+- independent MFMA or ALU work
+- epilogue preparation that does not depend on the just-written LDS data
+
+At the FlyDSL level, the pattern is:
+
+```python
+# BEFORE: write is followed by an immediate barrier/read
+lds_ptr.store(data, [offset])
+fx.gpu.barrier()
+value = lds_ptr.load([offset])
+
+# AFTER: insert independent work before the synchronization point
+lds_ptr.store(data, [offset])
+next_offsets = compute_next_offsets()
+# For example, issue the next global load here if it does not depend on the LDS write.
+next_data = buffer_ops.buffer_load(next_rsrc, next_offsets, vec_width=4, dtype=fx.T.f32())
+fx.gpu.barrier()
+value = lds_ptr.load([offset])
+```
+
+Avoid inserting work that depends on the just-written LDS value, or extra LDS
+traffic that competes with the same bottleneck you are trying to hide.
+
+#### LDS verification checklist
+
+After an LDS-focused rewrite, verify all of these:
+
+- correctness still holds on the same benchmark shapes
+- `ds_read_*` / `ds_write_*` stall decreased if you targeted bank conflicts
+- `s_waitcnt lgkmcnt(0)` stall decreased if you targeted write-read latency
+- barrier count or barrier stall decreased if you targeted cross-wave serialization
+- total LDS bytes still fit the target arch budget
+- added address math or prefetch state did not create a register-pressure regression
 
 #### FlyDSL memory rewrite contracts
 

--- a/skills/flydsl/docs/flydsl_optimization.md
+++ b/skills/flydsl/docs/flydsl_optimization.md
@@ -20,20 +20,24 @@ Parameter tuning alone yields marginal gains. **Prioritize structural optimizati
 ## Step 2: Classify the Bottleneck
 
 - Check the **target GPU arch** via `get_hip_arch()` — LDS size, MFMA variants, and wavefront width are arch-dependent (e.g. gfx942: 64 KB LDS, 304 CUs, wavefront 64)
-- **Memory-bound** → reduce data movement (fusion, LDS caching, vectorization)
+- **Memory-bound with cross-thread reuse** (e.g. tiled GEMM operands, attention K/V tiles) → LDS staging, prefetch, vectorization
+- **Memory-bound without cross-thread reuse** (e.g. pure elementwise ops, RoPE position encoding, cache-write-only passes) → vectorization and coalescing **only**; LDS staging adds overhead without benefit because each thread processes its own independent slice. Do not add LDS staging or structural rewrites to this class.
 - **Compute-bound** → improve instruction throughput (MFMA selection, software pipelining)
 - **Latency-bound** (small shapes) → reduce kernel launch count (fusion)
+- **Already-fused kernel** (kernel name contains `fused_`, or the source already combines multiple ops in one `@flyc.kernel`) → the structural optimum is likely already reached; prioritize Tier 2 (vectorization, coalescing) and Tier 3 (MFMA, scheduling) instead of further fusion or loop restructuring
 - **GEMM-like kernel** → if the next optimization question is mainly about `tile_m` / `tile_n` / `tile_k`, GEMM-specific LDS staging, epilogue strategy, or MFMA-loop ISA counts, use this guide for generic prioritization and then switch to `flydsl_gemm_optimization.md`
 
 ## Step 3: Optimize — High Impact First
 
 ### Tier 1: Structural (highest impact)
 
-- **Kernel fusion**: if the `@flyc.jit` wrapper launches 2+ kernels that share input data, merge them into a single `@flyc.kernel`. Eliminates launch overhead and redundant HBM reads
+**Guard**: Tier 1 rewrites carry the highest regression risk. Before applying any structural change, confirm that the kernel is NOT already at the structural optimum: single-kernel, single-pass, or already named `fused_*` / `*_2stage` / `*_multistage`. For those, skip to Tier 2.
+
+- **Kernel fusion**: if the `@flyc.jit` wrapper launches 2+ kernels that share input data, merge them into a single `@flyc.kernel`. Eliminates launch overhead and redundant HBM reads. Do not attempt further fusion on a kernel that is already named `fused_*` or already combines all relevant ops.
 - **Fast-path relaxation**: look for overly-restrictive conditions guarding optimized code paths (e.g. disabled branches, alignment checks stricter than necessary). Relaxing these lets more shapes use the fast path
-- **Loop restructuring**: if the kernel uses constexpr loop unrolling that causes code bloat for large iteration counts, convert to `scf.for` with loop-carried state to reduce binary size and register pressure
+- **Loop restructuring**: if the kernel uses constexpr loop unrolling that causes measurable code bloat or register pressure for large iteration counts, convert to `scf.for` with loop-carried state. Do not convert when unrolling is the primary source of ILP or the iteration count is small and fixed — converting then adds overhead rather than saving it.
 - **Redundant work elimination**: identify repeated loads, recomputed indices, or overlapping branches, and hoist/cache them
-- **Algorithm replacement**: if the current algorithm has unnecessary passes over data, restructure to reduce pass count (e.g. online softmax vs two-pass, fused attention vs separate Q×K then softmax then ×V)
+- **Algorithm replacement**: if the current algorithm has unnecessary passes over data, restructure to reduce pass count (e.g. online softmax vs two-pass, fused attention vs separate Q×K then softmax then ×V). For single-pass elementwise kernels, the algorithm is already optimal at the pass level; do not add passes or stages.
 
 #### FlyDSL refactor guardrails
 
@@ -44,16 +48,16 @@ Parameter tuning alone yields marginal gains. **Prioritize structural optimizati
 
 ### Tier 2: Memory hierarchy (medium impact)
 
-- **LDS utilization**: if the kernel reads the same global data multiple times across threads, stage through LDS for reuse. Use `SmemAllocator` / `SmemPtr` from `flydsl.utils.smem_allocator`
+- **LDS utilization**: if the kernel reads the same global data multiple times **across threads within the same workgroup**, stage through LDS for reuse. Use `SmemAllocator` / `SmemPtr` from `flydsl.utils.smem_allocator`. **Do not add LDS staging for kernels where each thread processes its own independent slice with no block-level data sharing** (e.g. pure elementwise, RoPE position encoding, cache-write-only passes) — LDS adds synchronization and address overhead with no reuse benefit.
 - **Vectorized access**: use the widest vector loads/stores (`vec(8, ...)`, `vec(4, ...)`) that match the element type for maximum HBM bandwidth
-- **Overlap loads with compute**: move global loads earlier so they complete while ALU/MFMA work is in progress. Use scheduler barriers (`sched_barrier`) to control interleaving
+- **Overlap loads with compute**: move global loads earlier so they complete while ALU/MFMA work is in progress. Use scheduler barriers (`sched_barrier`) to control interleaving. This is only beneficial when MFMA or non-trivial ALU work exists to overlap with; for load-dominated kernels this produces no gain.
 - **Pre-load across passes**: if the kernel makes multiple passes, load data needed in later passes during earlier ones to avoid redundant HBM reads
 - **Data layout / coalescing**: ensure memory access patterns are coalesced; restructure loop ordering if needed
 - **Register pressure management**: balance between keeping data in registers vs spilling to LDS
 
 #### FlyDSL prefetch rewrite pattern
 
-- Use prefetch when the loop has enough independent MFMA/ALU work, or a later barrier-heavy phase, to hide the next global load. If the body is already dominated by loads, prefetch alone is unlikely to help.
+- Use prefetch when the loop has enough independent MFMA/ALU work, or a later barrier-heavy phase, to hide the next global load. **If the loop body is dominated by global loads with minimal MFMA or ALU compute, do not add prefetch** — there is no compute to hide behind, and the extra loop-carried state increases register pressure and can reduce occupancy without any latency benefit.
 - Follow a real loop-carried structure: prologue preloads iteration 0, `scf.for` carries the prefetched values, the loop body unpacks current state and issues next-iteration loads immediately, and the epilogue consumes the final carried values.
 - Carry every value needed to materialize the next iteration together — not just tensor payloads, but also block-table entries, page IDs, scale values, and running accumulators.
 - Keep the swap/prefetch path simple: unpack from `state`, issue the next loads as early as legality allows, and leave the load-to-consume distance for compute or barrier wait to hide.
@@ -198,10 +202,11 @@ Always verify after each patch — violations often cause silent corruption:
 
 1. Run correctness tests first — never sacrifice correctness for speed
 2. Confirm speedup across **all** tested shapes, not just one
-3. For structural rewrites, dump IR/ISA with `FLYDSL_DUMP_IR=1` and inspect the relevant `.mlir` stage plus `final_isa.s`
-4. Verify the specific effect you wanted: `scf.for` survives tracing/lowering, wide loads/stores stay vectorized, the MFMA variant matches the target dtype/arch, and the final loop shape reflects the intended schedule
-5. If the generated form did not change, assume the optimization did not land yet, even if the Python source looks right
-6. If speedup is marginal, move to the next structural strategy rather than re-tuning the same approach
+3. **Report both speedup ratio and absolute optimized time (ms)**. A higher speedup ratio paired with a worse absolute optimized time means the baseline shifted, not that the kernel improved. Treat any case where the absolute optimized time regresses as a failure even if the ratio looks better.
+4. For structural rewrites, dump IR/ISA with `FLYDSL_DUMP_IR=1` and inspect the relevant `.mlir` stage plus `final_isa.s`
+5. Verify the specific effect you wanted: `scf.for` survives tracing/lowering, wide loads/stores stay vectorized, the MFMA variant matches the target dtype/arch, and the final loop shape reflects the intended schedule
+6. If the generated form did not change, assume the optimization did not land yet, even if the Python source looks right
+7. If speedup is marginal or absolute time regresses, move to the next structural strategy rather than re-tuning the same approach
 
 ## Key FlyDSL APIs
 


### PR DESCRIPTION
co-authored by @yuttian1

## Summary
This PR enhances the FlyDSL optimization skill set used by GEAK. The goal is to reduce common agent failure modes—unnecessary structural rewrites, misapplied LDS/prefetch optimizations, and brittle GEMM tuning—while giving agents clearer routing, diagnostics, and verification checklists.
**Scope:** documentation / skill guidance only (`skills/flydsl/`). 
### Motivation
The existing `flydsl_optimization.md` covered high-level tiered optimization but lacked:
1. **Actionable LDS diagnostics** to distinguish bank conflicts vs write-read latency vs cross-wave serialization, with arch-aware guidance for gfx942 vs gfx950
2. **FlyDSL-specific rewrite contracts** for `scf.for` state, `SmemPtr` lifetime, and `buffer_ops` offset semantics
3. **A dedicated GEMM follow-on guide** for tile/MFMA/epilogue decisions once a kernel is confirmed GEMM-like
These gaps often led agents to apply structurally correct-looking but counterproductive optimizations, or to report misleading speedup ratios when baselines shifted.
4. **Guardrails** against high-risk structural rewrites on already-optimal or inappropriate kernels (e.g. adding LDS to independent elementwise passes, prefetch on load-dominated loops, further fusion on `fused_*` kernels)
### Changes
#### 1. `skills/flydsl/SKILL.md`
- Add bottleneck routing for **LDS-dominated symptoms** (`ds_read`, `ds_write`, `lgkmcnt`, `s_barrier`, swizzle/padding)
- Add routing for **GEMM-like kernels** → generic optimization first, then `flydsl_gemm_optimization.md` for tile/MFMA/epilogue questions
- Register the new GEMM doc in the reference index
#### 2. `skills/flydsl/docs/flydsl_optimization.md` (+~136 lines)
- **Tier 1 guardrails**: skip structural rewrites when kernel is already fused / at structural optimum; avoid LDS for kernels without cross-thread reuse
- **FlyDSL refactor guardrails**: `range_constexpr()` vs `range(..., init=...)`, `scf.for` SSA/state alignment, `_view_cache` lifetime
- **Prefetch rewrite pattern**: loop-carried prologue/epilogue structure, when *not* to prefetch, register-budget checks
- **LDS diagnostics**: trace/ISA-based classification, gfx942/gfx950 bank/stride heuristics, swizzle vs padding, write-read distance patterns with FlyDSL code example
- **LDS verification checklist** and **memory rewrite contracts** (`buffer_load` offsets in elements, `SmemAllocator.finalize()`, etc.)
- **Tune-after-structure** guidance and stale-tuning warnings after codegen-affecting refactors
- **Stronger validation rules**: report **both speedup ratio and absolute optimized time (ms)**; use `FLYDSL_DUMP_IR=1` to confirm optimizations landed in IR/ISA
- Expanded Key APIs (control flow, buffer ops, IR dump, autotune)
#### 3. `skills/flydsl/docs/flydsl_gemm_optimization.md` (new, 217 lines)
- GEMM-specific workflow: confirm GEMM-like structure → classify bottleneck from ATT/ISA → prioritize tile → LDS staging → MFMA scheduling → epilogue → parameter tuning
- Core patterns for tiling constraints, ping-pong LDS, XOR swizzle vs padding, prefetch/sched hints, direct vs shuffle epilogue
- Quick-reference symptom table and common-mistake list
### Evaluation results with FlyDSL bench cases in TestAgentArena
Evaluation on MI300X shows that, for 7 FlyDSL bench cases in AgentArena, we have 100% correctness across tested kernels and **up to 1.14× speedup** versus the baseline GEAK FlyDSL optimization skill. Only 1 case shows -2% but we think this can be performance fluctuation.
<img width="548" height="147" alt="image" src="https://github.com/user-attachments/assets/2e0188f6-0cd8-46d2-a03f-7561c4e01e06" />

