### PR TITLE
fix(litellm): force streaming for AMD Primus-Safe gateway

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+# Read the Docs configuration. Required by readthedocs.com — without it the
+# build fails at the config stage before mkdocs runs.
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+  jobs:
+    install:
+      - pip install mkdocs-material
+
+mkdocs:
+  configuration: mkdocs.yml

--- a/docs/developer/prompts.md
+++ b/docs/developer/prompts.md
@@ -1,0 +1,20 @@
+# System & instance prompts
+
+How GEAK assembles the prompts it sends to the model: where prompt files live, how YAML configs merge, and which Jinja variables are available.
+
+## Where prompts live
+
+Prompt templates are stored as YAML alongside the agent and pipeline-worker modules under `src/minisweagent/`. Each agent loads a base prompt set, which a run-specific `--config` can override.
+
+## Merge order
+
+Prompt and model configuration merge in the same precedence order as the rest of the GEAK config: built-in defaults are overlaid by the resolved `--config` YAML, then by any environment-driven overrides. See **[Configuration files](../configuration.md)** for the full resolution rules.
+
+## Jinja variables
+
+Prompt templates are rendered with Jinja. Template variables are supplied by the model's `get_template_vars()` (for example `n_model_calls` and `model_cost`) together with the per-task context the agent passes in.
+
+## Related
+
+- **[MCP and native tools](mcp-tools.md)** — how tools are exposed to the model.
+- **[Configuration files](../configuration.md)** — YAML merge order and `--config` resolution.

--- a/docs/development_guidelines.md
+++ b/docs/development_guidelines.md
@@ -1,0 +1,9 @@
+# Development guidelines
+
+Branching model, pull request workflow, release process, code quality standards, and CI expectations for GEAK.
+
+The full, authoritative reference lives in the developer guide:
+
+- **[Contribution guidelines](developer/contribution_guidelines.md)** — branch strategy, PR workflow, release process, coding standards, and CI checks (ruff lint/format, pylint, tests).
+
+For extending GEAK itself (prompts, MCP servers, native tools), see the **[Developer guide](developer/index.md)**.

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -410,10 +410,7 @@ class LitellmModel:
             or (self.config.model_kwargs or {}).get("api_base")
             or (self.config.model_kwargs or {}).get("base_url")
         )
-        force_stream = (
-            _is_amd_llm_gateway_api_base(effective_api_base)
-            and not filtered.get("stream")
-        )
+        force_stream = _is_amd_llm_gateway_api_base(effective_api_base) and not filtered.get("stream")
         try:
             if force_stream:
                 chunks = list(

--- a/src/minisweagent/models/litellm_model.py
+++ b/src/minisweagent/models/litellm_model.py
@@ -399,7 +399,32 @@ class LitellmModel:
                 model_for_call,
             )
             model_for_call = f"openai/{model_for_call}"
+        # The AMD/core42 Primus-Safe gateway (VertexGenAI backend) rejects
+        # non-streaming predictions with an opaque 400 INVALID_ARGUMENT; only
+        # streamed requests are accepted. When routed there, force streaming and
+        # reassemble the chunks into a normal ModelResponse so the rest of
+        # ``query`` (``choices[0].message`` / ``model_dump``) is unchanged.
+        # Non-gateway providers keep the original non-streaming call.
+        effective_api_base = (
+            filtered.get("api_base")
+            or (self.config.model_kwargs or {}).get("api_base")
+            or (self.config.model_kwargs or {}).get("base_url")
+        )
+        force_stream = (
+            _is_amd_llm_gateway_api_base(effective_api_base)
+            and not filtered.get("stream")
+        )
         try:
+            if force_stream:
+                chunks = list(
+                    litellm.completion(
+                        model=model_for_call,
+                        messages=messages,
+                        timeout=request_timeout,
+                        **{**filtered, "stream": True},
+                    )
+                )
+                return litellm.stream_chunk_builder(chunks, messages=messages)
             return litellm.completion(
                 model=model_for_call,
                 messages=messages,

--- a/tests/models/test_litellm_model.py
+++ b/tests/models/test_litellm_model.py
@@ -249,6 +249,30 @@ def _fake_litellm_response() -> MagicMock:
     return response
 
 
+def _patch_gateway_llm(resp: MagicMock):
+    """Context managers patching the LLM call for AMD-gateway traffic.
+
+    Gateway calls are forced to stream (the proxy rejects non-streaming
+    predictions), so ``litellm.completion`` returns an iterable of chunks and
+    ``stream_chunk_builder`` reassembles them. ``completion`` is still invoked
+    with the real kwargs, so header assertions on its ``call_args`` hold.
+    """
+    return (
+        patch(
+            "minisweagent.models.litellm_model.litellm.completion",
+            return_value=iter([resp]),
+        ),
+        patch(
+            "minisweagent.models.litellm_model.litellm.stream_chunk_builder",
+            return_value=resp,
+        ),
+        patch(
+            "minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost",
+            return_value=0.0,
+        ),
+    )
+
+
 _AMD_GATEWAY_API_BASE = "https://llm-api.amd.com/Anthropic"
 _NON_AMD_API_BASE = "https://api.openai.com/v1"
 
@@ -265,15 +289,8 @@ class TestLitellmModelUserHeader:
             model_name="anthropic/claude-opus-4.6",
             model_kwargs={"api_key": "k", "api_base": _AMD_GATEWAY_API_BASE},
         )
-        with (
-            patch(
-                "minisweagent.models.litellm_model.litellm.completion", return_value=_fake_litellm_response()
-            ) as comp,
-            patch(
-                "minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost",
-                return_value=0.0,
-            ),
-        ):
+        comp_patch, builder_patch, cost_patch = _patch_gateway_llm(_fake_litellm_response())
+        with comp_patch as comp, builder_patch, cost_patch:
             model.query([{"role": "user", "content": "hi"}])
         headers = comp.call_args.kwargs["extra_headers"]
         assert headers["user"] == "alice@amd.com"
@@ -290,15 +307,8 @@ class TestLitellmModelUserHeader:
                 "extra_headers": {"user": "explicit", "Ocp-Apim-Subscription-Key": "k"},
             },
         )
-        with (
-            patch(
-                "minisweagent.models.litellm_model.litellm.completion", return_value=_fake_litellm_response()
-            ) as comp,
-            patch(
-                "minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost",
-                return_value=0.0,
-            ),
-        ):
+        comp_patch, builder_patch, cost_patch = _patch_gateway_llm(_fake_litellm_response())
+        with comp_patch as comp, builder_patch, cost_patch:
             model.query([{"role": "user", "content": "hi"}])
         headers = comp.call_args.kwargs["extra_headers"]
         assert headers["user"] == "explicit"
@@ -314,15 +324,8 @@ class TestLitellmModelUserHeader:
                 "extra_headers": {"Ocp-Apim-Subscription-Key": "k"},
             },
         )
-        with (
-            patch(
-                "minisweagent.models.litellm_model.litellm.completion", return_value=_fake_litellm_response()
-            ) as comp,
-            patch(
-                "minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost",
-                return_value=0.0,
-            ),
-        ):
+        comp_patch, builder_patch, cost_patch = _patch_gateway_llm(_fake_litellm_response())
+        with comp_patch as comp, builder_patch, cost_patch:
             model.query([{"role": "user", "content": "hi"}])
         headers = comp.call_args.kwargs["extra_headers"]
         assert headers["user"] == "alice@amd.com"
@@ -392,18 +395,54 @@ class TestLitellmModelUserHeader:
                 "api_base": "https://llm-gateway-dev.apps.amdcloud.com/api/gateway/v1",
             },
         )
+        comp_patch, builder_patch, cost_patch = _patch_gateway_llm(_fake_litellm_response())
+        with comp_patch as comp, builder_patch, cost_patch:
+            model.query([{"role": "user", "content": "hi"}])
+        headers = comp.call_args.kwargs["extra_headers"]
+        assert headers["user"] == "alice@amd.com"
+
+
+class TestGatewayForcedStreaming:
+    """The AMD/core42 Primus-Safe gateway rejects non-streaming predictions
+    (opaque 400 INVALID_ARGUMENT), so LitellmModel forces ``stream=True`` and
+    reassembles the chunks for gateway traffic only."""
+
+    def test_gateway_call_forces_stream_and_reassembles(self, monkeypatch):
+        monkeypatch.setenv("GEAK_USER", "alice@amd.com")
+        model = LitellmModel(
+            model_name="anthropic/claude-opus-4.6",
+            model_kwargs={"api_key": "k", "api_base": _AMD_GATEWAY_API_BASE},
+        )
+        resp = _fake_litellm_response()
+        comp_patch, builder_patch, cost_patch = _patch_gateway_llm(resp)
+        with comp_patch as comp, builder_patch as builder, cost_patch:
+            out = model.query([{"role": "user", "content": "hi"}])
+        assert comp.call_args.kwargs["stream"] is True
+        assert builder.called
+        assert out["content"] == "hello"
+
+    def test_non_gateway_call_stays_non_streaming(self, monkeypatch):
+        monkeypatch.setenv("GEAK_USER", "alice@amd.com")
+        model = LitellmModel(
+            model_name="openai/gpt-4o",
+            model_kwargs={"api_key": "k", "api_base": _NON_AMD_API_BASE},
+        )
         with (
             patch(
-                "minisweagent.models.litellm_model.litellm.completion", return_value=_fake_litellm_response()
+                "minisweagent.models.litellm_model.litellm.completion",
+                return_value=_fake_litellm_response(),
             ) as comp,
+            patch(
+                "minisweagent.models.litellm_model.litellm.stream_chunk_builder",
+            ) as builder,
             patch(
                 "minisweagent.models.litellm_model.litellm.cost_calculator.completion_cost",
                 return_value=0.0,
             ),
         ):
             model.query([{"role": "user", "content": "hi"}])
-        headers = comp.call_args.kwargs["extra_headers"]
-        assert headers["user"] == "alice@amd.com"
+        assert not comp.call_args.kwargs.get("stream")
+        assert not builder.called
 
 
 class TestPerCallToolsOverride:


### PR DESCRIPTION
## Summary

- Fixes 100% run failure against the AMD / core42 Primus-Safe gateway, whose VertexGenAI backend rejects **non-streaming** predictions with an opaque `400 INVALID_ARGUMENT`.
- In `LitellmModel._query`, when the call targets the gateway (`_is_amd_llm_gateway_api_base`), force `stream=True` and reassemble the chunks with `litellm.stream_chunk_builder` into a normal `ModelResponse`. Downstream `query()` access (`choices[0].message`, `model_dump()`, cost calc) is unchanged.
- Non-gateway providers keep the original non-streaming call.

Closes #301.

## Root cause (reproduced against the live gateway)

Using GEAK's exact `litellm.completion` form (`openai/claude-opus-4-8`, gateway `api_base`, `max_tokens=16384`):

| Request | Result |
|---|---|
| non-streaming (current) | **400 INVALID_ARGUMENT** |
| **`stream=True` + `stream_chunk_builder`** | **200 OK** |

`stream=True` is the only field that yields 200 — independent of model id and token cap (so it is unrelated to the earlier `claude-opus-4-7` -> `4-8` deployment change).

## Test plan

- [x] `tests/models/test_litellm_model.py` passes (41 passed), incl. two new tests: gateway call forces `stream=True` + reassembles; non-gateway call stays non-streaming.
- [x] Verified end-to-end against the live gateway: streamed call + `stream_chunk_builder` returns content and a `model_dump()`-able response.
- [ ] Observe a live GEAK run against the gateway and confirm preprocess no longer dies with `INVALID_ARGUMENT`.

## Notes

- Usage/cost: `stream_chunk_builder` reconstructs the assembled response; `completion_cost` continues to work on it (verified). `stream_options={"include_usage": true}` was not required.
- `timeout` semantics: the forced-stream branch passes the same `timeout` to `litellm.completion`; chunk iteration happens within the call's lifetime.