### PR TITLE
feat(profile): add metrix as a fallback profiler in profile_kernel.sh

### DIFF
--- a/kernel_workflow/scripts/profile_kernel.sh
+++ b/kernel_workflow/scripts/profile_kernel.sh
@@ -17,6 +17,7 @@
 #   RPC_PROFILE_ARGS   extra args passed to rocprof-compute/omniperf `profile` (default: "--no-roof")
 #   RPV3_TRACE_ARGS    args passed to rocprofv3 (default: "--kernel-trace --stats --output-format csv")
 #   RPROF_ARGS         args passed to legacy rocprof (default: "--stats")
+#   METRIX_ARGS        args passed to metrix (default: ""; override per `metrix --help` for this toolchain)
 #
 # Fault tolerance: a profiler that fails (e.g. a flag was renamed across toolchain versions) no longer
 # degrades silently. The failure + a self-heal pointer (which env var to override, where the recipe is)
@@ -37,10 +38,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GPU_LOCK="$SCRIPT_DIR/gpu_lock.sh"
 
 WARMUP_RUNS="${WARMUP_RUNS:-3}"
-PROFILER_PRIORITY="${PROFILER_PRIORITY:-rocprof-compute omniperf rocprofv3 rocprof}"
+PROFILER_PRIORITY="${PROFILER_PRIORITY:-rocprof-compute omniperf rocprofv3 rocprof metrix}"
 RPC_PROFILE_ARGS="${RPC_PROFILE_ARGS:---no-roof}"
 RPV3_TRACE_ARGS="${RPV3_TRACE_ARGS:---kernel-trace --stats --output-format csv}"
 RPROF_ARGS="${RPROF_ARGS:---stats}"
+METRIX_ARGS="${METRIX_ARGS:-}"
 
 mkdir -p "$OUTPUT_DIR"
 REPORT="$OUTPUT_DIR/profile_report.txt"
@@ -141,10 +143,30 @@ run_rocprof() {          # legacy: rocprof --stats (HIP dispatch stats).
     [ -s "$REPORT" ] && PROFILE_SUCCESS=true
 }
 
+run_metrix() {           # generic/extensible profiler: env-driven (METRIX_ARGS), harvest any csv/json/txt.
+    local dir="$OUTPUT_DIR/metrix"
+    # NO `rm` (prompts + blocks autonomous runs): move any stale dir aside, then make fresh.
+    [ -e "$dir" ] && mv "$dir" "${dir}.old_$(date +%s)_$$" 2>/dev/null || true
+    mkdir -p "$dir"
+    echo "=== Profiling with metrix ($METRIX_ARGS) ==="
+    local rc=0
+    # No hardcoded flags: pass METRIX_ARGS through and hint the output dir via env (ignored if unused).
+    bash "$GPU_LOCK" "$GPU_ID" env METRIX_OUTPUT_DIR="$dir" \
+        metrix $METRIX_ARGS bash -c "$BENCHMARK_CMD" \
+        > "$OUTPUT_DIR/metrix_run.log" 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ]; then emit_profiler_failure metrix "$rc" METRIX_ARGS "$OUTPUT_DIR/metrix_run.log"; fi
+    { cat "$OUTPUT_DIR/metrix_run.log"; echo ""; } >> "$REPORT" 2>/dev/null || true
+    while IFS= read -r f; do
+        { echo ""; echo "=== metrix artifact: $f ==="; cat "$f"; } >> "$REPORT" 2>/dev/null || true
+    done < <(find "$dir" -type f \( -name '*.csv' -o -name '*.json' -o -name '*.txt' \) 2>/dev/null | sort)
+    [ -s "$REPORT" ] && PROFILE_SUCCESS=true
+}
+
 case "$PROFILER" in
     rocprof-compute|omniperf) run_rocprof_compute "$PROFILER" ;;
     rocprofv3)                run_rocprofv3 ;;
     rocprof)                  run_rocprof ;;
+    metrix)                   run_metrix ;;
     "")                       echo "No profiler found in priority list; benchmark-only." ;;
 esac
 


### PR DESCRIPTION
  ## What
  Append `metrix` to the default `PROFILER_PRIORITY` (last, after `rocprof`) and wire a generic,
  env-driven handler for it in `kernel_workflow/scripts/profile_kernel.sh`.

  ## Why
  Before this, `metrix` could be added to the priority list but the `case "$PROFILER"` had no matching
  branch — on a box where only `metrix` is available it would be selected yet **silently do nothing**
  (degrade to benchmark-only). This wires it up so it actually runs.

  ## How (general, no hardcode, minimal)
  - Reuses the `rocprofv3` pattern: run, then harvest every `*.csv/*.json/*.txt` produced into the report.
  - **Zero hardcoded flags**: `metrix $METRIX_ARGS bash -c "$CMD"`, `METRIX_ARGS` defaults to empty; the
    output dir is *hinted* via the `METRIX_OUTPUT_DIR` env var (ignored if metrix doesn't use it). No
    assumption about metrix's CLI shape.
  - Failures go through the existing `emit_profiler_failure` self-heal path → tells the engineer to set
    `METRIX_ARGS="..."` per `metrix --help` for the local toolchain.
  - One file, +23/−1; all existing profilers untouched.

  ## Note
  If metrix's native invocation is known (e.g. `metrix profile -o dir -- cmd`), set it once via
  `METRIX_ARGS` — no script change needed; or we can adjust the default in a follow-up.