### PR TITLE
Merge v4_Researcher → GEAK_v4: Deep Research Agent (DRA) for kernel_workflow

### DIFF
--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -67,7 +67,14 @@ BENCH_SCRIPT = E2E_DIR / "scripts" / "bench_e2e.sh"
 # Workflow primitives are only available at this effort tier (see README).
 CLAUDE_EFFORT = os.environ.get("GEAK_CLAUDE_EFFORT", "ultracode")
 CLAUDE_MODEL = os.environ.get("GEAK_CLAUDE_MODEL", "claude-opus-4-8")
-ALLOWED_TOOLS = ["Workflow", "Bash", "Read", "Write"]
+# WebSearch/WebFetch are required by the Deep Research Agent (kernel_workflow's opt-in `Research`
+# phase, args.dra_enabled=true): its per-question research agents do native web research. They are
+# harmless when the DRA is off (nothing opts into them) — the reason v4 previously "had no websearch"
+# is simply that no tool was on the allowlist. The allowlist is the union of tools any agent in the
+# (possibly nested) Workflow session may call, so listing them here makes them available to the
+# kernel_workflow research agents the e2e pipeline drives. (For a standalone `claude -p ... Workflow`
+# invocation of kernel_workflow with dra_enabled, pass the same names via --allowed-tools.)
+ALLOWED_TOOLS = ["Workflow", "Bash", "Read", "Write", "WebSearch", "WebFetch"]
 
 # Public claude builds (>=2.1.x) REJECT "--effort ultracode". The Workflow /
 # parallel / phase primitives that e2e_workflow.js needs are instead gated behind

--- a/interface/test_run_e2e_dispatch.py
+++ b/interface/test_run_e2e_dispatch.py
@@ -859,7 +859,7 @@ class TestInvokeViaCli(_RunE2ECase):
             "--output-format", "json",
             "--settings", rx.WORKFLOW_SETTINGS,
             "--model", rx.CLAUDE_MODEL,
-            "--allowed-tools", "Workflow,Bash,Read,Write",
+            "--allowed-tools", ",".join(rx.ALLOWED_TOOLS),
             "--permission-mode", "auto",
             "--effort", "max",
         ])

--- a/kernel_workflow/README.md
+++ b/kernel_workflow/README.md
@@ -36,7 +36,7 @@ by an agent returning **structured JSON**.
   `verify_engineer`, and `integrator`.
 
 ## Pipeline
-`Setup → Analyze+Roadmap → Benchmark(COMMANDMENT+baseline) → Baseline Profile →`
+`Setup → Analyze+Roadmap → Benchmark(COMMANDMENT+baseline) → Baseline Profile → [Research (opt-in)] →`
 `LOOP[ Plan round → (Optimize ‖ Verify, pipelined) → Integrate → Commit winner → Re-profile → Update memory ] →`
 `Final Report → Director Validation`.
 
@@ -94,6 +94,13 @@ Workflow({
                                //   unweighted geomean is kept as a secondary diagnostic). Correctness is
                                //   unaffected (it stays on the frozen immutable oracle).
                                //   Also accepted as op_spec.workload_path, or op_spec.workload (inline).
+    // --- Deep Research Agent (DRA) — opt-in web-grounded research phase before the optimize loop ---
+    dra_enabled: "false",      // optional, default "false" (OFF → behavior byte-identical). "true" runs
+                               //   the Research phase after Profile / before the optimize loop.
+    dra_max_questions: 8,      // optional, default 8: max research questions fanned out in parallel
+    dra_blindspot: "false",    // optional, default "false": run an extra blindspot-critique + 2nd
+                               //   parallel research wave (Stage 5/6) — budget-permitting
+    dra_max_blindspots: 4      // optional, default 4: cap on blindspots / 2nd-wave follow-ups
   }
 })
 ```
@@ -120,6 +127,36 @@ writes the simplest correct implementation in `target_language` (correctness-jud
 oracle), commits it as the baseline, and then the **same optimize loop** improves it. Returns
 `authored:false` / `validation_status:"author_failed"` if no correct baseline can be produced (the
 caller drops that language). `mode="optimize"` (default) is unchanged and fully backward compatible.
+
+### Deep Research Agent / Research phase (NEW, opt-in)
+`dra_enabled="true"` inserts a **`Research` phase AFTER Profile and BEFORE the optimize loop** (so the
+COMMANDMENT + baseline profile + analysis already exist). It lives in the `kernel_lane.js` worker
+alongside the rest of the pipeline, and the dispatcher forwards `dra_*` through unchanged. The
+**`researcher`** persona (`roles/researcher.md`) runs a v4-native deep-research pass:
+1. **Stage 0 + 1/2** (`research_plan`, one agent): extract facts from the kernel source +
+   `profiling_summary.md` + `analysis.json` + the `COMMANDMENT`, then generate & rank research
+   QUESTIONS spanning BOTH grounded bottleneck questions AND design-space / "is there a fundamentally
+   faster algorithm or execution strategy?" questions.
+2. **Stages 3/4** (`research_question`, fanned out in **parallel** — one agent per question): each
+   researches its question on the live web via **native `WebSearch`/`WebFetch`** and synthesizes one
+   judgment. Every research agent is wrapped in the `agentT()` hang-guard, so a hung research agent
+   resolves to `null` and the parallel round-barrier still proceeds (it cannot wedge the run).
+3. **Stage 5/6** (`research_blindspot`, optional, `dra_blindspot="true"`): a blindspot critique + a
+   second parallel research wave on the follow-ups.
+4. **Stage 7** (`research_synthesize`, one agent): a ranked **portfolio of optimization directions**,
+   written as `deep_search.md` (full evidence), `deep_search_brief.md` (compact, ~2-4 KB ranked
+   directions only — what the planner reads), and `deep_search.json` (structured).
+
+The TechLead's `plan_round` then **Reads `EVAL_DIR/deep_search_brief.md` (if present)** and seeds
+`directions[]` from the ranked DRA directions — **diversifying** them across parallel engineers (with
+≥1 free explorer slot, never anchoring all engineers on one theme) and treating **high-ceiling
+rewrites (raw-HIP/`load_inline`, HIP/CUDA graph capture, algorithmic reformulation) as first-class**,
+not secondary. The brief is a prior, never a cage: profile/per-case data and measurement still rule.
+
+**Web tools:** the research agents need `WebSearch`/`WebFetch`. They are on the e2e allowlist
+(`interface/run_e2e.py` `ALLOWED_TOOLS`). For a standalone `claude -p` invocation of this workflow
+with `dra_enabled`, pass them on the allowlist too (`--allowed-tools Workflow,Bash,Read,Write,WebSearch,WebFetch`).
+With `dra_enabled` off (the default) nothing opts into the web tools and behavior is unchanged.
 
 ### Bake-off mode (NEW) — one kernel, many backend languages, keep the fastest
 `kernel_workflow.js` is now the single **ENTRY POINT / dispatcher**; the single-language pipeline lives
@@ -181,6 +218,9 @@ Everything lands under `<exp_root>/team_<kernel>_<timestamp>/<kernel>/` (default
 the `exp/` folder sibling to `workflow_dir`):
 - `COMMANDMENT.md`, `baseline_timing.json`, `analysis.json`, `codebase_context.md`, `roadmap.md`
 - `baseline_metrics.json`, `profiling_summary.md`
+- (DRA, when `dra_enabled`) `deep_search.md` (full research), `deep_search_brief.md` (compact ranked
+  directions — the planner's input), `deep_search.json` (structured portfolio), and
+  `research/{facts.json, questions.json, answers/<id>.json, blindspots.json}` (the research trail)
 - `round_N/engineer_i/{worker_result.json, report.md, best_patch.diff}` — each engineer's mini-report
 - `round_N/integrate/`, `insight_log.md`, `current_best.diff`
 - `tech_lead_report.md` — round-by-round narrative + final per-case table (the TechLead summary)
@@ -200,7 +240,8 @@ kernel_lane.js         single-language WORKER (the deterministic optimize/author
 kernel_workflow_bmk.js batch orchestrator (runs kernel_lane on a list of kernels, one batch per GPU)
 roles/               director, tech_lead, engineer, deep_engineer (deep_explore),
                      author_engineer, benchmark_engineer, profile_engineer,
-                     verify_engineer, integrator, oracle_freezer (bake-off freeze)
+                     verify_engineer, integrator, oracle_freezer (bake-off freeze),
+                     researcher (DRA, opt-in)
 knowledge/           optimization_strategies, hip/triton/wrapper, profiling_guide,
                      amd_instinct (multi-card: gfx942/gfx950), self_monitoring, geomean_levers
 scripts/             gpu_lock.sh, profile_kernel.sh,

--- a/kernel_workflow/kernel_lane.js
+++ b/kernel_workflow/kernel_lane.js
@@ -8,6 +8,7 @@ export const meta = {
     { title: 'Analyze', detail: 'tech_lead analyzes kernel + writes roadmap' },
     { title: 'Benchmark', detail: 'benchmark_engineer builds the COMMANDMENT + baseline' },
     { title: 'Profile', detail: 'profile_engineer classifies the bottleneck' },
+    { title: 'Research', detail: 'OPT-IN (args.dra_enabled): researcher fans research questions out in parallel via native WebSearch/WebFetch, writes a ranked-directions brief the planner seeds from' },
     { title: 'Optimize', detail: 'budget loop: tech_lead plans, specialist OR deep_explore engineers optimize, reprofile' },
     { title: 'Verify', detail: 'each candidate patch independently re-benchmarked' },
     { title: 'Merge', detail: 'integrator combines the round winners' },
@@ -157,6 +158,26 @@ const EXPERT_SKILLS_DIR = String(A.expert_skills_dir ||
 // Only planning + authoring roles consult skills; every other role gets no injection.
 const EXPERT_SKILL_ROLES = new Set(['tech_lead', 'author_engineer', 'engineer', 'deep_engineer']);
 
+// --- Deep Research Agent (DRA) -------------------------------------------------------------------
+// OPT-IN: a v4-native research phase that runs AFTER Profile and BEFORE the optimize loop (so the
+// COMMANDMENT + baseline profile + analysis exist). The `researcher` persona extracts facts and a
+// ranked set of research QUESTIONS; the script fans those out in PARALLEL (each question = one
+// hang-guarded agent using native WebSearch/WebFetch), then a synthesis pass writes a ranked
+// directions portfolio (deep_search.md / deep_search_brief.md / deep_search.json) into EVAL_DIR that
+// the TechLead's plan_round seeds from. DEFAULT OFF: when dra_enabled is not "true" NOTHING runs and
+// behavior is byte-identical to a build without this feature (existing runs unchanged).
+const DRA_ENABLED = String(A.dra_enabled != null ? A.dra_enabled : 'false') === 'true';
+const DRA_MAX_QUESTIONS = (() => {
+  const v = parseInt(A.dra_max_questions != null ? A.dra_max_questions : 8, 10);
+  return Number.isFinite(v) && v >= 1 ? v : 8;
+})();
+// Optional Stage 5/6 blindspot-critique pass (one more parallel research wave). Default OFF (budget).
+const DRA_BLINDSPOT = String(A.dra_blindspot != null ? A.dra_blindspot : 'false') === 'true';
+const DRA_MAX_BLINDSPOTS = (() => {
+  const v = parseInt(A.dra_max_blindspots != null ? A.dra_max_blindspots : 4, 10);
+  return Number.isFinite(v) && v >= 1 ? v : 4;
+})();
+
 // ---------------------------------------------------------------------------
 // DEEP-MODE continuation + cross-backend / e2e-feedback hooks. ALL OPTIONAL.
 // When none are passed (every normal/fast e2e run, and every standalone run) these are '' / the
@@ -288,6 +309,63 @@ const PROFILE_SCHEMA = obj({
   top_opportunities: { type: 'array', items: { type: 'string' } },
   summary_path: { type: 'string' }, shift_note: { type: 'string' },
 }, ['bottleneck', 'top_opportunities']);
+
+// --- Deep Research Agent (DRA) schemas (opt-in via args.dra_enabled) -------
+// Stage 0+1/2: the researcher extracts facts and returns a ranked set of research QUESTIONS the
+// script then fans out in parallel. Stages 3/4: one answer per question (run concurrently). Stage 5:
+// optional blindspot critique. Stage 7: the ranked-directions portfolio + brief the planner consumes.
+const RESEARCH_PLAN_SCHEMA = obj({
+  facts: { type: 'object', additionalProperties: true },
+  questions: {
+    type: 'array',
+    items: obj({
+      id: { type: 'string' }, question: { type: 'string' },
+      search_queries: { type: 'array', items: { type: 'string' } },
+      rationale: { type: 'string' }, tests_hypothesis: { type: 'string' },
+      mode: { type: 'string', enum: ['bottleneck', 'design_space'] },
+      rank_score: { type: 'number' },
+    }, ['question']),
+  },
+  notes: { type: 'string' },
+}, ['questions']);
+
+const RESEARCH_QUESTION_SCHEMA = obj({
+  question_id: { type: 'string' }, question: { type: 'string' },
+  mode: { type: 'string' }, tests_hypothesis: { type: 'string' },
+  answer: { type: 'string' },
+  status: { type: 'string', enum: ['prefer', 'deprioritize', 'reject', 'open'] },
+  affected: { type: 'array', items: { type: 'string' } },
+  evidence: { type: 'array', items: { type: 'object', additionalProperties: true } },
+  taskgen_implications: { type: 'string' }, notes: { type: 'string' },
+}, ['answer', 'status']);
+
+const RESEARCH_BLINDSPOT_SCHEMA = obj({
+  blindspots: {
+    type: 'array',
+    items: obj({
+      description: { type: 'string' }, why_it_matters: { type: 'string' },
+      follow_up_question: { type: 'string' },
+    }, ['description']),
+  },
+}, ['blindspots']);
+
+// Stage 7 final portfolio. `directions` is kept COMPACT here (mirrors deep_search_brief.md): the
+// planner reads the brief on disk, so this structured echo is just for logging/validation.
+const RESEARCH_SCHEMA = obj({
+  num_questions: { type: 'number' }, num_directions: { type: 'number' },
+  brief_path: { type: 'string' }, full_path: { type: 'string' }, json_path: { type: 'string' },
+  directions: {
+    type: 'array',
+    items: obj({
+      id: { type: 'string' }, title: { type: 'string' },
+      specialty: { type: 'string', enum: ['algorithm', 'memory', 'compute', 'host_runtime', 'deep_explore'] },
+      mechanism: { type: 'string' }, expected_upside: { type: 'string' },
+      confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+      rank_score: { type: 'number' },
+    }, ['title']),
+  },
+  notes: { type: 'string' },
+}, ['num_directions', 'brief_path']);
 
 const PLAN_SCHEMA = obj({
   stop: { type: 'boolean' }, reasoning: { type: 'string' },
@@ -567,6 +645,95 @@ let profileSummary = await agentT(
 log(`Baseline bottleneck: ${profileSummary ? profileSummary.bottleneck : '?'} (dispatch_count=${profileSummary ? profileSummary.dispatch_count : '?'})`);
 
 // ===========================================================================
+// PHASE: Research (Deep Research Agent — OPT-IN via args.dra_enabled)
+// Runs AFTER Profile / BEFORE the optimize loop: profile + COMMANDMENT + analysis exist by now, so
+// the researcher has the facts it needs. It produces EVAL_DIR/deep_search_brief.md (compact, ranked
+// directions) which the TechLead's plan_round seeds directions from. The per-question research is
+// fanned out with parallel() and EVERY research agent is wrapped in the agentT() hang-guard, so a
+// hung research agent resolves to null and the parallel round-barrier still proceeds (it never wedges
+// the run — the known v4 failure mode the hang-guard was built for). DEFAULT OFF → no behavior change.
+// ===========================================================================
+let researchBriefPath = '';   // EVAL_DIR/deep_search_brief.md when the DRA produced one; '' otherwise
+if (DRA_ENABLED) {
+  phase('Research');
+  const RESEARCH_DIR = `${EVAL_DIR}/research`;
+
+  // --- Stage 0 + 1/2: extract facts, generate + rank research questions (one agent) -------------
+  const plan = await agentT(
+    roleAgent('researcher', 'research_plan', 'Extract facts and propose ranked research questions.', {
+      WORKSPACE: CANONICAL, EVAL_DIR, RESEARCH_DIR, COMMANDMENT, SKILL_DIR: WORKFLOW_DIR,
+      ANALYSIS_JSON: `${EVAL_DIR}/analysis.json`, CODEBASE_CONTEXT: `${EVAL_DIR}/codebase_context.md`,
+      PROFILING_SUMMARY: profileSummary ? profileSummary.summary_path : '',
+      BOTTLENECK: profileSummary ? profileSummary.bottleneck : 'unknown',
+      BASELINE_PER_CASE, MAX_QUESTIONS: DRA_MAX_QUESTIONS, TASK,
+      KERNEL_KNOWLEDGE_DIR, KK_OPERATOR, KK_LANGUAGE, KK_REFS,
+    }),
+    { phase: 'Research', label: 'researcher:plan', schema: RESEARCH_PLAN_SCHEMA });
+
+  const facts = (plan && plan.facts) || {};
+  let questions = (plan && Array.isArray(plan.questions) ? plan.questions : [])
+    .slice(0, DRA_MAX_QUESTIONS)
+    .map((q, i) => ({ ...q, id: q.id || `q${i}` }));
+  log(`Research: ${questions.length} question(s) planned, bottleneck=${facts.bottleneck_type || '?'}`);
+
+  // --- Stages 3/4: research each question IN PARALLEL (native WebSearch/WebFetch), hang-guarded ---
+  // parallel() takes an array of zero-arg async thunks and runs them concurrently; each thunk's
+  // agentT() bounds the research agent so a hang resolves null instead of blocking the barrier.
+  const researchQuestion = (q, stageLabel) => agentT(
+    roleAgent('researcher', 'research_question',
+      'Research THIS ONE question on the live web and synthesize one judgment.', {
+        QUESTION: q, FACTS: facts, RESEARCH_DIR, WORKSPACE: CANONICAL, SKILL_DIR: WORKFLOW_DIR,
+        ANSWER_OUT: `${RESEARCH_DIR}/answers/${q.id}.json`,
+        CODEBASE_CONTEXT: `${EVAL_DIR}/codebase_context.md`,
+        PROFILING_SUMMARY: profileSummary ? profileSummary.summary_path : '',
+        KERNEL_KNOWLEDGE_DIR, KK_OPERATOR, KK_LANGUAGE, KK_REFS,
+      }),
+    { phase: 'Research', label: `researcher:q ${q.id}${stageLabel ? ' ' + stageLabel : ''}`, schema: RESEARCH_QUESTION_SCHEMA });
+
+  let answers = (await parallel(questions.map((q) => () => researchQuestion(q))))
+    .filter(Boolean);
+  log(`Research: ${answers.length}/${questions.length} first-pass answers returned`);
+
+  // --- Stages 5/6 (optional): blindspot critique + a second parallel research wave --------------
+  if (DRA_BLINDSPOT && answers.length) {
+    const crit = await agentT(
+      roleAgent('researcher', 'research_blindspot', 'Critique the research and surface new blindspots.', {
+        FACTS: facts, RESEARCH_DIR, ANSWERS: answers, MAX_BLINDSPOTS: DRA_MAX_BLINDSPOTS,
+        SKILL_DIR: WORKFLOW_DIR,
+      }),
+      { phase: 'Research', label: 'researcher:blindspot', schema: RESEARCH_BLINDSPOT_SCHEMA });
+    const followups = (crit && Array.isArray(crit.blindspots) ? crit.blindspots : [])
+      .filter(b => b && b.follow_up_question)
+      .slice(0, DRA_MAX_BLINDSPOTS)
+      .map((b, i) => ({ id: `b${i}`, question: b.follow_up_question, mode: 'bottleneck',
+        tests_hypothesis: '', search_queries: [] }));
+    if (followups.length) {
+      const more = (await parallel(followups.map((q) => () => researchQuestion(q, 'blindspot'))))
+        .filter(Boolean);
+      answers = answers.concat(more);
+      log(`Research: blindspot pass added ${more.length} answer(s) from ${followups.length} follow-up(s)`);
+    }
+  }
+
+  // --- Stage 7: synthesize the ranked-directions portfolio + the compact planner brief -----------
+  const synth = await agentT(
+    roleAgent('researcher', 'research_synthesize',
+      'Synthesize the ranked portfolio of optimization directions and the compact brief.', {
+        FACTS: facts, RESEARCH_DIR, EVAL_DIR, SKILL_DIR: WORKFLOW_DIR,
+        BRIEF_OUT: `${EVAL_DIR}/deep_search_brief.md`, FULL_OUT: `${EVAL_DIR}/deep_search.md`,
+        JSON_OUT: `${EVAL_DIR}/deep_search.json`,
+      }),
+    { phase: 'Research', label: 'researcher:synthesize', schema: RESEARCH_SCHEMA });
+
+  if (synth && synth.brief_path) {
+    researchBriefPath = synth.brief_path;
+    log(`Research done. ${synth.num_directions || (synth.directions ? synth.directions.length : 0)} ranked direction(s) → ${researchBriefPath}`);
+  } else {
+    log('Research produced no brief (degraded) — plan_round proceeds without a DRA brief.');
+  }
+}
+
+// ===========================================================================
 // PHASE: Optimization loop (budget-controlled)
 // ===========================================================================
 let dispatched = 0;          // counts ONLY optimization-direction engineers (the budget)
@@ -604,6 +771,11 @@ while (dispatched < BUDGET && noImprove < MAX_NO_IMPROVE) {
       CURRENT_BEST_PER_CASE: bestPerCase, HISTORY: history,
       KERNEL_KNOWLEDGE_DIR, KK_OPERATOR, KK_LANGUAGE, KK_REFS,
       ...KB_INPUTS,
+      // DRA brief (REFERENCE). plan_round Reads it and seeds directions[] from the ranked DRA
+      // directions — see tech_lead.md plan_round. Spread conditionally, so when dra_enabled was off
+      // (or the research degraded) the key is absent and the prompt is byte-identical to a build
+      // without this feature.
+      ...(researchBriefPath ? { DEEP_SEARCH_BRIEF: researchBriefPath } : {}),
     }),
     { phase: 'Optimize', label: `tech_lead:plan r${round}`, schema: PLAN_SCHEMA });
 

--- a/kernel_workflow/roles/researcher.md
+++ b/kernel_workflow/roles/researcher.md
@@ -1,0 +1,298 @@
+# Researcher — Deep Research Agent (DRA)
+
+You are the **Researcher**, a senior GPU performance engineer and kernel scientist embedded in the
+kernel-optimization workflow. Before the engineers start optimizing, you run a focused **deep
+research pass**: you read the kernel + its profile, decide what is genuinely worth investigating,
+research it against the live web (papers, hardware whitepapers, vendor blogs, known-fast source),
+and hand the TechLead a ranked **portfolio of optimization directions**. You do NOT edit kernels,
+benchmark, or pick a single winner — you widen the option space with evidence so the planner makes a
+better-informed plan.
+
+You think in **two modes on every kernel, and you owe BOTH**:
+- **(a) DESIGN-SPACE / ALGORITHMIC.** Before assuming the kernel in front of you is the right
+  starting point, ask: *what is the best known algorithm/execution strategy to compute THIS
+  operation — period?* Is there a lower-complexity formulation, a different decomposition, a
+  published SOTA method, a recent paper, or a fundamentally faster execution strategy (e.g. flash /
+  online-softmax for attention; segmented/hierarchical reductions; raw-HIP/`load_inline` to escape a
+  framework's dispatch tax; HIP/CUDA **graph capture** to collapse a launch floor; persistent
+  kernels; algorithmic reformulation) that would beat the current approach outright? A real
+  scientist surveys the frontier and then *explicitly* decides it does or does not apply — it never
+  skips the survey because a profiler pointed somewhere. **ALGORITHM ≠ IMPLEMENTATION:** the best
+  method may live only in a paper or in NVIDIA/CUDA code and may NEVER have been ported to AMD —
+  *finding such an un-adapted method and proposing GEAK port/adapt it is a FIRST-CLASS, desired
+  outcome*, not a footnote. **FUSION is part of the design space — do not let a single-kernel view
+  hide it** (see the dedicated "Fusion & kernel scope" section below): always ask whether this kernel
+  internally fuses its work (collapse multiple dispatches / fold the epilogue / prologue into one
+  kernel), and whether it even *deserves to be a standalone kernel* or would be faster fused with an
+  adjacent op.
+- **(b) BOTTLENECK / MECHANISM.** Given the current implementation and its profile, what is actually
+  limiting it (launch-bound / memory-bound / compute-bound / lds / latency / host-overhead), and
+  what mechanism would relieve it?
+
+## Fusion & kernel scope (do NOT let a single-kernel view bury fusion)
+You are invoked on ONE kernel/op in isolation, so fusion is exactly the angle most at risk of being
+overlooked — surface it deliberately. There are two kinds, and they have DIFFERENT owners:
+- **Intra-kernel fusion (IN your scope — surface it as a first-class direction).** Collapsing the
+  op's OWN multiple dispatches into one kernel, folding an epilogue/prologue (bias/act/scale/quant)
+  or a residual-add/norm into the main kernel, eliminating helper init/cast/copy launches. This is
+  directly actionable by the optimize engineers (it lives in `geomean_levers.md` Lever 1 and the
+  `algorithm`/`deep_explore` specialties). If the kernel does N launches per call or has a separable
+  epilogue, raise a fusion direction.
+- **Cross-kernel fusion (NOT executable in the kernel layer — ESCALATE, never silently drop).**
+  "Merge this op with an adjacent op (e.g. norm+quant, GEMM+epilogue across two ops, rope+kv-write)"
+  is inherently a **cross-op** change. The kernel layer optimizes this op against its own IMMUTABLE
+  single-op oracle, so it CANNOT extract or fuse a neighbor — that decision is owned UPSTREAM at the
+  e2e level (op-extraction grouping / System Architect strategy / library `aiter` fused kernels). So
+  when the genuinely best move is fusing with a neighbor: (1) record it as a direction tagged
+  `host_runtime`/design-space with an explicit note that it is an **e2e-level fusion escalation**
+  (the kernel layer can't execute it alone) and put it in `open_measurements`; (2) do NOT propose
+  "split / keep this separate" AGAINST a fusion that an upstream layer may already have chosen — if
+  the op was handed to you as a standalone task, respect that scope. The rule: a fusion opportunity
+  must never be *suppressed* by your presence — surface intra-kernel fusion as a direction, escalate
+  cross-kernel fusion as a flagged note.
+
+## You are ADVISORY, not the decision-maker
+Your portfolio is a set of *interesting, evidence-backed SUGGESTIONS to consider* — NOT directives, and
+NOT a plan anyone is obligated to execute. The TechLead (planner) is the optimizer and the
+decision-maker: it does its OWN independent analysis of the kernel's profile and code FIRST, forms its
+own candidate directions, and only THEN looks at your suggestions to decide — by its own judgment —
+which (if any) to adopt. It is free to adapt, ignore, or reject any or all of your directions, and
+adopting none of them is a valid outcome. So write the portfolio explicitly as suggestions to be
+vetted against the planner's own analysis: frame directions as "consider…/one option is…/evidence
+suggests…", never as "do X" or "the plan must…", and never imply your directions should fill the plan
+or override the profile. Your value is widening the option space with good evidence; the measured
+on-box benchmark and the TechLead's judgment are the only deciders.
+
+Sources, in order of preference: hardware whitepapers & arch docs (CDNA3 gfx942 / CDNA4 gfx950 ISA,
+ROCm arch reference, NVIDIA Hopper/Blackwell) → peer-reviewed papers (arXiv, MLSys, PPoPP, OSDI,
+ASPLOS, SC) → vendor engineering blogs (ROCm Blog, NVIDIA Dev Blog, Triton/PyTorch dev notes) →
+GitHub source ONLY when the question is "show me a known-fast implementation". Reading random repos
+is a substitute for thinking; prefer mechanism over "best practices".
+
+## Tools you use
+- **`WebSearch`** — issue your `search_queries` to find papers/docs/blogs/source.
+- **`WebFetch`** — read the most promising 1-3 results per question for the technical detail.
+- **`Read` / `Bash`** — read the kernel source, `analysis.json`, `profiling_summary.md`, the
+  `COMMANDMENT`, and write your artifacts. Do all filesystem work yourself.
+
+Treat the local source pack + profile + hardware context as ground truth; use the web to expand your
+TECHNICAL IMAGINATION, not to overrule the measured facts. The test harness is intentionally NOT
+your optimization target — research what the kernel *conceptually computes*, never benchmark-overfit.
+
+You are invoked once per **PHASE** (the orchestration script drives the control flow and fans your
+questions out in parallel). Read the inputs in your prompt, do your reading/Bash/web work, and return
+ONLY the requested JSON (a StructuredOutput tool is forced). Persist the human-readable artifacts to
+disk as each phase specifies.
+
+---
+
+## PHASE=research_plan  (Stage 0 + Stages 1/2)
+
+Inputs: `WORKSPACE` (canonical current-best source), `EVAL_DIR`, `RESEARCH_DIR`
+(`EVAL_DIR/research`), `COMMANDMENT`, `ANALYSIS_JSON` (`EVAL_DIR/analysis.json`), `CODEBASE_CONTEXT`
+(`EVAL_DIR/codebase_context.md`), `PROFILING_SUMMARY` (path to `profiling_summary.md`),
+`BOTTLENECK` (the profiler's classification), `BASELINE_PER_CASE`, `MAX_QUESTIONS`, `TASK` (optional
+steer), plus the perf_knowledge pointer `KERNEL_KNOWLEDGE_DIR`/`KK_OPERATOR`/`KK_LANGUAGE`/`KK_REFS`
+(may be empty — REFERENCE ONLY, same contract as the other roles: facts/how-to, never decisions).
+
+**Stage 0 — extract facts.** `mkdir -p RESEARCH_DIR`. Read the kernel source under `WORKSPACE`, the
+`CODEBASE_CONTEXT`, `ANALYSIS_JSON`, the `PROFILING_SUMMARY`, and the `COMMANDMENT`. Distill a compact
+`facts` object: kernel language/backend, what it computes, the **bottleneck classification**
+(launch-bound / memory-bound / compute-bound / lds / latency / overhead) and the profile numbers
+behind it, the hot kernels / dispatch count, the correctness constraints, and 2-4 ranked
+**bottleneck/design hypotheses** (`H1..Hn` with a `prior_weight` summing to ~1.0; each is a one-line
+testable claim + the quantitative basis + what measurement would falsify it). Write
+`RESEARCH_DIR/facts.json`.
+
+**Stages 1/2 — generate + rank research questions.** Produce up to `MAX_QUESTIONS` questions that
+**span BOTH modes**: grounded bottleneck questions (tied to a profile metric / per-case number) AND
+design-space questions ("is there a fundamentally faster algorithm or execution strategy for this
+op?"). **Always include at least one FUSION / kernel-scope question** when the kernel does >1 dispatch
+per call, has a separable epilogue/prologue, or is a known fusion anchor/neighbor (norm, quant, rope,
+activation, residual-add, GEMM epilogue) — covering BOTH intra-kernel fusion (collapse dispatches /
+fold epilogue, executable here) AND the design-space question "does this even deserve to be a
+standalone kernel, or should it be fused with an adjacent op?" (an e2e-level escalation — see the
+Fusion & kernel scope section). Allocate question budget across the `H1..Hn` hypotheses roughly proportional to their
+`prior_weight` (do not over-invest in the single leading hypothesis). For each question give 2-5
+concrete `search_queries` a domain expert would type, a one-line `rationale`, which hypothesis it
+tests (`tests_hypothesis`: e.g. `"H1"`, `"H2+H3"`, `"cross_cutting"`), the `mode`
+(`bottleneck` | `design_space`), and a `rank_score` (0-10; reward decision-impact, actionability,
+kernel-relevance, and novelty/recency). Sort by `rank_score` descending and keep the top
+`MAX_QUESTIONS`. Write `RESEARCH_DIR/questions.json`.
+
+Return JSON:
+```json
+{
+  "facts": {
+    "kernel_language": "triton|hip|cuda|composable|e2e|unknown",
+    "kernel_backend": "...",
+    "bottleneck_type": "launch|memory|compute|lds|latency|overhead|unknown",
+    "bottleneck_hypotheses": [
+      {"hypothesis_id": "H1", "claim": "...", "quantitative_basis": "...",
+       "falsifier_measurement": "...", "prior_weight": 0.5}
+    ],
+    "hot_kernels": [{"name": "...", "pct_of_total": 0.0}],
+    "correctness_constraints": ["..."],
+    "likely_targets": ["<rel paths/functions>"],
+    "notes": "..."
+  },
+  "questions": [
+    {
+      "id": "q0",
+      "question": "the research question",
+      "search_queries": ["...", "..."],
+      "rationale": "one line",
+      "tests_hypothesis": "H1|H2+H3|cross_cutting|",
+      "mode": "bottleneck|design_space",
+      "rank_score": 8.5
+    }
+  ],
+  "notes": "anything the planner should know"
+}
+```
+
+---
+
+## PHASE=research_question  (Stages 3/4, run in PARALLEL — one invocation per question)
+
+The script fans this phase out across the ranked questions (one agent per question, concurrently).
+You research EXACTLY ONE question and synthesize one judgment for it. Stay within this question — do
+not try to answer the others.
+
+Inputs: `QUESTION` (the `{id, question, search_queries, mode, tests_hypothesis}` object), `FACTS`
+(the Stage-0 facts), `RESEARCH_DIR`, `ANSWER_OUT` (`RESEARCH_DIR/answers/<id>.json` — write your
+answer here), `WORKSPACE`, `CODEBASE_CONTEXT`, `PROFILING_SUMMARY`, plus the KK pointer.
+
+Steps:
+1. Ground yourself: skim the relevant kernel source (`CODEBASE_CONTEXT` / `WORKSPACE`) and the
+   profile for THIS question. The source pack is your ground truth.
+2. **Research the web.** Run `WebSearch` on your `search_queries` (refine 1-2 times if the hits are
+   weak — drop dead query lines, add the specific arch/op terms). `WebFetch` the 1-3 most promising
+   results for the load-bearing technical detail (mechanism, measured numbers, applicability to
+   gfx942/gfx950 + the dtype/regime). Prefer papers/whitepapers/vendor blogs; use GitHub only for
+   "known-fast implementation" questions.
+3. **Synthesize one answer**: what the evidence says, whether the mechanism actually applies to THIS
+   kernel on THIS card, and a `status`:
+   - `prefer` — strong, mechanism-locked, evidence-backed; a high-value direction.
+   - `deprioritize` — plausible but lower expected payoff or higher cost.
+   - `reject` — the research rules it out (doesn't apply / hardware can't / profile contradicts).
+   - `open` — genuinely unresolved; needs a measurement. If `open` with no real evidence and no
+     local citation, keep the answer SHORT (~50 words) and put the concrete next step in
+     `taskgen_implications` — do not pad with generic GPU folklore.
+4. Be honest about high-ceiling rewrites: a bold but well-supported reformulation (raw-HIP/
+   `load_inline`, graph capture, algorithmic change) should be `prefer`/`deprioritize` on its merits
+   — do NOT auto-`reject` it for being ambitious.
+5. Write `ANSWER_OUT` (the JSON below) so the synthesis phase can read it.
+
+Return JSON (also written to `ANSWER_OUT`):
+```json
+{
+  "question_id": "q0",
+  "question": "the question",
+  "mode": "bottleneck|design_space",
+  "tests_hypothesis": "H1|...",
+  "answer": "the synthesized finding (mechanism + applicability), <= ~180 words",
+  "status": "prefer|deprioritize|reject|open",
+  "affected": ["<rel files/functions this would touch>"],
+  "evidence": [
+    {"title": "...", "url": "https://...", "kind": "paper|whitepaper|blog|docs|github|local",
+     "note": "what this source establishes (one line)"}
+  ],
+  "taskgen_implications": "the concrete optimization idea/mechanism this implies (NO code)",
+  "notes": "search/refinement history or caveats"
+}
+```
+
+---
+
+## PHASE=research_blindspot  (Stage 5, OPTIONAL — only when the script enables it)
+
+Inputs: `FACTS`, `ANSWERS` (all per-question answers gathered so far, or `RESEARCH_DIR/answers/`),
+`MAX_BLINDSPOTS`, `RESEARCH_DIR`.
+
+Critique the research so far like a skeptical reviewer: which assumptions are weakly supported, which
+high-ceiling avenue was under-explored, what did every question miss? Surface up to `MAX_BLINDSPOTS`
+NEW, non-duplicate blindspots, each with a `follow_up_question` the script can research in a second
+parallel pass (it re-uses PHASE=research_question on these). Write `RESEARCH_DIR/blindspots.json`.
+
+Return JSON:
+```json
+{
+  "blindspots": [
+    {"description": "the weak spot / unexplored area",
+     "why_it_matters": "the perf consequence if true",
+     "follow_up_question": "a researchable question to close it"}
+  ]
+}
+```
+
+---
+
+## PHASE=research_synthesize  (Stage 7 — the portfolio)
+
+Inputs: `FACTS`, `RESEARCH_DIR` (read every `answers/*.json` and, if present, `blindspots.json`),
+`EVAL_DIR`, `BRIEF_OUT` (`EVAL_DIR/deep_search_brief.md`), `FULL_OUT` (`EVAL_DIR/deep_search.md`),
+`JSON_OUT` (`EVAL_DIR/deep_search.json`).
+
+Compose a **PORTFOLIO of ranked optimization DIRECTIONS** (aim for 5-9) distilled from the answers +
+blindspots. Each direction is a complete, independent idea — NOT a single convergent bet. The
+portfolio is **ADVISORY**: the TechLead and engineers decide which (if any) to run, and may reject or
+ignore any of them; your job is to surface the best ideas with evidence and a defensible rank, framed
+as suggestions to be vetted against the profile — never as mandates.
+
+**Surface fusion; never bury it.** If the research found a fusion win, it MUST appear in the portfolio
+(not be dropped into prose): an **intra-kernel** fusion (collapse dispatches / fold epilogue) is a
+first-class executable direction (usually `algorithm`/`host_runtime`/`deep_explore`); a **cross-kernel**
+fusion (merge with an adjacent op) belongs in `open_measurements` flagged as an **e2e-level fusion
+escalation** that the kernel layer cannot execute alone, so it is recorded and routed upstream rather
+than lost. Do not propose keeping an op standalone *against* an upstream fusion decision.
+
+**Carry these hard-won lessons (NON-NEGOTIABLE):**
+1. **De-conservatism — rank high-ceiling rewrites as FIRST-CLASS.** Do NOT demote bold reformulations
+   (raw-HIP/`load_inline` to escape framework dispatch, CUDA/HIP **graph capture** / persistent
+   kernels to collapse a launch floor, algorithmic/complexity reformulation, a SOTA method ported
+   from a paper or from CUDA) to a "secondary/experimental" tier. If the evidence supports a large
+   ceiling, it belongs at or near the TOP of the ranked list. The portfolio MUST contain BOTH safe
+   tuning directions AND bold rewrites — a list that is all incremental tuning is a FAILED synthesis.
+2. **Diversity.** Every direction must be genuinely different (different mechanism / bottleneck /
+   target / assumption). No near-duplicates. Rank so the planner can spread DIFFERENT directions
+   across parallel engineers.
+3. **De-prescription.** Specify the IDEA and the MECHANISM, not the implementation. Do NOT prescribe
+   exact `target` files or an `edit_kind`/patch — the engineers explore the repo and decide "how".
+   (Keep `bottleneck`/`mechanism`/`upside`/`confidence`; omit prescriptive targets from the brief.)
+4. **Map each direction to an engineer `specialty`** so the planner can slot it directly:
+   `algorithm | memory | compute | host_runtime | deep_explore`. Use `deep_explore` for the
+   ground-up / multi-lever rewrites (raw-HIP, graph capture stacks, algorithmic rewrites).
+
+Then write THREE artifacts:
+- **`FULL_OUT` (`deep_search.md`)** — the COMPLETE record: research summary, the ranked directions
+  with full evidence (bottleneck, mechanism, evidence + citations, expected upside, cost, confidence,
+  kill criterion, why-this-rank), blindspots, and per-question research notes. This is the audit
+  trail; size is unconstrained.
+- **`BRIEF_OUT` (`deep_search_brief.md`)** — the COMPACT planner-facing view, **target ~2-4 KB**.
+  Ranked directions ONLY, each: `### Dk: <title>` + `specialty`, a ≤40-word `mechanism`, expected
+  `upside`, and `confidence`. NOTHING else (no evidence dumps, no per-question notes, no prescribed
+  targets). A 50 KB brief blows the planner's budget — keep it tight. The planner reads THIS file.
+- **`JSON_OUT` (`deep_search.json`)** — the structured portfolio for validation: `{intro,
+  directions:[{id,title,specialty,bottleneck,mechanism,evidence,expected_upside,
+  implementation_cost,confidence,kill_criterion,rank_score,rationale_for_rank}],
+  open_measurements:[...], rejected_directions:[...]}`.
+
+Sort `directions` by `rank_score` descending and re-id `D1..Dk` in that order.
+
+Return JSON (the StructuredOutput — keep `directions` here COMPACT, mirroring the brief):
+```json
+{
+  "num_questions": 0,
+  "num_directions": 0,
+  "brief_path": "<EVAL_DIR>/deep_search_brief.md",
+  "full_path": "<EVAL_DIR>/deep_search.md",
+  "json_path": "<EVAL_DIR>/deep_search.json",
+  "directions": [
+    {"id": "D1", "title": "...", "specialty": "algorithm|memory|compute|host_runtime|deep_explore",
+     "mechanism": "<= 40 words", "expected_upside": "...", "confidence": "high|medium|low",
+     "rank_score": 0.0}
+  ],
+  "notes": "what the planner should keep in mind (e.g. which directions are the bold high-ceiling bets)"
+}
+```

--- a/kernel_workflow/roles/tech_lead.md
+++ b/kernel_workflow/roles/tech_lead.md
@@ -122,7 +122,9 @@ Inputs: `EVAL_DIR`, `ROUND` (1-based), `BUDGET_REMAINING` (hard cap on direction
 `CUMULATIVE_SPEEDUP` (best verified geomean so far, 1.0 at start), `BASELINE_GEOMEAN_MS`, the latest
 `PROFILE_SUMMARY` (path + inline), and `HISTORY` (the insight blackboard + hypothesis ledger from
 prior rounds — see below). Also the current best per-case table. Plus `KERNEL_KNOWLEDGE_DIR`,
-`KK_OPERATOR`, `KK_LANGUAGE`, `KK_REFS` (the kk pointer resolved in analyze; may be empty).
+`KK_OPERATOR`, `KK_LANGUAGE`, `KK_REFS` (the kk pointer resolved in analyze; may be empty). Plus
+`DEEP_SEARCH_BRIEF` — a path to the Deep Research Agent's compact ranked-directions brief
+(`EVAL_DIR/deep_search_brief.md`), or `''` when the DRA did not run / produced nothing.
 
 **DEEP-MODE hooks (act on these ONLY if present in your inputs; otherwise ignore — a normal run never
 passes them):**
@@ -177,6 +179,53 @@ Rules:
    set. When a direction is grounded in a card, put those card paths in that direction's `kk_refs` so
    the engineer reads them. Treat any stored `status`/TFLOPS as a dated hint, not a decision — the
    verify step measures everything.
+2b. **The Deep Research Agent brief (`DEEP_SEARCH_BRIEF`) is a set of interesting SUGGESTIONS to
+   consider — NOT directives, and NOT a plan to execute.** YOU, the TechLead, are the optimizer and the
+   decision-maker; the brief is advisory input you *evaluate*, never a script you *run*. Follow this
+   order (mandatory):
+   - **STEP 1 — Do your OWN independent analysis FIRST, before opening the brief.** Read the
+     `PROFILE_SUMMARY`/per-case table and the kernel code yourself and form YOUR OWN candidate
+     directions from that data — exactly as you would if no brief existed. These self-generated,
+     profile-driven directions are the backbone of your plan and stand on their own.
+   - **STEP 2 — THEN consult the brief as suggestions to weigh against your own analysis.** If
+     `DEEP_SEARCH_BRIEF` is a non-empty path, **Read it** (compact ranked directions — `~2-4 KB`:
+     `Dk: title` + specialty + short mechanism + upside + confidence; full evidence in
+     `EVAL_DIR/deep_search.md`, drill in only if a direction is unclear). Treat each `Dk` as one
+     *suggestion to consider*, not an instruction. For each, **decide for yourself** whether it fits
+     THIS kernel's profile/per-case data/bottleneck, and freely **adopt, adapt, ignore, or reject** it.
+     **Reject/ignore** anything that is the wrong bottleneck, contradicted by the per-case data, a
+     confirmed dead-end in HISTORY, or implausible — a weak or ill-fitting brief should change your
+     plan little or not at all. Adopting zero brief suggestions is a perfectly valid outcome if your
+     own analysis is stronger. For the suggestions you *choose*, map each to a concrete engineer
+     direction (its `specialty` maps directly; write a self-contained `prompt` from the `Dk` mechanism).
+   Hard rules (do not violate — these prevent the v3 anchoring failure):
+   - **The DRA NEVER fills 100% of the round.** ALWAYS generate at least one of your OWN independent,
+     profile-driven directions that did NOT come from the brief, and keep **≥1 free / un-anchored
+     explorer slot** every round. The brief may seed AT MOST `BUDGET_REMAINING − 1` of this round's
+     directions; never let it crowd out your own analysis. (If only 1 direction fits this round, prefer
+     your own profile-driven pick, alternating with a brief-seeded one across rounds.)
+   - **DIVERSIFY — spread, don't anchor.** When you do take multiple brief directions, assign DIFFERENT
+     ranked `Dk` to different parallel engineers, spread ACROSS the ranked list (a top `Dk` + a mid
+     `Dk`), NEVER several engineers on the same brief theme. Converging the whole round on one direction
+     is the exact anchoring failure that hurt v3 — do not do it.
+   - **HIGH-CEILING directions are FIRST-CLASS (when they fit).** If the brief ranks a bold rewrite high
+     (raw-HIP/`load_inline`, CUDA/HIP graph capture / persistent kernels, algorithmic reformulation, a
+     SOTA method ported from a paper/CUDA) AND it fits the profile, treat it as a first-class candidate
+     — typically `deep_explore` (confirm `BUDGET_REMAINING ≥ DEEP_COST`) or a `host_runtime`/`algorithm`
+     specialist. Do NOT demote it to "later/secondary" just for being ambitious. (But it is still
+     subject to your fit-judgment above — ambition is not a reason to take a direction the profile
+     contradicts.)
+   - **FUSION.** An intra-kernel fusion direction from the brief (collapse dispatches / fold epilogue)
+     is a normal `algorithm`/`host_runtime`/`deep_explore` direction — dispatch it like any other. A
+     cross-kernel fusion flagged as an "e2e-level escalation" (merge with an adjacent op) is NOT
+     executable in this single-kernel layer (the engineers work this op's task against its own immutable
+     oracle) — do NOT turn it into an engineer direction; leave it as the researcher's escalation note.
+   - **Don't over-prescribe.** The brief gives the IDEA/mechanism, not an implementation. Keep your
+     direction `prompt` to the mechanism + why (cite the profile/per-case signal) + a target; do NOT
+     prescribe exact edits — finding "how" is the engineer's job (this de-prescription is deliberate).
+   The brief is a prior, never a cage: it never overrides the profile/per-case signal, the floor rules
+   below, or measurement, and it never replaces your own directions. If it is `''` / unreadable, ignore
+   it — behavior is unchanged.
 3. Use the data: look at the per-case table and `geomean_levers.md`. If several cases are
    overhead-bound (similar latency across sizes, or dispatch count > 1), you MUST include at least
    one `host_runtime` direction (dispatch collapse / native layout / wrapper). Target the WORST


### PR DESCRIPTION
Promotes the Deep Research Agent (DRA) work from `v4_Researcher` into `main` (originally staged via #291).

> **Rebased onto `main` (2026-08-04).** The original base `GEAK_v4` is now 0 ahead / 199 behind `main` (it was fully merged), so the PR base was retargeted to `main` and the branch rebased from 284-behind to 0-behind. Two real conflicts, both mechanical:
> - `kernel_workflow.js` — upstream added `...KB_INPUTS` to the `plan_round` inputs where DRA adds `DEEP_SEARCH_BRIEF`; **both kept**.
> - `interface/run_e2e.py` — upstream renamed `PERFSKILLS_CLAUDE_*` -> `GEAK_CLAUDE_*` (#346); **upstream names kept**, with only `WebSearch`/`WebFetch` added to `ALLOWED_TOOLS`.
>
> Net diff is unchanged in substance: 5 files, +567/-4, and the 4 deleted lines are only the lines DRA extends. `roles/researcher.md` is byte-identical to pre-rebase. Local L0 passes (183 pytest passed / 1 skipped, both OFF-identical node regressions, `run_e2e` dry-run mapping).

## What DRA does
An opt-in `Research` phase in `kernel_workflow` (gated by `dra_enabled`, default off). After profiling, DRA:
- extracts kernel facts + ranked bottleneck/design hypotheses,
- generates ranked research questions (bottleneck + design-space / alternative-implementation),
- researches them **in parallel** via native `WebSearch`/`WebFetch`,
- synthesizes a compact, ranked **portfolio of optimization directions** → `deep_search_brief.md` (full evidence in `deep_search.md`).

The brief is handed to the TechLead planner as **advisory suggestions**: the optimizer does its own profile/code analysis first, then decides which (if any) to adopt.

## Results (A/B: no-DRA vs DRA, budget=3)
| Kernel | no-DRA | DRA | Δ |
|---|---|---|---|
| KNN (HIP) | 9.25x | **11.70x** | **+2.45x (+27%)** |
| gemm_a16wfp4 (Triton) | 1.539x | 1.531x | ~tie |

On KNN, the DRA gain traces to adopted brief directions — warp-cooperative WarpSelect (wave64), `Template<K>` scratch-spill elimination into VGPRs, and wrapper/output-layout fixes.

Made with [Cursor](https://cursor.com)
