### PR TITLE
wire upstream TraceLens prior into the GEAK e2e optimization pipeline

### DIFF
--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -32,6 +32,21 @@ const KERNEL_WF_SCRIPT = `${KERNEL_WF_DIR}/kernel_workflow.js`;
 // EXP_ROOT = where timestamped run dirs go. Default: sibling "exp/" next to this workflow dir.
 const EXP_ROOT = String(A.exp_root || (WORKFLOW_DIR.replace(/\/[^/]*$/, '') + '/exp')).replace(/\/+$/, '');
 
+// ---- Upstream TraceLens / kernel-agent prior (OPTIONAL; forwarded by run_e2e.py as args.tracelens) ----
+// run_e2e.py resolves these paths beside the perfskills handoff and forwards ONLY the non-null ones.
+// They are a PRIOR for the Profile/Strategize/Extract phases: if analysis_md exists the Profiler skips
+// its own trace collection and builds the Top-N from TraceLens (and runs an EXTRA parse_profile pass on
+// trace_file when present); the Architect uses kernel_candidates as a routing prior. ENTIRELY ADDITIVE:
+// when args.tracelens is absent every TRACELENS_* input is '' and the run is byte-identical.
+const TL = (A.tracelens && typeof A.tracelens === 'object') ? A.tracelens : {};
+const TRACELENS_INPUTS = {
+  TRACELENS_ANALYSIS_MD: String(TL.analysis_md || ''),
+  TRACELENS_KERNEL_CANDIDATES_JSON: String(TL.kernel_candidates_json || ''),
+  TRACELENS_REPORT_JSON: String(TL.tracelens_report_json || ''),
+  TRACELENS_TRACE_FILE: String(TL.trace_file || ''),
+};
+if (TL && Object.keys(TL).length) log(`TraceLens prior present: ${Object.keys(TL).filter(k => TL[k]).join(', ') || '(none non-null)'}.`);
+
 // ---- single-kernel pass-through: if kernel_path (and no model_path), just run the kernel layer ----
 const KERNEL_PATH = A.kernel_path || '';
 const MODEL_PATH = A.model_path || '';
@@ -677,6 +692,7 @@ if (want('setup')) {
     roleAgent('profiler', 'baseline', 'Capture a warm trace and emit the standardized Top-N.', {
       EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, ROUND: 0,
       OVERLAY_PYTHONPATH: '', EXTRA_SERVER_ARGS: curFlags, EXTRA_ENV: curEnv, SKILL_DIR: WORKFLOW_DIR,
+      ...TRACELENS_INPUTS,
     }),
     { phase: 'Profile', label: 'profiler:baseline', schema: PROFILE_SCHEMA });
   log(`Baseline profiled. ${profile ? (profile.top_kernels || []).length : 0} top kernels.`);
@@ -686,6 +702,7 @@ if (want('setup')) {
     roleAgent('system_architect', 'strategize', 'Route the Top-N into config/kernel/host tracks by Amdahl.', {
       EVAL_DIR, PROFILE_TOPN: profile ? profile.profile_topN_json : '', BASELINE_THROUGHPUT: BASELINE_TPUT,
       WORKLOAD, BUDGET, HEAD_THRESHOLD_PCT, CONFIG_TUNE_ENABLED, SKILL_DIR: WORKFLOW_DIR,
+      ...TRACELENS_INPUTS,
     }),
     { phase: 'Strategize', label: 'architect:strategize', schema: STRATEGY_SCHEMA });
   kernelQueue = (strategy && strategy.kernel_candidates) ? strategy.kernel_candidates.slice() : [];

--- a/e2e_workflow/roles/kernel_extractor.md
+++ b/e2e_workflow/roles/kernel_extractor.md
@@ -26,9 +26,13 @@ You are invoked once per kernel candidate. Read first:
 
 Inputs: `EVAL_DIR`, `MODEL_PATH`, `GPU_ID`, `WORKLOAD`, `KERNEL` (the Architect's candidate:
 short_name, classification, extract_hint = the `module:attr` callable to hook, candidate_backends,
-regime), `CURRENT_FLAGS`/`CURRENT_ENV`, `SKILL_DIR`.
+regime, and — when an upstream TraceLens prior was available — OPTIONAL `source_hint` (resolved source
+file), `launcher_hint` (launcher seam), `bound_type`), `CURRENT_FLAGS`/`CURRENT_ENV`, `SKILL_DIR`.
 
-1. **Locate the source.** Resolve the kernel's defining file in the installed package
+1. **Locate the source.** **If `KERNEL.source_hint`/`KERNEL.launcher_hint` is provided (TraceLens
+   pre-resolved the file/seam), look there FIRST** — but always CONFIRM by importing the package +
+   grepping the `short_name`/`module:attr` target; never trust the hint blindly (it may point at a
+   launcher/wrapper rather than the true defining file). If no hint, resolve as usual
    (`python3 -c "import sglang,os;print(os.path.dirname(sglang.__file__))"`, then grep the
    `short_name` / the `module:attr` target). Confirm it's truly editable (Triton/custom/aiter) — if
    it resolves to a library GEMM/attention, STOP and report `editable=false` (it belongs to the
@@ -102,8 +106,17 @@ GEMM, CK attention) with a clean math contract, so it does NOT need a copy of ed
 needs an op task dir the **Op Benchmarker** can bake-off across backends. `edit=N` is fine here.
 
 Inputs: `EVAL_DIR`, `MODEL_PATH`, `GPU_ID`, `WORKLOAD`, `KERNEL` (Architect head candidate: short_name,
-op_kind=gemm|attn, the profiled `shapes`, dtype, regime, `target_callable` for attn), `GEMM_SYNTH`
-(bool, default true), `CURRENT_FLAGS`/`CURRENT_ENV`, `SKILL_DIR`.
+op_kind=gemm|attn, the profiled `shapes`, dtype, regime, `target_callable` for attn, and OPTIONAL
+TraceLens `source_hint`/`launcher_hint`/`bound_type`), `GEMM_SYNTH` (bool, default true),
+`CURRENT_FLAGS`/`CURRENT_ENV`, `SKILL_DIR`.
+
+> **TraceLens shape double-check (mandatory when the shapes came from TraceLens).** If `KERNEL.shapes`
+> originated from the upstream `analysis.md`/`kernel_candidates.json` prior, treat them ONLY as a
+> starting hint — they "不一定准" (may be inaccurate, mis-parsed from the `<br>` arg list, or for the
+> wrong regime). You MUST re-verify them against a live capture (the `capture_shapes.py` overlay below,
+> or the profiler's own torch-trace `profile_topN.json` shapes) before freezing the unittest, and use
+> the live-captured `(M,N,K)`/dtype as authoritative whenever they disagree. Note any correction in
+> `notes`.
 
 ### op task-dir contract (what op_bench.py + Op Benchmarker expect)
 ```

--- a/e2e_workflow/roles/profiler.md
+++ b/e2e_workflow/roles/profiler.md
@@ -28,6 +28,57 @@ classification semantics) and `SKILL_DIR/knowledge/sglang_internals.md` (profile
 Inputs: `EVAL_DIR`, `MODEL_PATH`, `BACKEND`, `GPU_ID`, `WORKLOAD` (isl/osl/conc), `ROUND`,
 `OVERLAY_PYTHONPATH` (empty for baseline; set after a kernel change for reprofile),
 `EXTRA_SERVER_ARGS`/`EXTRA_ENV` (the current accepted config), `SKILL_DIR`.
+OPTIONAL upstream TraceLens prior (may be empty strings — treat empty/missing as "not provided"):
+`TRACELENS_ANALYSIS_MD`, `TRACELENS_KERNEL_CANDIDATES_JSON`, `TRACELENS_REPORT_JSON`,
+`TRACELENS_TRACE_FILE`.
+
+### Step 0 — TraceLens fast-path (PHASE=baseline / ROUND 0 ONLY; skip entirely for any reprofile)
+
+An upstream orchestrator may already have profiled the SAME baseline workload with TraceLens. Use it to
+**avoid re-collecting a trace** when it is available:
+
+- **If `TRACELENS_ANALYSIS_MD` is a non-empty path that EXISTS on disk → SKIP the internal trace
+  collection (steps 1–2 below).** Build the standardized Top-N directly from the TraceLens artifacts
+  instead of launching the profiler bench. Prefer the machine-readable
+  `TRACELENS_KERNEL_CANDIDATES_JSON` (else `TRACELENS_REPORT_JSON`) — its `hot_kernels[]` carry, per
+  entry: `name`, `gpu_pct`, `call_count`, `duration_us`, `efficiency_percent`, `bound_type`,
+  `kernel_category`/`tracelens_category`, `source_file`/`source_path`, `kernel_path`/
+  `launcher_source_file`, `shapes`/`input_shapes` (a `<br>`-joined "(dims) dtype" list), and
+  `op_to_source_patchable`. Map them into the canonical `profile_topN.json` schema (same fields the
+  parser emits): `short_name`←name, `pct_gpu_time`←gpu_pct, `calls`←call_count,
+  `total_ms`←duration_us/1000, `avg_us`←duration_us/call_count, `shapes`/`dtypes`←parsed from the
+  `<br>` args, `classification`←map from `kernel_category`/`bound_type` (MoE/grouped-GEMM→library_gemm
+  or triton per `kernel_kind`; attention→library_attn; etc.), `editable`←`op_to_source_patchable`. Carry
+  `source_file`/`kernel_path` into each entry's `notes` (the Architect/Extractor reuse them). Write
+  `profile_topN.json` + `.md` via your own Write (you may shell out to `parse_profile.py` only if you
+  also have a trace; otherwise assemble the JSON yourself) and set `source:"tracelens"`.
+- **If `TRACELENS_TRACE_FILE` is also a non-empty path that EXISTS → run an ADDITIONAL trace-analysis
+  pass on top of analysis.md to sharpen the picture** (this is required by contract when the trace is
+  present). `TRACELENS_TRACE_FILE` is a `torch_trace` **directory** that holds one steady-state serving
+  trace PER TP rank at top level (e.g. `dp0_pp0_tp0..._rank0.*.pt.trace.json.gz`) PLUS a
+  `capture_traces/` subdir of CUDA-graph *warmup/capture* traces. `parse_profile.py` reads ONE trace, so
+  pick the **top-level rank0 serving** trace and IGNORE `capture_traces/` (graph-capture warmup would
+  mislead the ranking):
+  ```bash
+  # Prefer the top-level rank0 serving trace; never recurse into capture_traces/.
+  TLT=$(ls -1 "$TRACELENS_TRACE_FILE"/*rank0*.pt.trace.json.gz 2>/dev/null | head -1)
+  [ -z "$TLT" ] && TLT=$(ls -1 "$TRACELENS_TRACE_FILE"/*.pt.trace.json.gz "$TRACELENS_TRACE_FILE"/*.json.gz "$TRACELENS_TRACE_FILE"/*.json 2>/dev/null | head -1)
+  [ -n "$TLT" ] && python3 "$EVAL_DIR/parse_profile.py" --torch-trace "$TLT" \
+    --top 25 --out "$EVAL_DIR/profile/round_${ROUND}/profile_topN_tracelens"
+  ```
+  Then **reconcile**: the parser's per-launch `shapes`/`dtypes` are derived directly from the trace and
+  are MORE RELIABLE than the `<br>` shapes in `analysis.md` — **prefer the parser shapes for any kernel
+  that matches** (this is the mandatory shape double-check, since `analysis.md` shapes "不一定准"). Keep
+  the TraceLens ranking/`%gpu` as the primary impact signal, but cross-check that the same heads top both
+  views; note any disagreement in `notes`. Emit the final reconciled `profile_topN.json`/`.md` with
+  `source:"tracelens+trace"`.
+- **If `TRACELENS_ANALYSIS_MD` is empty/missing (or the file does not exist) → ignore TraceLens entirely
+  and run the normal collection (steps 1–5) unchanged.** Likewise, for ANY reprofile round the TraceLens
+  prior is stale (it reflects the baseline config) — ignore it and re-collect.
+
+After the fast-path you may still apply the §5 per-call distribution sanity to the resulting Top-N. Then
+return the same JSON contract below (with `source` set as above). Do NOT fail if TraceLens is partial —
+degrade to whatever is available, and if both analysis.md and trace are unusable, fall back to steps 1–5.
 
 1. Capture a trace with a warm server using the shared bench script (the adapter sets the stack's
    torch-profiler dir and runs the bounded `--profile` bench):
@@ -97,7 +148,7 @@ Return JSON:
   "round": 0,
   "profile_topN_json": "<EVAL_DIR>/profile/round_0/profile_topN.json",
   "profile_topN_md": "<EVAL_DIR>/profile/round_0/profile_topN.md",
-  "source": "torch-trace|merged",
+  "source": "torch-trace|merged|tracelens|tracelens+trace",
   "total_gpu_time_ms": 0.0,
   "top_kernels": [
     {"rank": 1, "short_name": "...", "classification": "...", "pct_gpu_time": 0.0,

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -64,6 +64,9 @@ admits*, not by the edit flag:
 Inputs: `EVAL_DIR`, `PROFILE_TOPN` (path to profile_topN.json + inline top entries),
 `BASELINE_THROUGHPUT`, `WORKLOAD` (isl/osl/conc → tells you prefill vs decode regime mix),
 `BUDGET` (max kernel-optimization tasks), `CONFIG_TUNE_ENABLED` (bool), `SKILL_DIR`.
+OPTIONAL upstream TraceLens prior (may be empty strings — treat empty/missing as "not provided"):
+`TRACELENS_KERNEL_CANDIDATES_JSON`, `TRACELENS_REPORT_JSON`, `TRACELENS_ANALYSIS_MD`,
+`TRACELENS_TRACE_FILE`.
 
 0. Read `EVAL_DIR/env_report.json`. Let `model_arch_class` set expectations (e.g. MoE → expect
    grouped/fused-MoE GEMM in the Top-N; hybrid-mamba → expect linear-attn Triton kernels; MLA → expect
@@ -73,6 +76,19 @@ Inputs: `EVAL_DIR`, `PROFILE_TOPN` (path to profile_topN.json + inline top entri
    (use the backend playbook priors for plausible_speedup per class, keyed by `model_class`+`gfx` when
    present). Note the regime each serves (large-M shape = prefill, small-M/batch = decode). **Dedupe
    GEMMs by shape** — one bake-off per distinct (shape,dtype) covers all its launches.
+1b. **TraceLens prior (ADVISORY — only if `TRACELENS_KERNEL_CANDIDATES_JSON` / `TRACELENS_REPORT_JSON`
+   is a non-empty path that EXISTS).** Read its `hot_kernels[]`. Each entry pre-resolves things you would
+   otherwise hand to the Extractor: `source_file`/`source_path` (the patched python source),
+   `kernel_path`/`launcher_source_file` (the launcher seam), `kernel_category`/`tracelens_category`,
+   `bound_type` (memory|compute), `efficiency_percent`, and `op_to_source_patchable`. Use it ONLY to
+   (a) **cross-check** that your measured heads line up with TraceLens's hot kernels (note any
+   disagreement), and (b) **enrich** each `head_candidate`/`kernel_candidate` you emit with a
+   `source_hint` (the matching `source_file`/`source_path`), a `launcher_hint`
+   (`kernel_path`/`launcher_source_file`), and `bound_type` — so the Kernel Extractor can locate the
+   source/seam faster. **NEVER let TraceLens override the on-box measured `pct_gpu_time`/ranking — the
+   profile is the judge; TraceLens only ADDs hints/candidates, never prunes them.** Treat any `shapes` it
+   carries as a STARTING hint that the Extractor will re-verify against a live capture (they "不一定准").
+   If the prior is absent, proceed exactly as before.
 2. Partition the Top-N into FOUR routes (by what optimization the op admits, NOT by edit flag):
    - **config fast path** — service-level env/flag with no op isolation: `--attention-backend` swap,
      `--quantization fp8`, cuda-graph, torch-compile, kv-cache-dtype, scheduling/mem knobs → Config
@@ -105,12 +121,18 @@ Return JSON:
      "shapes": "[[1024,5120],[5120,34816]]", "dtype": "bf16", "regime": "prefill|decode|both",
      "transpose_b": true, "bias": false,
      "candidate_backends": ["aiter","hipblaslt","triton","ck"],
-     "amdahl_priority": 0.0, "rationale": "why this is the head; what win to expect"}
+     "amdahl_priority": 0.0, "rationale": "why this is the head; what win to expect",
+     "source_hint": "<TraceLens source_file/source_path if any, else ''>",
+     "launcher_hint": "<TraceLens kernel_path/launcher_source_file if any, else ''>",
+     "bound_type": "<memory|compute|'' from TraceLens>"}
   ],
   "kernel_candidates": [
     {"id": "k0", "short_name": "...", "classification": "...", "pct_gpu_time": 0.0,
      "regime": "prefill|decode|both", "candidate_backends": ["triton","hip","ck","asm"],
-     "amdahl_priority": 0.0, "extract_hint": "which callable to hook (module:attr) + why"}
+     "amdahl_priority": 0.0, "extract_hint": "which callable to hook (module:attr) + why",
+     "source_hint": "<TraceLens source_file/source_path if any, else ''>",
+     "launcher_hint": "<TraceLens kernel_path/launcher_source_file if any, else ''>",
+     "bound_type": "<memory|compute|'' from TraceLens>"}
   ],
   "drop_list": [{"short_name": "...", "why": "below Amdahl threshold"}],
   "order_of_work": ["config fast path first", "then h0 (GEMM #1)", "then k0", "..."],

--- a/interface/run_e2e.md
+++ b/interface/run_e2e.md
@@ -79,10 +79,43 @@ a ~10-15% 口径 gap. Both default to `0` (fixed) so the standalone and forwarde
 | `accepted_env` | `initial_extra_env` | seeds baseline env |
 | `launch_recipe` | `launch_script` | optional |
 | `exp_root` | `exp_root` | run dir root |
+| (derived from `exp_root`) | `tracelens` | auto-discovered upstream TraceLens / kernel-agent artifacts (see below); only non-null paths forwarded; key omitted entirely when none found |
 | `bench_client` / `inferencex_path` | env `BENCH_CLIENT` + `INFERENCEX_PATH` | exported so every `bench_e2e.sh` call inherits it (not a JS arg) |
 | `bench_protocol.{random_range_ratio,num_prompts,num_warmups,seed}` | env `RANDOM_RANGE_RATIO` / `NUM_PROMPTS` / `NUM_WARMUPS` / `SEED` | `run_e2e.py:apply_bench_protocol` exports ONLY the provided keys, overriding `bench_e2e.sh` standalone defaults; absent ⇒ defaults kept (not a JS arg) |
 | — | `config_tune="false"` | caller already did config search; never double-run |
 | — | `apply_to_original="true"` | so `final/final_launch.sh` + overlay are emitted for sweep reuse |
+
+### TraceLens prior auto-discovery (owned by `run_e2e.py:resolve_tracelens_report`)
+
+An upstream orchestrator may have already profiled the SAME baseline workload with
+TraceLens and dropped its artifacts beside the handoff's `perfskills` dir (i.e.
+under the experiment root = the parent of `perfskills`). `map_args` resolves them
+by glob (each `**` is a randomly-named nested dir) and forwards the **non-null**
+paths to the workflow as `args.tracelens`:
+
+| key | glob (relative to the experiment root) | what it is |
+|---|---|---|
+| `analysis_md` | `kernel-agent/**/tracelens/analysis.md` | human TraceLens hot-kernel report |
+| `kernel_candidates_json` | `kernel-agent/**/kernel_candidates.json` | machine-readable hot-kernel list (name/category/source_file/launcher/shapes/bound_type/…) |
+| `tracelens_report_json` | `kernel-agent/**/tracelens/tracelens_report.json` | full TraceLens report (same `hot_kernels[]` shape) |
+| `trace_file` | `runs/roofline/**/torch_trace` | the roofline torch-trace **directory** (per-TP-rank `*.pt.trace.json.gz`) |
+
+Resolution prefers the parent of the `perfskills` segment in `exp_root`; if that
+path is not present on the box it falls back to the on-disk grandparent of the
+handoff file. The same four paths are also surfaced (with nulls) in the human
+`tracelens_report` block of the driver prompt.
+
+**How the workflow uses it (entirely additive — a tracelens-less run is byte-identical):**
+the Profiler reads `args.tracelens` and, **only when `analysis_md` exists, SKIPS its
+own warm-server trace collection** and builds the standardized Top-N from the
+TraceLens artifacts; **when `trace_file` also exists it runs an ADDITIONAL
+`parse_profile.py` pass** on the rank0 serving trace to recover real kernel
+symbols + reliable per-launch shapes and reconcile them (TraceLens `analysis.md`
+shapes are treated as a hint and double-checked). The System Architect uses
+`kernel_candidates.json` as an advisory routing prior (enriching candidates with
+`source_hint`/`launcher_hint`/`bound_type`) without ever overriding the measured
+`%gpu`. When `args.tracelens` is absent (or for any post-config reprofile, where
+the baseline prior is stale) the workflow profiles/strategizes exactly as before.
 
 ## `result.json` (workflow → caller)
 

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -25,6 +25,7 @@ path. See interface/run_e2e.md for the full contract.
 from __future__ import annotations
 
 import atexit
+import glob
 import json
 import os
 import shutil
@@ -149,11 +150,83 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
         ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         eval_dir = str(Path(h["exp_root"]) / f"e2e_{model_name}_{ts}")
     ps_args["eval_dir"] = eval_dir
+    # Bridge the upstream TraceLens / kernel-agent artifacts INTO the workflow args
+    # (not just the driver prompt) so the JS Profile/Strategize/Extract phases can
+    # use them as a prior. Only non-null paths are forwarded; when nothing is found
+    # the key is omitted entirely, so a tracelens-less run is byte-identical.
+    tl = resolve_tracelens_report(h.get("exp_root", ""))
+    tl_paths = {k: v for k, v in tl.items() if k != "search_root" and v}
+    if tl_paths:
+        ps_args["tracelens"] = tl_paths
     return ps_args
+
+
+# ---------------------------------------------------------------------------
+# TraceLens / kernel-agent artifact discovery.
+# ---------------------------------------------------------------------------
+# The four artifacts live ABOVE the handoff's ``perfskills`` directory, under
+# the experiment root (the parent of ``perfskills``). ``**`` denotes one or
+# more randomly-named nested directories, so the lookup is glob based
+# (recursive) and stays generic across runs.
+_TRACELENS_ARTIFACT_PATTERNS = {
+    "analysis_md": "kernel-agent/**/tracelens/analysis.md",
+    "kernel_candidates_json": "kernel-agent/**/kernel_candidates.json",
+    "tracelens_report_json": "kernel-agent/**/tracelens/tracelens_report.json",
+    "trace_file": "runs/roofline/**/torch_trace",
+}
+
+
+def _experiment_root_from_exp_root(exp_root: str) -> str:
+    """Return the experiment root (the directory that CONTAINS ``perfskills``).
+
+    ``handoff.exp_root`` points at ``<experiment_root>/perfskills`` so the four
+    TraceLens artifacts live one level up, beside ``perfskills``.
+    """
+    norm = str(exp_root or "").rstrip("/")
+    if os.path.basename(norm) == "perfskills":
+        return os.path.dirname(norm)
+    return norm
+
+
+def _find_latest_artifact(root: str, pattern: str) -> str | None:
+    """Return the latest match for ``pattern`` under ``root`` (or None).
+
+    Matches are sorted for determinism; the timestamps embedded in the run
+    directory names sort chronologically, so the last entry is the most recent.
+    """
+    matches = sorted(glob.glob(os.path.join(root, pattern), recursive=True))
+    return matches[-1] if matches else None
+
+
+def resolve_tracelens_report(exp_root: str) -> dict:
+    """Resolve the four TraceLens artifacts beside the handoff's ``perfskills``.
+
+    Returns a dict with ``search_root`` plus the four artifact paths
+    (``analysis_md``, ``kernel_candidates_json``, ``tracelens_report_json``,
+    ``trace_file``); any artifact that cannot be located is ``None``.
+    """
+    root = _experiment_root_from_exp_root(exp_root)
+    report: dict = {"search_root": root}
+    for key, pattern in _TRACELENS_ARTIFACT_PATTERNS.items():
+        report[key] = _find_latest_artifact(root, pattern) if root else None
+    return report
 
 
 def build_prompt(ps_args: dict) -> str:
     eval_dir = ps_args.get("eval_dir", "")
+    # Locate the upstream TraceLens / kernel-agent artifacts (analysis.md,
+    # kernel_candidates.json, tracelens_report.json) plus the roofline torch
+    # trace, and surface them to the agent as a single tracelens_report block.
+    tracelens_report = resolve_tracelens_report(ps_args.get("exp_root", ""))
+    # The prompt only needs the four artifact paths, not the internal search_root.
+    tracelens_prompt_payload = {
+        k: v for k, v in tracelens_report.items() if k != "search_root"
+    }
+    tracelens_block = (
+        "\n\ntracelens_report (upstream kernel-agent / roofline artifacts; "
+        "any path is null when that artifact was not produced):\n"
+        f"  {json.dumps(tracelens_prompt_payload)}\n"
+    )
     # NOTE: the wall-clock budget is NOT surfaced in this prompt. The top driver
     # agent only invokes the Workflow tool once and waits, so it never acts on the
     # budget; enforcement lives entirely in the JS (the time_budget_s arg drives the
@@ -174,6 +247,7 @@ def build_prompt(ps_args: dict) -> str:
         f'"{eval_dir}/workflow_return.json" does not exist when the tool returns, '
         "write that exact return value there yourself with the Write tool before "
         "printing. Print nothing after the JSON line."
+        + tracelens_block
     )
 
 


### PR DESCRIPTION
## Summary

Make the GEAK e2e workflow consume the upstream **TraceLens / kernel-agent**
analysis that the orchestrator already produced for the same baseline workload,
instead of re-discovering everything from scratch. The four artifacts are
auto-discovered beside the handoff's `perfskills` dir, forwarded into the
workflow, and used as a prior by the Profile / Strategize / Extract phases.

The change is **entirely additive and null-safe**: when no TraceLens artifacts
are found (or for any post-config reprofile, where the baseline prior is stale)
the workflow profiles/strategizes exactly as before — a tracelens-less run is
byte-identical.

## Motivation

`run_e2e.py` already surfaced a `tracelens_report` block in the driver prompt,
but those paths were **never threaded into the workflow args**, so the JS
phases and role agents could not use them. TraceLens already provides hot-kernel
names, source files, launcher seams, categories, bound types, and shapes — and a
full roofline torch-trace — which overlaps with GEAK's own Profile/Strategize/
Extract work. Reusing it lets GEAK skip an expensive warm-server profiling pass
and start optimization from a richer prior.

## What changed

**`interface/run_e2e.py`**
- `resolve_tracelens_report()` + helpers: glob-discover the four artifacts under
  the experiment root (parent of `perfskills`), with a fallback to the on-disk
  grandparent of the handoff when `exp_root` is not present on the box.
- `map_args()` now injects the **non-null** resolved paths as `args.tracelens`
  (bridge into the JS workflow); the key is omitted entirely when none are found.
- `build_prompt()` still renders a human-readable `tracelens_report` block.

**`e2e_workflow.js`**
- Parse `args.tracelens` into `TRACELENS_INPUTS` and thread it into the
  **baseline Profile** and **first Strategize** role inputs only (post-config
  reprofile/re-strategize are intentionally excluded — the baseline prior is
  stale once config changes). Empty when absent ⇒ byte-identical.

**`roles/profiler.md`**
- New "Step 0 — TraceLens fast-path" (PHASE=baseline / ROUND 0 only):
  - If `analysis_md` exists → **skip internal trace collection** and build the
    canonical `profile_topN.json` from `kernel_candidates.json`/`tracelens_report.json`.
  - If `trace_file` also exists → run an **additional `parse_profile.py` pass**
    on the top-level **rank0** serving trace (ignoring `capture_traces/` graph
    warmups) and reconcile: prefer the parser's per-launch shapes (the mandatory
    shape double-check, since analysis.md shapes are unreliable).
  - Missing/empty, or any reprofile → unchanged collection.

**`roles/system_architect.md`**
- New advisory step 1b: read `kernel_candidates.json` as a routing prior;
  cross-check measured heads and enrich `head_candidates`/`kernel_candidates`
  with `source_hint` / `launcher_hint` / `bound_type`. Never overrides the
  on-box measured `pct_gpu_time`.

**`roles/kernel_extractor.md`**
- Use `KERNEL.source_hint`/`launcher_hint` as the first place to locate the
  source/seam (still confirmed by import+grep, never trusted blindly).
- Mandatory TraceLens shape double-check against a live capture before freezing
  the unittest.

**`interface/run_e2e.md`**
- Document the new `args.tracelens` mapping row + a "TraceLens prior
  auto-discovery" section (discovery globs, resolution order, and how the
  workflow consumes it). `handoff.json` contract is unchanged (`schema_version`
  stays `1`); `tracelens` is derived from the existing `exp_root`.

## Compatibility

- No new required handoff field; `tracelens` is derived from `exp_root`.
- Absent artifacts ⇒ key omitted ⇒ unchanged behavior. Reprofile rounds ignore
  the (stale) baseline prior.
- New candidate fields ride on `additionalProperties: true` schemas, so existing
  StructuredOutput validation is unaffected.

## Validation

- `develop_geak/tracelens_integration_check.py`: 11/11 local cases inject the
  correct non-null `args.tracelens`; bogus `exp_root` omits the key (null-safe)
  — ALL PASS.
- `develop_geak/dump_full_prompt.py`: full `build_prompt()` output regenerated
  for all 11 cases.
- Ran `parse_profile.py` on a real roofline trace: it recovers the **real**
  kernel symbol `fused_moe_kernel_gptq_awq` (71.5% GPU, editable) + concrete
  per-launch shapes, vs TraceLens's pseudo-op `pseudo_op::moe_gptq_awq_up` +
  launcher path — confirming the value of the extra analysis + shape double-check.
- `python -c ast.parse` clean on `run_e2e.py`; rank0 trace-selection verified on
  real data.

## Test plan

- [ ] End-to-end dry run: `python interface/run_e2e.py <handoff.json> <result.json> --dry-run`
      and confirm `args.tracelens` appears when artifacts exist.
- [ ] One full e2e run on a case WITH tracelens (skip-collection path) and one
      WITHOUT (legacy path) to confirm parity.