### PR TITLE
feat(eval): GEAK_VERIFY_IN_LOOP — full-set in-loop verified speedup, drop redundant post-round FULL_BENCHMARK

### DIFF
--- a/src/minisweagent/run/postprocess/evaluation.py
+++ b/src/minisweagent/run/postprocess/evaluation.py
@@ -748,6 +748,35 @@ def run_correctness_and_benchmark(
     else:
         logger.warning("No CORRECTNESS commands found in COMMANDMENT")
 
+    # --- GEAK_VERIFY_IN_LOOP: trust the in-loop full-set verified benchmark ---
+    # When the subagent's `--benchmark` already runs the FULL weighted shape set
+    # and emits GEAK_RESULT_SPEEDUP (see kernel_languages/contract.py +
+    # subagents/preprocess/harness-generator/SUBAGENT.yaml), the post-round
+    # FULL_BENCHMARK below is a redundant re-timing that ALSO times out on heavy
+    # CK/.cu rebuilds (GEAK_BENCH_TIMEOUT). Skip the FB subprocess, but KEEP the
+    # clean-worktree CORRECTNESS above — it is the only worktree-bypass guard
+    # (see contract.py "always ~1.00x" note). Adopt the already-trusted in-loop
+    # speedup as the verified value so select_best_verified_round_evaluation can
+    # rank it. Default-off => byte-identical to current behaviour.
+    if os.environ.get("GEAK_VERIFY_IN_LOOP", "").strip() == "1":
+        if round_eval.get("status") == "correctness_failed":
+            return
+        in_loop = round_eval.get("benchmark_speedup")
+        round_eval["full_benchmark"] = {
+            "verified_speedup": float(in_loop) if isinstance(in_loop, (int, float)) else None,
+            "candidate_ms": round_eval.get("candidate_shape_latency_ms"),
+            "baseline_ms": round_eval.get("baseline_shape_latency_ms"),
+            "success": True,
+            "source": "in_loop_full_benchmark",
+        }
+        logger.info(
+            "GEAK_VERIFY_IN_LOOP=1: skipping redundant post-round FULL_BENCHMARK; "
+            "adopting in-loop full-set verified_speedup=%s "
+            "(correctness re-checked in clean worktree above).",
+            round_eval["full_benchmark"]["verified_speedup"],
+        )
+        return
+
     # If neither baseline file exists, try to recapture from the COMMANDMENT
     # on the unpatched repo. This covers the case where preprocessing didn't
     # produce a baseline (e.g. non-standard harness that failed validation).

--- a/src/minisweagent/subagents/preprocess/harness-generator/SUBAGENT.yaml
+++ b/src/minisweagent/subagents/preprocess/harness-generator/SUBAGENT.yaml
@@ -62,7 +62,7 @@ system_prompt: |
 
   Harness shape (the four CLI modes)
   - `--full-benchmark`: runs ALL configs from the shape source file. Per-shape latency + dual-signal output markers (see below).
-  - `--benchmark`: runs `_pick(configs, 25)`. Same output format.
+  - `--benchmark`: runs THE SAME full config set as `--full-benchmark` (see "Subsetting" below — both run `_cap(all configs)`; uncapped that is all configs). Same output format. `--benchmark` is the per-step optimization signal best-of-N selects on; it MUST score the same shapes as the final verification, otherwise a kernel can win the benchmark shapes and regress the verification shapes. Do NOT subsample it to 25.
   - `--correctness`: runs correctness check on `_pick(configs, 25)`. Non-zero exit on failure.
   - `--profile`: runs `_pick(configs, 5)`. No correctness.
 


### PR DESCRIPTION
## What
`GEAK_VERIFY_IN_LOOP` (default-off): make the per-candidate **in-loop** benchmark the authoritative full-set verified signal, and **skip the redundant post-round FULL_BENCHMARK** (which currently times out via `GEAK_BENCH_TIMEOUT`).

## Why
Across the last 40h of CI, **0 kernels** ever produced a FULL_BENCHMARK-verified speedup — the post-round re-run times out and `select_best_verified` finds nothing, so only the quick `report_scan` survives. The two harness modes also disagreed (`--benchmark`=`_pick(25)` vs the "same full set" rule), so the optimization signal scored different shapes than verification.

## Changes
- `run/postprocess/evaluation.py`: when `GEAK_VERIFY_IN_LOOP=1`, keep the **clean-worktree CORRECTNESS** (the sole worktree-bypass guard, see `contract.py`), skip the post-round FULL_BENCHMARK timing, and adopt the in-loop full-set `verified_speedup` so `select_best_verified_round_evaluation` ranks it.
- `subagents/preprocess/harness-generator/SUBAGENT.yaml`: resolve the contradiction — `--benchmark` runs the **same full config set** as `--full-benchmark` (no `_pick(25)`).

Default-off ⇒ byte-identical. `py_compile` clean.
