### PR TITLE
fix(rag): make RAG provisioning best-effort, don't abort the run (#316)

### DIFF
--- a/src/minisweagent/run/mini.py
+++ b/src/minisweagent/run/mini.py
@@ -354,53 +354,67 @@ def main(
         if enabled is False:
             disabled_tools.append(tool_name)
 
-    # RAG MCP toggle: disable RAG tools when rag is not enabled
+    # RAG MCP toggle: disable RAG tools when rag is not enabled. RAG is
+    # best-effort — if it is enabled but the package or index cannot be
+    # provisioned (offline node, pip failure, build error), degrade to
+    # RAG-disabled and continue the optimization run instead of aborting the
+    # whole agent. Previously any provisioning failure raised and killed the
+    # run, so an environment hiccup wasted the entire kernel attempt (GH #316).
     rag_enabled = tools_cfg.get("rag", False)
+    rag_failed = False
     if rag_enabled:
-        _repo_root = get_repo_root()
-        # Auto-install rag-mcp package if missing
         try:
-            import rag_mcp  # noqa: F401
-        except ImportError:
-            logger.info("rag-mcp package not found, installing automatically...")
-            _rag_mcp_path = _repo_root / "mcp_tools" / "rag-mcp"
-            result = subprocess.run(
-                [sys.executable, "-m", "pip", "install", "-e", str(_rag_mcp_path)],
-                capture_output=True, text=True,
-            )
-            if result.returncode != 0:
-                raise RuntimeError(
-                    "Auto-install of rag-mcp failed.\n\n"
-                    f"stderr:\n{result.stderr}\n\n"
-                    "Please install manually:\n"
-                    f"  pip install -e {_rag_mcp_path}"
+            _repo_root = get_repo_root()
+            # Auto-install rag-mcp package if missing
+            try:
+                import rag_mcp  # noqa: F401
+            except ImportError:
+                logger.info("rag-mcp package not found, installing automatically...")
+                _rag_mcp_path = _repo_root / "mcp_tools" / "rag-mcp"
+                result = subprocess.run(
+                    [sys.executable, "-m", "pip", "install", "-e", str(_rag_mcp_path)],
+                    capture_output=True, text=True,
                 )
-            logger.info("rag-mcp installed successfully.")
-            # Refresh sys.path so the newly installed package is discoverable
-            import importlib
-            sys.path.insert(0, str(_rag_mcp_path / "src"))
-            importlib.invalidate_caches()
-            import rag_mcp  # noqa: F401
-        # Auto-build semantic index if missing
-        _index_path = Path.home() / ".cache" / "amd-ai-devtool" / "semantic-index"
-        _has_faiss = (_index_path / "index.faiss").exists() or (_index_path / "faiss.index").exists()
-        _has_pkl = bool(list(_index_path.glob("*.pkl"))) if _index_path.exists() else False
-        if not (_has_faiss and _has_pkl):
-            logger.info("RAG index not found at %s, building automatically...", _index_path)
-            _build_script = _repo_root / "scripts" / "build_index.py"
-            result = subprocess.run(
-                [sys.executable, str(_build_script), "--force"],
-                capture_output=True, text=True,
-            )
-            if result.returncode != 0:
-                raise RuntimeError(
-                    "Auto-build of RAG index failed.\n\n"
-                    f"stderr:\n{result.stderr}\n\n"
-                    "Please build manually:\n"
-                    f"  python {_build_script} --force"
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        "Auto-install of rag-mcp failed.\n\n"
+                        f"stderr:\n{result.stderr}\n\n"
+                        "Please install manually:\n"
+                        f"  pip install -e {_rag_mcp_path}"
+                    )
+                logger.info("rag-mcp installed successfully.")
+                # Refresh sys.path so the newly installed package is discoverable
+                import importlib
+                sys.path.insert(0, str(_rag_mcp_path / "src"))
+                importlib.invalidate_caches()
+                import rag_mcp  # noqa: F401
+            # Auto-build semantic index if missing
+            _index_path = Path.home() / ".cache" / "amd-ai-devtool" / "semantic-index"
+            _has_faiss = (_index_path / "index.faiss").exists() or (_index_path / "faiss.index").exists()
+            _has_pkl = bool(list(_index_path.glob("*.pkl"))) if _index_path.exists() else False
+            if not (_has_faiss and _has_pkl):
+                logger.info("RAG index not found at %s, building automatically...", _index_path)
+                _build_script = _repo_root / "scripts" / "build_index.py"
+                result = subprocess.run(
+                    [sys.executable, str(_build_script), "--force"],
+                    capture_output=True, text=True,
                 )
-            logger.info("RAG index built successfully.")
-    else:
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        "Auto-build of RAG index failed.\n\n"
+                        f"stderr:\n{result.stderr}\n\n"
+                        "Please build manually:\n"
+                        f"  python {_build_script} --force"
+                    )
+                logger.info("RAG index built successfully.")
+        except Exception as exc:  # noqa: BLE001 — RAG is best-effort; never abort the run
+            logger.warning(
+                "RAG setup failed (%s); continuing with RAG disabled. The optimization "
+                "run proceeds without RAG retrieval tools.",
+                exc,
+            )
+            rag_failed = True
+    if (not rag_enabled) or rag_failed:
         disabled_tools.append("query")
         disabled_tools.append("optimize")
 


### PR DESCRIPTION
Addresses **one of the four** failure modes in #316 (the `rag-mcp` env crash).

## Problem
When `tools.rag=true` but `rag-mcp` cannot be installed/imported or the semantic index cannot be built (offline node, pip failure), `mini.py` raised `RuntimeError` and **killed the whole kernel-optimization run**. On the GLM-4.7-FP8 sglang fleet run, every GEAK attempt died right after:
```
rag-mcp package not found, installing automatically...
```
i.e. an environment hiccup wasted the entire kernel attempt (all 8 GEAK kernels REVERT, E2E 0%).

## Fix
Make RAG **best-effort**: wrap the provisioning in try/except — on any failure, log a warning, disable the RAG `query`/`optimize` tools, and continue the optimization run without retrieval. RAG-enabled success path is unchanged.

(The large deletion count is just re-indentation from wrapping the existing block in try/except.)

## Scope / not covered
The other three #316 modes remain open and are larger (GEAK-internal): `.cu`/CK `preprocess_failed`, harness-gen "no `@perftest/@benchmark` decorators" on sglang kernels, and `exit 124` timeouts. GLM specifically also needs the `.cu` preprocess fix to actually produce wins.

## Validation
ruff lint + format clean; syntax verified. End-to-end verification needs a live GEAK run (tracked with the broader #316 work).

Refs #316.