### PR TITLE
integrate geak_v4 with hyperloom

### DIFF
--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -86,6 +86,12 @@ const ISL = parseInt(A.isl != null ? A.isl : 1024, 10);
 const OSL = parseInt(A.osl != null ? A.osl : 1024, 10);
 const CONC = parseInt(A.conc != null ? A.conc : 64, 10);
 const WORKLOAD = { isl: ISL, osl: OSL, conc: CONC };
+// Seed config: when an external orchestrator (e.g. Hyperloom) already did
+// config/param search, it passes its accepted best flags/env so the PerfSkills
+// baseline is measured ON that config (fair engagement start), not the stack
+// default. Serving TP/GPU are handled by SERVING_TP / SERVING_GPU above.
+const INIT_FLAGS = String(A.initial_extra_server_args || '');
+const INIT_ENV = String(A.initial_extra_env || '');
 // Acceptance noise band (%). Tight measurement (interleaved A/B, E2E_REPEATS repeats, non-overlap +
 // engagement proof — see e2e_integrator) makes a 0.5% default trustworthy. Prompt-tunable.
 const NOISE_BAND_DEFAULT = parseFloat(A.noise_band_pct != null ? A.noise_band_pct : 0.5);
@@ -122,7 +128,8 @@ const SETUP_SCHEMA = obj({
   eval_dir: { type: 'string' }, model_name: { type: 'string' },
   baseline_throughput_tok_s: { type: 'number' }, baseline_spread_pct: { type: 'number' },
   noise_band_pct: { type: 'number' }, baseline_summary_path: { type: 'string' },
-  server_flags: { type: 'object', additionalProperties: true }, workload: { type: 'object', additionalProperties: true },
+  server_flags: { type: 'object', additionalProperties: true }, server_env: { type: 'string' },
+  tp: { type: 'number' }, workload: { type: 'object', additionalProperties: true },
   bench_script: { type: 'string' }, notes: { type: 'string' },
 }, ['eval_dir', 'baseline_throughput_tok_s']);
 
@@ -332,7 +339,7 @@ if (want('setup')) {
   const setup = await safeAgent(
     roleAgent('director', 'setup', 'Build the isolated e2e eval dir and record the baseline throughput.', {
       LAUNCH_SCRIPT, MODEL_PATH, EXP_ROOT, EVAL_DIR_OVERRIDE, MODEL_NAME_HINT, TASK,
-      GPU_IDS, WORKLOAD, SKILL_DIR: WORKFLOW_DIR,
+      GPU_IDS, WORKLOAD, INIT_FLAGS, INIT_ENV, SKILL_DIR: WORKFLOW_DIR,
     }),
     { phase: 'Setup', label: 'director:setup', schema: SETUP_SCHEMA });
   if (!setup || !setup.eval_dir) throw new Error('Setup failed: no eval_dir');
@@ -340,8 +347,10 @@ if (want('setup')) {
   MODEL_NAME = setup.model_name || MODEL_NAME_HINT;
   BASELINE_TPUT = setup.baseline_throughput_tok_s;
   NOISE_BAND = setup.noise_band_pct || NOISE_BAND_DEFAULT;
-  curFlags = (setup.server_flags && setup.server_flags.extra) || '';
-  curEnv = '';
+  // Seed flags/env win when provided (baseline was measured on them); else fall
+  // back to whatever the director resolved.
+  curFlags = INIT_FLAGS || (setup.server_flags && setup.server_flags.extra) || '';
+  curEnv = INIT_ENV || (setup.server_env || '');
   log(`Setup done. EVAL_DIR=${EVAL_DIR}, baseline ${BASELINE_TPUT} tok/s (noise band ${NOISE_BAND}%)`);
 
   phase('Profile');

--- a/e2e_workflow/roles/director.md
+++ b/e2e_workflow/roles/director.md
@@ -32,7 +32,9 @@ driven through `bench_e2e.sh` with `BACKEND=<backend>` so the stack stays a swap
 
 Inputs: `LAUNCH_SCRIPT` (path to a bench/launch script; may be empty), `MODEL_PATH`, `BACKEND`
 (sglang|vllm; default sglang), `EXP_ROOT`, `EVAL_DIR_OVERRIDE` (may be empty), `MODEL_NAME_HINT`,
-`TASK`, `SKILL_DIR`, `GPU_IDS`, `WORKLOAD` (ISL/OSL/conc).
+`TASK`, `SKILL_DIR`, `GPU_IDS`, `SERVING_TP`/`SERVING_GPU` (serving config invariant), `WORKLOAD`
+(ISL/OSL/conc), `INIT_FLAGS` (seed `--server` flags from the caller's best config; may be empty),
+`INIT_ENV` (seed `KEY=VAL` env from the caller's best config; may be empty).
 
 Steps:
 1. Collision-proof run id: `TS=$(date +%Y%m%d_%H%M%S)_$$_${RANDOM}`.
@@ -68,14 +70,22 @@ Steps:
    inputs / the SERVING CONFIG INVARIANT block of your prompt). `GPU_IDS` is the optimization-parallelism
    pool, NOT the serving tensor-parallel size; the serving config is `TP=SERVING_TP GPU=SERVING_GPU`.
    Every later e2e measurement (sweep, integrate, validate) MUST match this exact `TP=SERVING_TP
-   GPU=SERVING_GPU` config, or deltas are meaningless. Use the copied bench script (substitute the actual
-   SERVING_TP / SERVING_GPU values from your inputs):
+   GPU=SERVING_GPU` config, or deltas are meaningless.
+   **Seed config**: if `INIT_FLAGS`/`INIT_ENV` are given (the caller's already-searched best config),
+   the baseline MUST be measured ON them (pass `EXTRA_SERVER_ARGS`/`EXTRA_ENV`), so PerfSkills' baseline
+   == the caller's best config and later kernel gains compound on top of it. Use the copied bench script
+   (substitute the actual SERVING_TP / SERVING_GPU values from your inputs):
    ```bash
    BACKEND="<backend>" OUT_DIR="$EVAL_DIR/baseline" GPU="<SERVING_GPU>" TP="<SERVING_TP>" MODEL="$MODEL_PATH" \
    ISL=<isl> OSL=<osl> CONC=<conc> REPEATS=3 PROFILE=0 \
+   EXTRA_SERVER_ARGS="<INIT_FLAGS>" EXTRA_ENV="<INIT_ENV>" \
      bash "$EVAL_DIR/bench_e2e.sh" 2>&1 | tee "$EVAL_DIR/logs/baseline_bench.log"
    ```
    Parse `EVAL_DIR/baseline/bench_summary.json` for `output_throughput_tok_s_median` + spread.
+   **Prove engagement**: grep `EVAL_DIR/logs/baseline_bench.log` / `server.log` to confirm the seed
+   flags/env actually took effect (e.g. the chosen attention backend / env var appears in the server
+   banner). If a seed flag did not engage, record it loudly in `notes` — a baseline measured on a
+   silently-ignored config corrupts every later gain.
 6. If baseline spread > ~5%, re-run — a noisy baseline poisons every later comparison. Set
    `noise_band_pct = 0.5` (the default accept threshold): the Integrator gates with a TIGHT protocol
    (interleaved A/B, E2E_REPEATS per leg, non-overlap + engagement proof) that makes 0.5% trustworthy.
@@ -91,7 +101,9 @@ Return JSON:
   "baseline_spread_pct": 0.0,
   "noise_band_pct": 0.5,
   "baseline_summary_path": "<EVAL_DIR>/baseline/bench_summary.json",
-  "server_flags": {"...": "..."},
+  "server_flags": {"extra": "<resolved server flags, incl. INIT_FLAGS>"},
+  "server_env": "<resolved KEY=VAL env, incl. INIT_ENV>",
+  "tp": 1,
   "workload": {"isl": 1024, "osl": 1024, "conc": 64},
   "bench_script": "<EVAL_DIR>/bench_e2e.sh",
   "notes": "sglang version, anything unusual"
@@ -115,10 +127,14 @@ TRUE baseline with the tight 2-block protocol and decide if the COMBINED result 
 1. Measure baseline AND final **same-session, tight** (2 launches, not per-repeat): a reference block
    (stack/stack-default = the TRUE baseline config, i.e. NO overlay/flags) and a final block (full
    overlay + flags), each `E2E_REPEATS` (default 7) timed repeats on ONE server:
+   The TRUE-baseline block MUST reproduce the seed config the baseline was measured on (the caller's
+   best config = the recorded `baseline` flags/env, i.e. the same `INIT_FLAGS`/`INIT_ENV`) — NOT
+   `FINAL_FLAGS` minus PerfSkills' kernel wins. Use the same `TP=SERVING_TP GPU=SERVING_GPU` as setup.
    ```bash
-   # fresh TRUE-baseline block (no overlay, no accepted flags) — re-measured NOW to cancel box drift.
+   # fresh TRUE-baseline block (baseline seed flags/env, NO kernel overlay) — re-measured NOW for drift.
    # Serving config MUST be the run-wide invariant: TP=SERVING_TP GPU=SERVING_GPU (from your inputs).
    BACKEND="<backend>" OUT_DIR="$EVAL_DIR/validation/base" GPU="<SERVING_GPU>" TP="<SERVING_TP>" MODEL="$MODEL_PATH" \
+   EXTRA_SERVER_ARGS="<baseline seed flags>" EXTRA_ENV="<baseline seed env>" \
    REPEATS="${E2E_REPEATS:-7}" PROFILE=0 ISL=<isl> OSL=<osl> CONC=<conc> \
      bash "$EVAL_DIR/bench_e2e.sh" 2>&1 | tee -a "$EVAL_DIR/logs/validation_bench.log"
    # final block (full overlay + flags + env), SAME TP=SERVING_TP GPU=SERVING_GPU

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -283,7 +283,10 @@ attempt, win or not. REQUIRED sections, in order:
 
 4. **Artifacts tree**: `tree -L 2 -I "__pycache__|*.pyc|.git|*.so"` of the eval dir, annotating `[P#]` per path.
 
-5. **Summary table** of all attempts (lever | isolated | e2e | verdict | root cause).
+5. **Summary table** of all attempts (lever | what changed | isolated | e2e | verdict | root cause).
+   For every attempt record **WHAT optimization was applied and exactly WHICH params changed** (e.g.
+   backend swap triton→flydsl, tile/block sizes, num_warps, dtype, fused epilogue, the flag/env value),
+   not just the verdict — so the report explains *how* each gain/no-op happened.
 
 6. **⚠️ FLAGGED dominant heads** (from `FLAGGED_HEADS`): MANDATORY if non-empty. For each, list `pct_gpu_time`,
    the stage it failed at (extract / bakeoff / no_candidate), whether it was a `harness_error` (bake-off could
@@ -291,7 +294,10 @@ attempt, win or not. REQUIRED sections, in order:
    carry the LARGEST remaining headroom (top "next direction"). Never bury a flagged head in the no-ops.
 
 7. **Final deliverable + measurement caveats** (box drift → trust ONLY same-session A/B; the official number
-   is the Director's same-session value) **+ next directions to explore.**
+   is the Director's same-session value) **+ next directions to explore.** Quote the FINAL serving numbers
+   from `EVAL_DIR/validation/final/bench_summary.json` — throughput (median + spread), **TTFT and TPOT** —
+   next to the baseline numbers, so the report shows the full E2E throughput / TTFT / TPOT delta (not just
+   throughput).
 
 Data sources (read the ACTUAL files, never invent): `director_e2e_validation.json`,
 `final/bench/bench_summary.json`, `config/sweep_results.json`, `overlay/cand_*/integrate_result.json`,
@@ -304,8 +310,13 @@ to architect_report.md; also mention `final_report.md` in `note` if the schema l
   "baseline_throughput_tok_s": 0.0,
   "final_throughput_tok_s": 0.0,
   "throughput_speedup": 1.0,
+  "baseline_ttft_ms": 0.0, "baseline_tpot_ms": 0.0,
+  "final_ttft_ms": 0.0, "final_tpot_ms": 0.0,
   "accepted_config": {"flags": "...", "env": "..."},
-  "accepted_kernels": [{"short_name": "...", "backend": "...", "e2e_delta_pct": 0.0}],
+  "accepted_kernels": [
+    {"short_name": "...", "backend": "...", "optimization": "what was done",
+     "changed_params": {"...": "..."}, "isolated_speedup": 1.0, "e2e_delta_pct": 0.0}
+  ],
   "milestones": 0,
   "report_path": "<EVAL_DIR>/architect_report.md"
 }

--- a/e2e_workflow/scripts/adapters/clients/inferencex.sh
+++ b/e2e_workflow/scripts/adapters/clients/inferencex.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# InferenceX bench CLIENT adapter (identical to Hyperloom / Magpie).
+#
+# This is NOT a serving backend — the server is still launched by the BACKEND
+# adapter (sglang/vllm). This file ONLY redefines adapter_bench so the timed
+# benchmark is driven by the EXACT same client Hyperloom uses: InferenceX's
+# utils/bench_serving/benchmark_serving.py (OpenAI-compatible --backend vllm),
+# with the same dataset / warmups / percentile metrics. That removes the
+# "different bench client" residual when comparing PerfSkills numbers to a
+# Hyperloom Magpie baseline.
+#
+# Enable with:  BENCH_CLIENT=inferencex  (bench_e2e.sh sources this and preserves
+# the backend's native bench as adapter_bench_native for profiling).
+#
+# Requires: $INFERENCEX_PATH (or $INFERENCEX_BENCH_SERVING pointing straight at
+# benchmark_serving.py). bench_e2e.sh exports MODEL/BASE_URL/ISL/OSL/CONC/SEED/
+# NUM_WARMUPS/RANDOM_RANGE_RATIO/PROFILE_DIR.
+
+_ix_resolve_bench_py() {
+  if [ -n "${INFERENCEX_BENCH_SERVING:-}" ] && [ -f "${INFERENCEX_BENCH_SERVING}" ]; then
+    echo "${INFERENCEX_BENCH_SERVING}"; return 0
+  fi
+  local root="${INFERENCEX_PATH:-}"
+  for cand in \
+    "${root}/utils/bench_serving/benchmark_serving.py" \
+    "${root}/benchmarks/benchmark_serving.py" \
+    "${root}/benchmark_serving.py"; do
+    [ -n "$root" ] && [ -f "$cand" ] && { echo "$cand"; return 0; }
+  done
+  return 1
+}
+
+# adapter_bench NUMP MAXC PROF — run ONE InferenceX bench; append a canonical
+# result line to $RESULT_JSONL (output_throughput / mean_ttft_ms / mean_tpot_ms).
+adapter_bench() {
+  local NUMP="$1" MAXC="$2" PROF="${3:-0}"
+
+  # The portable InferenceX client has no server-trace hook; for the profile
+  # round fall back to the backend's native bench (set up by bench_e2e.sh).
+  if [ "$PROF" = "1" ] && declare -F adapter_bench_native >/dev/null; then
+    adapter_bench_native "$NUMP" "$MAXC" 1
+    return $?
+  fi
+
+  local py="${PYTHON_BIN:-python3}"
+  local bench_py
+  if ! bench_py="$(_ix_resolve_bench_py)"; then
+    echo "!!! inferencex client: benchmark_serving.py not found. Set INFERENCEX_PATH or INFERENCEX_BENCH_SERVING." >&2
+    return 5
+  fi
+
+  # Dedicated dir so a robust "newest json" fallback can't grab an unrelated file
+  # (some benchmark_serving.py builds ignore --result-filename and auto-name).
+  local res_dir="${OUT_DIR:-$PROFILE_DIR}/ix_client"
+  mkdir -p "$res_dir"
+  local res_name="ix_bench_$$_${RANDOM}"
+  local num_warmups="${NUM_WARMUPS:-$(( MAXC < 8 ? MAXC : 8 ))}"
+
+  # --backend vllm: OpenAI-compatible client regardless of the actual serving
+  # stack (matches Hyperloom). --request-rate inf + --max-concurrency: the same
+  # saturation driver. --ignore-eos + fixed seed + random-range-ratio: identical
+  # dataset semantics.
+  "$py" "$bench_py" \
+    --model "$MODEL" \
+    --backend vllm \
+    --base-url "$BASE_URL" \
+    --dataset-name random \
+    --random-input-len "$ISL" \
+    --random-output-len "$OSL" \
+    --random-range-ratio "${RANDOM_RANGE_RATIO:-1}" \
+    --num-prompts "$NUMP" \
+    --max-concurrency "$MAXC" \
+    --request-rate inf \
+    --ignore-eos \
+    --num-warmups "$num_warmups" \
+    --percentile-metrics "ttft,tpot,itl,e2el" \
+    --seed "$SEED" \
+    --save-result \
+    --result-dir "$res_dir" \
+    --result-filename "${res_name}.json" || return $?
+
+  local res_json="$res_dir/${res_name}.json"
+  if [ ! -f "$res_json" ]; then
+    # build ignored --result-filename: take the newest json it just wrote
+    res_json="$(ls -t "$res_dir"/*.json 2>/dev/null | head -n1)"
+  fi
+  if [ -n "$res_json" ] && [ -f "$res_json" ]; then
+    "$py" -c "import json,sys; print(json.dumps(json.load(open(sys.argv[1]))))" "$res_json" \
+      >> "$RESULT_JSONL" 2>/dev/null || cat "$res_json" >> "$RESULT_JSONL"
+    rm -f "$res_json"
+  else
+    echo "!!! inferencex client: no result file in $res_dir" >&2
+    return 6
+  fi
+}

--- a/e2e_workflow/scripts/bench_e2e.sh
+++ b/e2e_workflow/scripts/bench_e2e.sh
@@ -35,7 +35,7 @@ BACKEND=${BACKEND:-sglang}
 ADAPTER="${ADAPTER:-$HERE/adapters/${BACKEND}.sh}"
 if [ ! -f "$ADAPTER" ]; then
   echo "!!! No adapter for BACKEND='$BACKEND' at $ADAPTER" >&2
-  echo "    Available: $(ls "$HERE/adapters" 2>/dev/null | sed 's/\.sh$//' | tr '\n' ' ')" >&2
+  echo "    Available: $(ls "$HERE"/adapters/*.sh 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/\.sh$//' | tr '\n' ' ')" >&2
   exit 3
 fi
 # shellcheck disable=SC1090
@@ -45,6 +45,34 @@ for fn in adapter_launch adapter_health adapter_bench; do
     echo "!!! Adapter $ADAPTER does not define $fn()" >&2; exit 3
   fi
 done
+
+# ---- optional bench-CLIENT override (server stack stays the BACKEND above) ----
+# The serving server is always launched by the backend adapter (sglang/vllm).
+# BENCH_CLIENT swaps ONLY the client that drives the benchmark, so a run can use
+# the EXACT same client as another harness. BENCH_CLIENT=inferencex => Hyperloom/
+# Magpie's own InferenceX benchmark_serving.py (口径-identical client). Default
+# 'native' keeps each backend's built-in bench (sglang.bench_serving / vllm).
+BENCH_CLIENT=${BENCH_CLIENT:-native}
+copy_function() {  # copy_function SRC DST — clone a shell function under a new name
+  declare -F "$1" >/dev/null || return 1
+  eval "${2}() $(declare -f "$1" | sed '1d')"
+}
+if [ "$BENCH_CLIENT" != "native" ]; then
+  CLIENT_ADAPTER="${CLIENT_ADAPTER:-$HERE/adapters/clients/${BENCH_CLIENT}.sh}"
+  if [ ! -f "$CLIENT_ADAPTER" ]; then
+    echo "!!! No bench client '$BENCH_CLIENT' at $CLIENT_ADAPTER" >&2
+    echo "    Available: $(ls "$HERE/adapters/clients" 2>/dev/null | sed 's/\.sh$//' | tr '\n' ' ')" >&2
+    exit 3
+  fi
+  # Preserve the backend's native bench so the client can delegate profiling
+  # (server-side trace hooks live in the native bench, not the portable client).
+  copy_function adapter_bench adapter_bench_native
+  # shellcheck disable=SC1090
+  source "$CLIENT_ADAPTER"   # MUST redefine adapter_bench (the timed client)
+  if ! declare -F adapter_bench >/dev/null; then
+    echo "!!! Client adapter $CLIENT_ADAPTER must define adapter_bench()" >&2; exit 3
+  fi
+fi
 
 # ---- model / server ----
 # MODEL is REQUIRED. No rig-specific default — a wrong-but-silent default benches the wrong target.
@@ -82,7 +110,31 @@ fi
 ISL=${ISL:-1024}
 OSL=${OSL:-1024}
 CONC=${CONC:-64}
-NUM_PROMPTS=${NUM_PROMPTS:-$((CONC * 5))}
+# NUM_PROMPTS default.
+#  * native client (standalone GEAK default): keep the original CONC*5 default so
+#    standalone behaviour is byte-identical to before the inferencex integration.
+#  * inferencex client (Hyperloom口径 alignment): mirror Hyperloom's ADAPTIVE
+#    factor — the number of timed prompts scales DOWN as the per-request sequence
+#    cost (ISL+OSL) grows so each repeat stays bounded.
+#    factor = {<=1024:10, <=4096:5, <=16384:3, else 2}.
+# Override NUM_PROMPTS to pin a fixed count regardless of client.
+if [ -z "${NUM_PROMPTS:-}" ]; then
+  if [ "$BENCH_CLIENT" = "inferencex" ]; then
+    _seq_cost=$((ISL + OSL))
+    if   [ "$_seq_cost" -le 1024 ];  then _factor=10
+    elif [ "$_seq_cost" -le 4096 ];  then _factor=5
+    elif [ "$_seq_cost" -le 16384 ]; then _factor=3
+    else _factor=2; fi
+    NUM_PROMPTS=$(( CONC * _factor > CONC ? CONC * _factor : CONC ))
+  else
+    NUM_PROMPTS=$((CONC * 5))
+  fi
+fi
+# Client-side warmup prompts (口径 alignment with Hyperloom's materialize default
+# NUM_WARMUPS=min(CONC,8)). Consumed by the inferencex client adapter; the native
+# adapters use their own warmup round instead.
+NUM_WARMUPS=${NUM_WARMUPS:-$(( CONC < 8 ? CONC : 8 ))}
+RANDOM_RANGE_RATIO=${RANDOM_RANGE_RATIO:-1}   # fixed sequence lengths (matches Hyperloom)
 REPEATS=${REPEATS:-3}                 # repeat the bench this many times; report median + spread
 SEED=${SEED:-0}                       # fixed seed for reproducibility / parity
 
@@ -102,6 +154,7 @@ RESULT_JSONL="$OUT_DIR/bench_runs.jsonl"
 # export everything the adapter reads
 export MODEL HOST PORT TP GPU MEM_FRACTION EXTRA_SERVER_ARGS EXTRA_ENV OVERLAY_PYTHONPATH
 export ISL OSL CONC SEED PROFILE PROFILE_DIR PROFILE_NUM_STEPS BASE_URL RESULT_JSONL LOG
+export NUM_PROMPTS NUM_WARMUPS RANDOM_RANGE_RATIO BENCH_CLIENT
 
 echo "Backend:      $BACKEND  (adapter: $ADAPTER)"
 echo "Model:        $MODEL"
@@ -193,6 +246,8 @@ summ = {
     "tpot_ms_median": round(med(tpot), 3) if tpot else None,
     "runs": len(tps),
     "all_throughput": tps,
+    # Aggregate output tok/s (NOT divided by TP) — matches Hyperloom/Magpie output_throughput 口径.
+    "metric_basis": "aggregate_output_tok_s",
 }
 with open(out_path, "w") as fh: json.dump(summ, fh, indent=2)
 print(f"E2E_SUMMARY output_tok_s={summ['output_throughput_tok_s_median']} "

--- a/interface/run_e2e.md
+++ b/interface/run_e2e.md
@@ -1,0 +1,143 @@
+# `interface/run_e2e.py` — external integration contract
+
+`interface/` is the **only** surface an external orchestrator (e.g. Hyperloom)
+touches. Everything volatile about the e2e workflow (the `e2e_workflow.js` arg
+names, the Claude Code `Workflow` invocation, the `--effort ultracode`
+requirement, the SDK-vs-CLI choice) is hidden behind one command and two JSON
+files. As long as `schema_version` stays `1`, the caller never changes when
+the workflow evolves internally.
+
+## Command
+
+```bash
+python interface/run_e2e.py <handoff.json> <result.json> [--dry-run]
+```
+
+* Exit code `0` → `result.json.status` is `ok` or `no_gain`.
+* Exit code `1` → a crash; `result.json.status == "error"` with an `error` field.
+* Exit code `2` → bad usage / unreadable handoff.
+* `--dry-run` → print the mapped `e2e_workflow.js` args + the prompt and
+  exit `0` (no GPU work). Use this to validate the mapping in CI.
+
+Discovery: the installer should export `PERFSKILLS_E2E_RUNNER` pointing at this
+file (`$PERFSKILLS_ROOT/interface/run_e2e.py`) so the caller has a single
+hard-coded handle.
+
+## `handoff.json` (caller → workflow)
+
+```jsonc
+{
+  "schema_version": 1,
+  "model_path": "/models/Qwen-Qwen3.5-27B",
+  "framework": "sglang",                 // -> backend (sglang|vllm)
+  "gpu_type": "MI300X",
+  "tp": 8,                               // serving tensor-parallel size (honoured, no TP=1 lock)
+  "gpu_ids": "0,1,2,3,4,5,6,7",          // optional; default 0..tp-1
+  "workload": { "isl": 1024, "osl": 1024, "conc": 64 },
+  "accepted_flags": "--attention-backend triton",  // best config from the caller's search
+  "accepted_env": "SGLANG_USE_AITER=1",
+  "launch_recipe": "/path/baseline_config.with_envs.yaml",  // optional launch script/recipe
+  "raw_baseline_tput": 1485.4,           // caller's official raw baseline (carried for reference)
+  "exp_root": "/work/perfskills_exp",    // where the timestamped run dir is created
+  "bench_client": "auto",                // auto|inferencex|native — see口径 alignment below
+  "inferencex_path": "/opt/InferenceX"   // optional; else taken from $INFERENCEX_PATH
+}
+```
+
+Required: `model_path`, `exp_root`. Everything else has a default.
+
+### How handoff maps to the workflow (owned by `run_e2e.py:map_args`)
+
+| handoff field | `e2e_workflow.js` arg | note |
+|---|---|---|
+| `model_path` | `model_path` | required |
+| `framework` | `backend` | `sglang` \| `vllm` |
+| `tp` | `tp` | serving tensor-parallel (threaded to bench `TP`) |
+| `gpu_ids` / `tp` | `gpu_ids` | defaults to `0..tp-1` |
+| `workload.{isl,osl,conc}` | `isl` / `osl` / `conc` | profile + bench workload |
+| `accepted_flags` | `initial_extra_server_args` | seeds the baseline = caller best config |
+| `accepted_env` | `initial_extra_env` | seeds baseline env |
+| `launch_recipe` | `launch_script` | optional |
+| `exp_root` | `exp_root` | run dir root |
+| `bench_client` / `inferencex_path` | env `BENCH_CLIENT` + `INFERENCEX_PATH` | exported so every `bench_e2e.sh` call inherits it (not a JS arg) |
+| — | `config_tune="false"` | caller already did config search; never double-run |
+| — | `apply_to_original="true"` | so `final/final_launch.sh` + overlay are emitted for sweep reuse |
+
+## `result.json` (workflow → caller)
+
+```jsonc
+{
+  "schema_version": 1,
+  "status": "ok | no_gain | error",
+  "eval_dir": "/work/perfskills_exp/e2e_<model>_<ts>",
+  "baseline_throughput_tok_s": 1485.4,   // baseline (= caller best config)
+  "final_throughput_tok_s": 1551.4,
+  "throughput_speedup": 1.044,
+  "output_parity": "pass | fail | n/a | unknown",
+  "ttft_ms": 3598.0,                     // median, aligned with caller's ttft
+  "tpot_ms": 39.5,                       // median, aligned with caller's tpot
+  "final_launch_script": ".../final/final_launch.sh",  // self-contained: overlay/flags/env baked in
+  "bench_script": ".../bench_e2e.sh",    // supports REUSE_SERVER=1 + CONC/ISL/OSL
+  "final_patch": ".../final/final_patch.diff",
+  "final_overlay": ".../final/overlay",
+  "metric_basis": "aggregate_output_tok_s",   // NOT per-GPU; matches Magpie output_throughput
+  "bench_client": "inferencex",               // inferencex => identical client to caller; else native
+  "validated_regimes": [ { "isl": 1024, "osl": 1024, "conc": 64 } ],  // redo parity outside these
+  "accepted_kernels": [ /* what was optimized + how (per-kernel) */ ],
+  "accepted_heads": [ /* head GEMM/attn winners */ ],
+  "accepted_config": { "flags": "...", "env": "..." },
+  "report_path": ".../final_report.md"   // human report: per-kernel optimizations, changed params, TTFT/TPOT
+}
+```
+
+## Reusing the deliverables for a workload sweep
+
+`final_launch.sh` is self-contained (it bakes `OVERLAY_PYTHONPATH`, accepted
+flags/env, `BACKEND`, `TP`) and delegates server launch + bench to
+`bench_e2e.sh`. To sweep workloads on the optimized server without rebuilding
+the overlay:
+
+1. Start the optimized server once via `final_launch.sh`.
+2. For each `(CONC, ISL, OSL)` point, call `bench_e2e.sh` with
+   `REUSE_SERVER=1 CONC=.. ISL=.. OSL=..` against the warm server.
+3. For any point outside `validated_regimes`, redo a greedy/temp=0 parity probe
+   (the kernels were only validated at the single handoff workload point).
+
+## Measurement-口径 alignment (vs Hyperloom Magpie)
+
+The workflow must measure on the **same口径** as the caller's official baseline so
+`final` and sweep curves are comparable to the caller's raw baseline:
+
+| knob | aligned value |
+|---|---|
+| primary metric | aggregate `output_throughput` (output tok/s, **not** per-GPU) |
+| latency | `ttft_ms` / `tpot_ms` median |
+| dataset | `random`, `random-range-ratio 1.0` (fixed lengths) |
+| workload | same `ISL/OSL/CONC`; `NUM_PROMPTS = max(CONC*factor, CONC)` |
+| warmups | `NUM_WARMUPS = min(CONC, 8)` (matches Hyperloom's materialize default) |
+| seed | fixed `SEED` |
+| TP | same tensor-parallel as the caller (no TP=1 lock) |
+| parity | greedy / temp=0 fixed-seed output diff vs baseline |
+| **bench client** | `BENCH_CLIENT=inferencex` → the **exact same** `benchmark_serving.py` as Hyperloom |
+
+### Bench-CLIENT adapter (closes the last口径 residual)
+
+The serving stack is always launched by the **backend** adapter
+(`adapters/sglang.sh` / `vllm.sh`). The **client** that drives the timed bench is
+selected independently by `BENCH_CLIENT`:
+
+* `native` (default standalone) — each backend's built-in bench
+  (`sglang.bench_serving` / vLLM). Small cross-harness差异 may remain.
+* `inferencex` — `adapters/clients/inferencex.sh` redefines `adapter_bench` to
+  call **Hyperloom/Magpie's own** `InferenceX/utils/bench_serving/benchmark_serving.py`
+  (`--backend vllm --dataset-name random --request-rate inf --ignore-eos
+  --num-warmups $NUM_WARMUPS --percentile-metrics ttft,tpot,itl,e2el`). This is
+  byte-for-byte the same client Hyperloom uses, so the only remaining difference
+  is `REPEATS`-median vs single-run — not the client.
+
+`run_e2e.py` resolves `handoff.bench_client` (`auto` → `inferencex` when an
+InferenceX checkout is discoverable via `INFERENCEX_PATH`, else `native`) and
+exports `BENCH_CLIENT` + `INFERENCEX_PATH` so every `bench_e2e.sh` the agents run
+inherits it. The profile round (server-side trace) always delegates back to the
+backend's native bench. The chosen client is echoed in `result.bench_client`, and
+the sweep reuse path carries it forward so sweep points use the same client.

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""PerfSkills/GEAK e2e runner — the ONLY entry point Hyperloom (or any external
+orchestrator) calls.
+
+Contract (stable, see interface/run_e2e.md):
+
+    run_e2e.py <handoff.json> <result.json> [--dry-run]
+
+* Reads ``handoff.json``  (external orchestrator -> e2e workflow).
+* Maps the stable handoff fields onto ``e2e_workflow/e2e_workflow.js``
+  args (this mapping is the ONLY thing that changes when the JS workflow's args
+  evolve; the handoff/result JSON contract stays put).
+* Invokes the JS workflow through the Claude Code ``Workflow`` tool (the JS
+  workflow CANNOT be run with ``node`` directly — it needs the agent runtime's
+  Workflow/agent/parallel/phase primitives, which are only exposed under
+  ``--effort ultracode``). Prefers the Python ``claude_agent_sdk``; falls back
+  to the ``claude -p`` CLI.
+* Normalizes the workflow artifacts (``director_e2e_validation.json`` +
+  ``baseline/bench_summary.json`` + ``final/``) into the stable ``result.json``.
+
+All Claude-SDK / ``--effort`` / args-mapping detail lives HERE, inside this
+repo, so the external caller only deals with two JSON files + one command
+path. See interface/run_e2e.md for the full contract.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+# interface/ is a sibling of e2e_workflow/ under the repo root.
+INTERFACE_DIR = Path(__file__).resolve().parent
+PERFSKILLS_ROOT = INTERFACE_DIR.parent
+E2E_DIR = PERFSKILLS_ROOT / "e2e_workflow"
+E2E_SCRIPT = E2E_DIR / "e2e_workflow.js"
+BENCH_SCRIPT = E2E_DIR / "scripts" / "bench_e2e.sh"
+
+# Workflow primitives are only available at this effort tier (see README).
+CLAUDE_EFFORT = os.environ.get("PERFSKILLS_CLAUDE_EFFORT", "ultracode")
+CLAUDE_MODEL = os.environ.get("PERFSKILLS_CLAUDE_MODEL", "claude-opus-4-8")
+ALLOWED_TOOLS = ["Workflow", "Bash", "Read", "Write"]
+
+
+# ---------------------------------------------------------------------------
+# handoff (stable)  ->  e2e_workflow.js args (volatile, owned here)
+# ---------------------------------------------------------------------------
+def map_args(h: dict) -> dict:
+    workload = h.get("workload") or {}
+    tp = int(h.get("tp", 1) or 1)
+    # gpu_ids is the optimization-parallelism pool AND the serving device set.
+    # Default to 0..tp-1 so serving honours the requested tensor-parallel size.
+    gpu_ids = h.get("gpu_ids") or ",".join(str(i) for i in range(max(tp, 1)))
+    ps_args = {
+        "model_path": h["model_path"],
+        "workflow_dir": str(E2E_DIR),
+        "backend": h.get("framework", "sglang"),
+        "tp": tp,
+        "gpu_ids": str(gpu_ids),
+        "isl": int(workload.get("isl", 1024)),
+        "osl": int(workload.get("osl", 1024)),
+        "conc": int(workload.get("conc", 64)),
+        # Seed the baseline with Hyperloom's accepted best config so the
+        # baseline == Hyperloom best config (fair engagement start).
+        "initial_extra_server_args": h.get("accepted_flags", "") or "",
+        "initial_extra_env": h.get("accepted_env", "") or "",
+        # Hyperloom already did config/param search in EXPLORE; do not double-run.
+        "config_tune": "false",
+        # Produce the final/ bundle (final_launch.sh + overlay) so the caller can
+        # reuse it for a workload sweep.
+        "apply_to_original": "true",
+        "exp_root": h["exp_root"],
+    }
+    if h.get("launch_recipe"):
+        ps_args["launch_script"] = h["launch_recipe"]
+    return ps_args
+
+
+def build_prompt(ps_args: dict) -> str:
+    return (
+        "Invoke the Workflow tool exactly once with:\n"
+        f'  scriptPath: "{E2E_SCRIPT}"\n'
+        f"  args: {json.dumps(ps_args)}\n"
+        "Run the full e2e pipeline (Setup -> Profile -> Strategize -> "
+        "HeadKernel -> Milestone -> Finalize -> Report -> Validate). When it "
+        "finishes, print EXACTLY ONE final line of compact JSON that is the "
+        "Workflow tool's full return value (it includes eval_dir, "
+        "baseline_throughput_tok_s, final_throughput_tok_s, throughput_speedup, "
+        "validation_status, output_parity, final_overlay, final_launch_script, "
+        "report_path, accepted_kernels, accepted_config). Print nothing after it."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bench-client口径 alignment.
+# ---------------------------------------------------------------------------
+def apply_bench_client(h: dict) -> str:
+    """Decide + export the bench CLIENT so workflow bench_e2e.sh calls inherit it.
+
+    handoff.bench_client: "auto" (default) | "inferencex" | "native".
+    "auto" => use InferenceX's benchmark_serving.py (口径-identical to the
+    caller's Magpie harness) when an InferenceX checkout is discoverable, else
+    fall back to each backend's native client. The value is exported into the
+    environment so every ``bench_e2e.sh`` invocation the agents make inherits it.
+    """
+    requested = str(h.get("bench_client", "auto") or "auto").strip().lower()
+    ix_path = str(h.get("inferencex_path") or os.environ.get("INFERENCEX_PATH", "")).strip()
+    if ix_path:
+        os.environ["INFERENCEX_PATH"] = ix_path
+    if requested == "auto":
+        client = "inferencex" if ix_path else "native"
+    else:
+        client = requested
+    if client == "inferencex" and not ix_path:
+        sys.stderr.write(
+            "bench_client=inferencex requested but no INFERENCEX_PATH; "
+            "falling back to native client (口径 NOT aligned).\n"
+        )
+        client = "native"
+    os.environ["BENCH_CLIENT"] = client
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Invocation: SDK preferred, CLI fallback.
+# ---------------------------------------------------------------------------
+def _invoke_via_sdk(prompt: str, timeout_s: int) -> str:
+    import anyio
+    from claude_agent_sdk import ClaudeAgentOptions, query
+
+    async def _run() -> str:
+        opts = ClaudeAgentOptions(
+            model=CLAUDE_MODEL,
+            allowed_tools=ALLOWED_TOOLS,
+            permission_mode="bypassPermissions",
+            extra_args={"effort": CLAUDE_EFFORT},
+            cwd=str(E2E_DIR),
+        )
+        last = ""
+        async for msg in query(prompt=prompt, options=opts):
+            text = getattr(msg, "text", None)
+            if getattr(msg, "type", "") == "assistant" and text:
+                last = text
+        return last
+
+    return anyio.run(_run)
+
+
+def _invoke_via_cli(prompt: str, timeout_s: int) -> str:
+    claude = shutil.which("claude") or os.environ.get("CLAUDE_BIN", "claude")
+    cmd = [
+        claude, "-p", prompt,
+        "--output-format", "json",
+        "--effort", CLAUDE_EFFORT,
+        "--model", CLAUDE_MODEL,
+        "--allowed-tools", ",".join(ALLOWED_TOOLS),
+        "--permission-mode", "auto",
+    ]
+    env = dict(os.environ, IS_SANDBOX="1")
+    proc = subprocess.run(
+        cmd, cwd=str(E2E_DIR), env=env, capture_output=True, text=True,
+        timeout=timeout_s,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"claude CLI failed (rc={proc.returncode}): {proc.stderr[-2000:]}"
+        )
+    # claude -p --output-format json wraps the assistant text; try to unwrap.
+    out = proc.stdout.strip()
+    try:
+        wrapped = json.loads(out)
+        if isinstance(wrapped, dict):
+            return str(wrapped.get("result") or wrapped.get("text") or out)
+    except json.JSONDecodeError:
+        pass
+    return out
+
+
+def invoke_workflow(prompt: str, timeout_s: int) -> dict:
+    """Run the JS workflow and return its parsed JSON return value."""
+    try:
+        import claude_agent_sdk  # noqa: F401
+        raw = _invoke_via_sdk(prompt, timeout_s)
+    except ImportError:
+        raw = _invoke_via_cli(prompt, timeout_s)
+    return _parse_last_json_line(raw)
+
+
+def _parse_last_json_line(raw: str) -> dict:
+    for line in reversed([ln for ln in (raw or "").splitlines() if ln.strip()]):
+        try:
+            obj = json.loads(line.strip())
+            if isinstance(obj, dict) and obj.get("eval_dir"):
+                return obj
+        except json.JSONDecodeError:
+            continue
+    raise RuntimeError(
+        "Could not parse a JSON workflow return (with eval_dir) from the agent "
+        f"output. Last 2000 chars:\n{(raw or '')[-2000:]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Normalize workflow artifacts -> stable result.json
+# ---------------------------------------------------------------------------
+def _read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def normalize_result(h: dict, wf: dict) -> dict:
+    eval_dir = Path(wf["eval_dir"])
+    validation = _read_json(eval_dir / "director_e2e_validation.json")
+    baseline_summary = _read_json(eval_dir / "baseline" / "bench_summary.json")
+    final_summary = _read_json(eval_dir / "validation" / "final" / "bench_summary.json")
+
+    speedup = float(wf.get("throughput_speedup") or validation.get("throughput_speedup") or 1.0)
+    status = "ok" if speedup > 1.0 else "no_gain"
+
+    final_launch = (
+        wf.get("final_launch_script")
+        or validation.get("final_launch_script")
+        or str(eval_dir / "final" / "final_launch.sh")
+    )
+    workload = h.get("workload") or {"isl": 1024, "osl": 1024, "conc": 64}
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "eval_dir": str(eval_dir),
+        "baseline_throughput_tok_s": float(
+            wf.get("baseline_throughput_tok_s")
+            or validation.get("baseline_throughput_tok_s")
+            or 0.0
+        ),
+        "final_throughput_tok_s": float(
+            wf.get("final_throughput_tok_s")
+            or validation.get("director_verified_throughput_tok_s")
+            or 0.0
+        ),
+        "throughput_speedup": speedup,
+        "output_parity": wf.get("output_parity") or validation.get("output_parity") or "unknown",
+        # Latency口径 (median ms), aligned field names with Hyperloom.
+        "ttft_ms": final_summary.get("ttft_ms_median") or baseline_summary.get("ttft_ms_median"),
+        "tpot_ms": final_summary.get("tpot_ms_median") or baseline_summary.get("tpot_ms_median"),
+        # Sweep-reuse handles (see interface/run_e2e.md).
+        "final_launch_script": final_launch,
+        "bench_script": str(eval_dir / "bench_e2e.sh"),
+        "final_patch": str(eval_dir / "final" / "final_patch.diff"),
+        "final_overlay": wf.get("final_overlay") or str(eval_dir / "final" / "overlay"),
+        # Measurement basis: reports aggregate output tok/s (not per-GPU),
+        # matching Hyperloom's Magpie output_throughput. See run_e2e.md alignment table.
+        "metric_basis": "aggregate_output_tok_s",
+        # Which bench client measured these numbers. "inferencex" => identical
+        # client to Hyperloom/Magpie (benchmark_serving.py); "native" => the
+        # backend's own client (small cross-harness差异 may remain).
+        "bench_client": os.environ.get("BENCH_CLIENT", "native"),
+        # The kernels are only extracted/validated at this single workload point;
+        # the caller must redo parity on out-of-regime sweep points.
+        "validated_regimes": [workload],
+        # What the kernel phase actually did (req: report must carry this).
+        "accepted_kernels": wf.get("accepted_kernels") or [],
+        "accepted_heads": wf.get("accepted_heads") or [],
+        "accepted_config": wf.get("accepted_config") or {},
+        "report_path": wf.get("report_path") or str(eval_dir / "final_report.md"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main(argv: list[str]) -> int:
+    args = [a for a in argv if not a.startswith("--")]
+    flags = {a for a in argv if a.startswith("--")}
+    if len(args) < 2:
+        sys.stderr.write(
+            "usage: run_e2e.py <handoff.json> <result.json> [--dry-run]\n"
+        )
+        return 2
+    handoff_path, result_path = Path(args[0]), Path(args[1])
+    timeout_s = int(os.environ.get("PERFSKILLS_E2E_TIMEOUT_S", "21600"))  # 6h
+
+    h = _read_json(handoff_path)
+    if not h:
+        sys.stderr.write(f"empty/invalid handoff: {handoff_path}\n")
+        return 2
+
+    ps_args = map_args(h)
+    bench_client = apply_bench_client(h)
+    prompt = build_prompt(ps_args)
+
+    if "--dry-run" in flags:
+        print(json.dumps({"mapped_args": ps_args, "bench_client": bench_client,
+                          "inferencex_path": os.environ.get("INFERENCEX_PATH", ""),
+                          "prompt": prompt, "e2e_script": str(E2E_SCRIPT)}, indent=2))
+        return 0
+
+    try:
+        wf = invoke_workflow(prompt, timeout_s)
+        out = normalize_result(h, wf)
+    except Exception as e:  # crash: status=error + nonzero exit (caller distinguishes)
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(json.dumps(
+            {"schema_version": SCHEMA_VERSION, "status": "error", "error": str(e)},
+            indent=2), encoding="utf-8")
+        sys.stderr.write(f"PerfSkills e2e failed: {e}\n")
+        return 1
+
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(json.dumps({"status": out["status"], "result_json": str(result_path),
+                      "speedup": out["throughput_speedup"]}))
+    return 0 if out["status"] != "error" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What changed

### New: `interface/run_e2e.py` + `interface/run_e2e.md` (the integration contract)
The **only** surface an external orchestrator touches. Everything volatile
(the `e2e_workflow.js` arg names, the Claude Code `Workflow` invocation, the
`--effort ultracode` requirement, SDK-vs-CLI choice) is hidden behind one
command + two JSON files:

```bash
python interface/run_e2e.py <handoff.json> <result.json> [--dry-run]