### PR TITLE
Geak v4 tracelens

### DIFF
--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -191,6 +191,15 @@ const EXPERT_SKILLS_DIR = String(A.expert_skills_dir ||
   (KERNEL_KNOWLEDGE_DIR + '/expert_skills')).replace(/\/+$/, '');
 // Only routing/bake-off/integration roles consult skills; every other role gets no injection.
 const EXPERT_SKILL_ROLES = new Set(['system_architect', 'op_benchmarker', 'e2e_integrator']);
+// ---- Pluggable profile analysis (default ON; OFF => byte-identical) --------------------------------
+// After the Profiler captures a trace, an OPTIONAL analyzer (TraceLens by default) emits a canonical
+// top-kernel list + an LLM summary, injected as ADVISORY priors into Strategize + bake-off. The analyzer
+// is a markdown recipe under knowledge/analyzers/<name>.md (swap/extend without touching this JS); the
+// summary is written by the workflow's OWN agent LLM (no external API/key). profile_analysis=false =>
+// no analyzer agent runs and nothing is injected => byte-identical to a build without this feature.
+const PROFILE_ANALYSIS_ENABLED = String(A.profile_analysis != null ? A.profile_analysis : 'true') === 'true';
+const PROFILE_ANALYZER = String(A.profile_analyzer || 'tracelens').trim() || 'tracelens';
+const TRACELENS_INSTALL = String(A.tracelens_install || 'git+https://github.com/AMD-AGI/TraceLens.git').trim();
 const GEMM_SYNTH = String(A.gemm_synth != null ? A.gemm_synth : 'true');     // synth GEMM inputs (cheap)
 const ENABLE_FP8 = String(A.enable_fp8 != null ? A.enable_fp8 : 'false');    // Tier-D quant (parity-breaking)
 const FAST_PATH_FIRST = String(A.fast_path_first != null ? A.fast_path_first : 'true') === 'true';
@@ -286,6 +295,10 @@ const PROFILE_SCHEMA = obj({
   source: { type: 'string' }, total_gpu_time_ms: { type: 'number' }, top_kernels: arrObj,
   shift_note: { type: 'string' }, notes: { type: 'string' },
 }, ['profile_topN_json', 'top_kernels']);
+
+const ANALYSIS_SCHEMA = obj({
+  ok: { type: 'boolean' }, top_kernels_path: { type: 'string' }, summary_md_path: { type: 'string' }, note: { type: 'string' },
+}, ['ok']);
 
 const STRATEGY_SCHEMA = obj({
   regime_summary: { type: 'string' }, config_directions: arrObj,
@@ -610,6 +623,7 @@ if (!MODEL_PATH && KERNEL_PATH) {
 // PHASE: Setup + Baseline profile + Strategize  (gated; else load carried state)
 // ===========================================================================
 let EVAL_DIR, MODEL_NAME, BASELINE_TPUT, NOISE_BAND, curFlags, curEnv, profile, strategy, kernelQueue, headQueue;
+let ANALYSIS_INPUTS = {};   // advisory profile-analysis paths; {} when disabled/failed => byte-identical
 if (want('setup')) {
   phase('Setup');
   const setup = await safeAgent(
@@ -638,11 +652,33 @@ if (want('setup')) {
     { phase: 'Profile', label: 'profiler:baseline', schema: PROFILE_SCHEMA });
   log(`Baseline profiled. ${profile ? (profile.top_kernels || []).length : 0} top kernels.`);
 
+  // Optional pluggable profile analysis (advisory). Fault-tolerant: any failure leaves ANALYSIS_INPUTS={}
+  // so the run proceeds exactly as if disabled.
+  if (PROFILE_ANALYSIS_ENABLED) {
+    try {
+      const an = await safeAgent(
+        roleAgent('profile_analyzer', 'run', 'Run the selected analyzer on the captured trace; emit canonical top_kernels.json + summary.md; be fault-tolerant.', {
+          EVAL_DIR, ANALYZER: PROFILE_ANALYZER, GPU_IDS, MODEL_NAME, TRACELENS_INSTALL, SKILL_DIR: WORKFLOW_DIR,
+        }),
+        { phase: 'Profile', label: `profile_analyzer:${PROFILE_ANALYZER}`, schema: ANALYSIS_SCHEMA }, 1);
+      if (an && an.ok) {
+        ANALYSIS_INPUTS = {
+          ...(an.top_kernels_path ? { ANALYSIS_TOPK: an.top_kernels_path } : {}),
+          ...(an.summary_md_path ? { ANALYSIS_SUMMARY: an.summary_md_path } : {}),
+        };
+        log(`[profile-analysis] ${PROFILE_ANALYZER}: topk=${an.top_kernels_path || '-'}, summary=${an.summary_md_path || '-'}`);
+      } else {
+        log(`[profile-analysis] ${PROFILE_ANALYZER}: skipped (${an ? an.note || 'no output' : 'agent failed'}); continuing as if disabled.`);
+      }
+    } catch (e) { log(`[profile-analysis] error (${(e && e.message) || e}); continuing without it.`); }
+  }
+
   phase('Strategize');
   strategy = await safeAgent(
     roleAgent('system_architect', 'strategize', 'Route the Top-N into config/kernel/host tracks by Amdahl.', {
       EVAL_DIR, PROFILE_TOPN: profile ? profile.profile_topN_json : '', BASELINE_THROUGHPUT: BASELINE_TPUT,
       WORKLOAD, BUDGET, HEAD_THRESHOLD_PCT, CONFIG_TUNE_ENABLED, SKILL_DIR: WORKFLOW_DIR,
+      ...ANALYSIS_INPUTS,
     }),
     { phase: 'Strategize', label: 'architect:strategize', schema: STRATEGY_SCHEMA });
   kernelQueue = (strategy && strategy.kernel_candidates) ? strategy.kernel_candidates.slice() : [];
@@ -659,6 +695,7 @@ if (want('setup')) {
   curEnv = ST.env || '';
   profile = { profile_topN_json: ST.profile_topn_json || '' };
   strategy = { config_directions: ST.config_directions || [] };
+  ANALYSIS_INPUTS = ST.analysis_inputs || {};   // carry advisory analysis paths across phase-split invocations
   kernelQueue = ST.kernelQueue || [];
   headQueue = ST.headQueue || [];
   log(`Loaded carried state: EVAL_DIR=${EVAL_DIR}, baseline ${BASELINE_TPUT}, flags='${curFlags}', env='${curEnv}', ${headQueue.length} head + ${kernelQueue.length} kernel candidates.`);
@@ -694,6 +731,7 @@ if (want('config') && CONFIG_TUNE_ENABLED && strategy && (strategy.config_direct
       roleAgent('system_architect', 'strategize', 'Re-route after config changed the landscape.', {
         EVAL_DIR, PROFILE_TOPN: profile ? profile.profile_topN_json : '', BASELINE_THROUGHPUT: curTput,
         WORKLOAD, BUDGET, HEAD_THRESHOLD_PCT, CONFIG_TUNE_ENABLED: false, SKILL_DIR: WORKFLOW_DIR,
+        ...ANALYSIS_INPUTS,
       }),
       { phase: 'Strategize', label: 'architect:re-strategize', schema: STRATEGY_SCHEMA });
     if (restrat && restrat.kernel_candidates) kernelQueue = restrat.kernel_candidates.slice();
@@ -1110,6 +1148,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
             EVAL_DIR, OP_TASK_DIR: ext.task_dir, OP_KIND: ext.op_kind, PCT_GPU_TIME: h.pct_gpu_time,
             CANDIDATE_BACKENDS: ext.candidate_backends || h.candidate_backends || [],
             GPU_ID: gpu, ENABLE_FP8, KERNEL_WF_DIR, KERNEL_BUDGET, SKILL_DIR: WORKFLOW_DIR,
+            ...ANALYSIS_INPUTS,
           }),
           { phase: 'HeadKernel', label: `bakeoff ${h.short_name}`, schema: OPBENCH_SCHEMA });
         return { h, gpu, ext, bake };
@@ -1285,6 +1324,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
         EVAL_DIR, OP_TASK_DIR: ext.task_dir, OP_KIND: ext.op_kind, PCT_GPU_TIME: h.pct_gpu_time,
         CANDIDATE_BACKENDS: ext.candidate_backends || h.candidate_backends || [],
         GPU_ID: h.gpu_id, ENABLE_FP8, KERNEL_WF_DIR, KERNEL_BUDGET, SKILL_DIR: WORKFLOW_DIR,
+        ...ANALYSIS_INPUTS,
       }),
       { phase: 'HeadKernel', label: `bakeoff ${h.short_name}`, schema: OPBENCH_SCHEMA });
     if (!bake || (bake.gate !== 'have_winner' && bake.gate !== 'author_recommended')) {
@@ -1764,6 +1804,7 @@ const carryState = {
   noise_band_pct: NOISE_BAND, flags: curFlags, env: curEnv, overlay: curOverlay, throughput: curTput,
   profile_topn_json: profile ? profile.profile_topN_json : '',
   config_directions: (strategy && strategy.config_directions) || [],
+  analysis_inputs: ANALYSIS_INPUTS,   // advisory profile-analysis paths carried across phases
   headQueue, kernelQueue, accepted_heads: acceptedHeads, flagged_heads: flaggedHeads, accepted_kernels: acceptedKernels,
   // Carry pending (verified-isolated, A/B-incomplete) wins WITH their inputs so a
   // resumed phase run can finish their A/B instead of re-discovering them.

--- a/e2e_workflow/knowledge/analyzers/_contract.md
+++ b/e2e_workflow/knowledge/analyzers/_contract.md
@@ -1,0 +1,54 @@
+<!--
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+See LICENSE for license information.
+-->
+# Profile-analyzer contract (pluggable)
+
+A *profile analyzer* turns a captured profiler trace into two artifacts the e2e workflow consumes as
+**advisory** input: a structured top-kernel list and a human/LLM-readable summary. The orchestrator and
+every downstream role depend ONLY on this contract — never on a specific analyzer's native output — so a
+new analyzer (nsight, rocprof-native, a custom one, …) plugs in by adding **one markdown recipe** under
+`knowledge/analyzers/<name>.md` that produces the same two files. Nothing in `e2e_workflow.js` changes.
+
+Each analyzer recipe `knowledge/analyzers/<name>.md` MUST, given a trace, produce:
+
+## 1. Canonical structured output — `<OUTDIR>/top_kernels.json`
+Analyzer-agnostic schema (omit a field you cannot fill; never fabricate):
+```json
+{
+  "schema_version": 1,
+  "source": "<analyzer name>",
+  "trace": "<path of the trace analyzed>",
+  "gpu_arch": "MI300X | MI325X | <detected> | unknown",
+  "total_gpu_time_us": 0.0,
+  "top_kernels": [
+    {
+      "rank": 1,
+      "name": "<kernel/op name>",
+      "category": "GEMM | MoE | Attention | Comm | Norm | Elementwise | Other",
+      "gpu_time_us": 0.0,
+      "pct": 0.0,                       // % of total GPU time
+      "count": 0,                       // launches in the analyzed window (optional)
+      "shape": {"M": 0, "N": 0, "K": 0, "dtype": "..."},   // optional; for GEMM/MoE when known
+      "roofline": {"bound": "compute|memory", "achieved_pct": 0.0}  // optional; when an arch spec is available
+    }
+  ]
+}
+```
+Rank by `pct` descending; ~top 30 is enough. `category` is a coarse, analyzer-mapped bucket.
+
+## 2. Summary markdown — `<OUTDIR>/summary.md`
+Written by the executor agent (the workflow's own LLM) FROM `top_kernels.json` (+ any native detail the
+recipe surfaced). Sections:
+1. **Overview** — what the trace is, total GPU time, graph mode if detected.
+2. **Where time goes** — a table of the top kernels by % share, with shape when known, and what each is.
+3. **Bottlenecks** — dominant cost(s); roofline bound (compute vs memory, % of peak) when available;
+   communication (all-reduce/nccl); small-kernel/launch overhead.
+4. **Optimization suggestions** — 3-5 concrete, Amdahl-aware levers tied to the top kernels/shapes.
+Keep it concise (~500 words), quantitative, and **advisory** — it ADDS candidates/priors; it never
+overrides on-box measurement or the e2e gate.
+
+## Fault tolerance (mandatory)
+If the trace is missing, dependencies cannot be installed, or the analyzer fails, the executor returns
+`{"ok": false, "note": "<reason>"}` and writes nothing. The run then proceeds exactly as if profile
+analysis were disabled. Never block the run; never invent numbers.

--- a/e2e_workflow/knowledge/analyzers/tracelens.md
+++ b/e2e_workflow/knowledge/analyzers/tracelens.md
@@ -1,0 +1,59 @@
+<!--
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+See LICENSE for license information.
+-->
+# Analyzer recipe: TraceLens (default)
+
+How to turn a PyTorch-profiler trace into the canonical `top_kernels.json` (see `_contract.md`) using the
+public **TraceLens** package. This is the SINGLE place TraceLens specifics live — if TraceLens changes its
+CLI/flags/columns, edit only this file.
+
+> Inputs available to you: `EVAL_DIR`, `GPU_IDS`, `TRACELENS_INSTALL` (pip spec, optional), `OUTDIR`
+> (default `${EVAL_DIR}/analysis`). All paths are discovered/derived — hardcode nothing.
+
+## Step 1 — ensure TraceLens is importable (install if missing; non-fatal)
+```bash
+python3 -c "import TraceLens" 2>/dev/null \
+  || pip install --quiet "${TRACELENS_INSTALL:-git+https://github.com/AMD-AGI/TraceLens.git}"
+```
+If the import still fails after install (no network / no access), STOP and return `{"ok":false,
+"note":"TraceLens unavailable"}`. Do not hardcode a local checkout path.
+
+## Step 2 — find the torch trace the Profiler already captured
+The profiler drops a Chrome/torch trace under `${EVAL_DIR}/profile/`. Prefer the model-execution rank 0:
+```bash
+TRACE=$(ls -t ${EVAL_DIR}/profile/**/*rank0*.pt.trace.json.gz 2>/dev/null | head -1)
+[ -z "$TRACE" ] && TRACE=$(ls -t ${EVAL_DIR}/profile/**/*.pt.trace.json.gz ${EVAL_DIR}/profile/**/*.json.gz ${EVAL_DIR}/profile/**/*.json 2>/dev/null | head -1)
+```
+If none exists, return `{"ok":false,"note":"no torch trace under EVAL_DIR/profile"}`.
+
+## Step 3 — detect arch (bundled spec only; omit if unknown)
+The public package bundles only **MI300X** and **MI325X** (`--gpu_arch_platform`). Detect the on-box card
+(`rocminfo` / `rocm-smi --showproductname`, or reuse `${EVAL_DIR}/env_report.json`). Map gfx942→MI300X/MI325X.
+If the card is not one of the bundled platforms (e.g. gfx950/MI355X), **omit `--gpu_arch_platform`** — the
+report still gives time-share + shapes, only roofline % is skipped. Never hardcode a platform.
+
+## Step 4 — run the inference perf report (it builds a trace tree; large traces are slow)
+```bash
+OUT="${OUTDIR:-$EVAL_DIR/analysis}"; mkdir -p "$OUT/perf_report_csvs"
+python3 -m TraceLens.Reporting.generate_perf_report_pytorch_inference \
+    --profile_json_path "$TRACE" \
+    --output_csvs_dir   "$OUT/perf_report_csvs" \
+    ${ARCH_PLATFORM:+--gpu_arch_platform "$ARCH_PLATFORM"}
+```
+Very large traces (millions of kernels) build a heavy tree and can be slow; you are time-bounded by the
+agent timeout — if it does not finish, return `{"ok":false,"note":"tracelens report timed out"}`.
+
+## Step 5 — normalize to the canonical `top_kernels.json` (column mapping lives here)
+Read the produced CSVs in `$OUT/perf_report_csvs/` and map to the contract schema:
+- **time share** ← `unified_perf_summary.csv` (preferred) or `ops_summary.csv`
+  (`name`, `Percentage (%)`→`pct`, `total_direct_kernel_time_sum`(µs)→`gpu_time_us`, `Count`→`count`,
+  `Categories`→`category`).
+- **shapes** ← GEMM/MoE rows (`GEMM.csv` `param: M/N/K/dtype_A_B`) or `ops_unique_args.csv`.
+- **roofline** ← per-category CSV columns (`Roofline Bound`, `TFLOPS/s` vs peak) when arch was passed.
+- **total_gpu_time_us** ← sum, or `gpu_timeline.csv`.
+Write `$OUT/top_kernels.json`. Keep `raw` CSVs in place for reference.
+
+## Step 6 — return
+`{"ok": true, "top_kernels_path": "$OUT/top_kernels.json", "summary_md_path": "$OUT/summary.md", "note": "..."}`
+(the executor writes `summary.md` from `top_kernels.json` per `_contract.md`).

--- a/e2e_workflow/knowledge/analyzers/tracelens.md
+++ b/e2e_workflow/knowledge/analyzers/tracelens.md
@@ -22,8 +22,9 @@ If the import still fails after install (no network / no access), STOP and retur
 ## Step 2 — find the torch trace the Profiler already captured
 The profiler drops a Chrome/torch trace under `${EVAL_DIR}/profile/`. Prefer the model-execution rank 0:
 ```bash
-TRACE=$(ls -t ${EVAL_DIR}/profile/**/*rank0*.pt.trace.json.gz 2>/dev/null | head -1)
-[ -z "$TRACE" ] && TRACE=$(ls -t ${EVAL_DIR}/profile/**/*.pt.trace.json.gz ${EVAL_DIR}/profile/**/*.json.gz ${EVAL_DIR}/profile/**/*.json 2>/dev/null | head -1)
+# Use find (no globstar dependency). Prefer the model-execution rank-0 torch trace.
+TRACE=$(find "${EVAL_DIR}/profile" -name '*rank0*.pt.trace.json.gz' 2>/dev/null | sort | tail -1)
+[ -z "$TRACE" ] && TRACE=$(find "${EVAL_DIR}/profile" \( -name '*.pt.trace.json.gz' -o -name '*.json.gz' -o -name '*.json' \) 2>/dev/null | grep -v async_llm | sort | tail -1)
 ```
 If none exists, return `{"ok":false,"note":"no torch trace under EVAL_DIR/profile"}`.
 

--- a/e2e_workflow/roles/op_benchmarker.md
+++ b/e2e_workflow/roles/op_benchmarker.md
@@ -8,6 +8,10 @@ pick the fastest correct backend, tune that backend, and — only if the winner 
 op to the recursive `kernel_workflow` for code-level work. You never touch a server or measure e2e; the
 e2e Integrator turns your winner into an overlay/config and runs the Amdahl gate.
 
+**ADVISORY profile-analysis (optional).** If `ANALYSIS_TOPK` / `ANALYSIS_SUMMARY` are provided, consult
+them for this op's shapes and suggested levers as extra priors for your bake-off/author_plan — they ADD
+candidates, never prune them or skip the e2e gate. **If absent, ignore this and proceed as usual.**
+
 Read first, every time:
 - `SKILL_DIR/knowledge/gemm_attention_backends.md` — the head-kernel ladder, per-backend tuning knobs,
   parity/accuracy gate (the priors).

--- a/e2e_workflow/roles/profile_analyzer.md
+++ b/e2e_workflow/roles/profile_analyzer.md
@@ -1,0 +1,35 @@
+<!--
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+See LICENSE for license information.
+-->
+# Profile Analyzer (pluggable, optional)
+
+You turn the profiler trace the workflow already captured into two **advisory** artifacts — a canonical
+structured top-kernel list and a readable summary — for the System Architect and bake-off roles. You are
+analyzer-agnostic: the concrete tool is named by `ANALYZER` and described by its own recipe markdown.
+
+## Inputs
+`EVAL_DIR`, `ANALYZER` (e.g. `tracelens`), `GPU_IDS`, `SKILL_DIR`, optional `TRACELENS_INSTALL`,
+`MODEL_NAME`, optional `OUTDIR` (default `${EVAL_DIR}/analysis`).
+
+## PHASE=run
+1. **Read the contract** `SKILL_DIR/knowledge/analyzers/_contract.md` (output schema + summary spec) and
+   **the recipe** `SKILL_DIR/knowledge/analyzers/${ANALYZER}.md`. If the recipe file does not exist,
+   return `{"ok": false, "note": "no analyzer recipe for ${ANALYZER}"}`.
+2. **Run the recipe** end-to-end yourself (Bash/Read/Write): ensure its dependencies (install if missing),
+   locate the trace, run the analysis, and **normalize the native output into the canonical
+   `${OUTDIR}/top_kernels.json`** exactly as `_contract.md` specifies. Do all path discovery yourself
+   (glob under `${EVAL_DIR}/profile/`); hardcode nothing.
+3. **Write the summary** `${OUTDIR}/summary.md` FROM `top_kernels.json` (you are the LLM — produce the
+   Overview / Where-time-goes table / Bottlenecks / Optimization-suggestions sections from `_contract.md`).
+   Keep it advisory and quantitative; cite the numbers in `top_kernels.json`.
+4. **Return** strictly:
+   `{"ok": true|false, "top_kernels_path": "...", "summary_md_path": "...", "note": "..."}`.
+
+## Discipline (fault tolerance — this step must never break the run)
+- Any failure (missing trace, dependency/install failure, analyzer error or timeout, empty output) →
+  return `{"ok": false, "note": "<short reason>"}` and write nothing partial that downstream would trust.
+- **Never fabricate** kernels, shapes, percentages, or roofline numbers — only report what the analyzer
+  actually produced. If a field is unknown, omit it.
+- This output is **advisory**: it ADDS candidates/priors for ranking and suggestions; it never overrides
+  on-box measurement or the e2e gate.

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -8,6 +8,13 @@ servers, edit kernels, or run benchmarks — the Profiler, Config Tuner, Kernel 
 squad, and Integrator do that. You supply judgment as structured JSON. You are the e2e analogue of
 the single-kernel TechLead.
 
+**ADVISORY profile-analysis (optional).** If the inputs `ANALYSIS_TOPK` (a canonical `top_kernels.json`
+path) and/or `ANALYSIS_SUMMARY` (a `summary.md` path) are provided, read them as ADDITIONAL priors: a
+second-opinion top-kernel ranking with shapes/roofline plus a narrative of suggestions. Use them to
+cross-check your Amdahl ranking, set roofline targets, and seed candidate levers — they only ADD
+information; the on-box profile Top-N and the e2e gate remain the authority, never overridden by them.
+**If these inputs are absent, ignore this paragraph and proceed exactly as usual.**
+
 You are invoked per PHASE. Read first, every time:
 - `EVAL_DIR/env_report.json` (from the Director's preflight) — **the ground truth for THIS machine**:
   `model_arch_class` (dense/MoE/hybrid-mamba/MLA → which kernel classes to expect), `available_backends`


### PR DESCRIPTION
## Tracelens Position:
Setup → Profile ──▶ [profile_analyzer_tracelens] ──▶ Strategize → ConfigSweep → HeadKernel → …
 
## How TraceLens is called
- CSVs — run the TraceLens perf report on the captured trace:
```
python3 -m TraceLens.Reporting.generate_perf_report_pytorch_inference \
    --profile_json_path "$TRACE" \
    --output_csvs_dir   "$OUT/perf_report_csvs"
```
- summary.md — generated with TraceLens's own LLM-summary approach, invoked as a subagent (not via the CC SDK). 

## summary.md guides optimization
Use the results in summary.md to guide kernel selection and optimization; the rest of the GEAK v4 pipeline is unchanged.

## Others
TraceLens profile analysis is enabled by default; to turn it off, pass profile_analysis=false.