### PR TITLE
feat(workload-align): workload-weighted unittest oracle with regime-aware extraction

### DIFF
--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -340,6 +340,7 @@ const SETUP_SCHEMA = obj({
 
 const PROFILE_SCHEMA = obj({
   round: { type: 'number' }, profile_topN_json: { type: 'string' }, profile_topN_md: { type: 'string' },
+  profile_workload_json: { type: 'string' }, // per-(shape,dtype) weighted workload model (optional)
   source: { type: 'string' }, total_gpu_time_ms: { type: 'number' }, top_kernels: arrObj,
   shift_note: { type: 'string' }, notes: { type: 'string' },
 }, ['profile_topN_json', 'top_kernels']);
@@ -364,6 +365,7 @@ const PLAN_SCHEMA = obj({
 const EXTRACT_OP_SCHEMA = obj({
   short_name: { type: 'string' }, op_kind: { type: 'string' }, editable: { type: 'boolean' },
   task_dir: { type: 'string' }, shapes: { type: 'object', additionalProperties: true },
+  workload_path: { type: 'string' }, // per-(shape,dtype) weighted workload model for this kernel (optional)
   dtype: { type: 'string' }, synthesized: { type: 'boolean' }, regimes_captured: arrStr,
   candidate_backends: arrStr, reference_io_sha256: { type: 'string' },
   target_callable: { type: 'string' }, // module:attr rebind seam for an authored kernel ('' if none)
@@ -589,7 +591,7 @@ async function tryCorrectiveReauthor(spec) {
       fix = await fastBoundedWorkflow({ scriptPath: KERNEL_WF_SCRIPT }, {
         kernel_path: spec.kernel_eval_dir || spec.task_dir, workflow_dir: KERNEL_WF_DIR,
         mode: 'optimize', target_language: spec.language || 'triton',
-        op_spec: { op_kind: spec.op_kind, shapes: spec.shapes || {}, dtype: spec.dtype || 'bf16', regime: spec.regime || '', cuda_graph_safe: true },
+        op_spec: { op_kind: spec.op_kind, shapes: spec.shapes || {}, dtype: spec.dtype || 'bf16', regime: spec.regime || '', cuda_graph_safe: true, ...(spec.workload_path ? { workload_path: spec.workload_path } : {}) },
         perf_knowledge_dir: KERNEL_KNOWLEDGE_DIR,
         use_expert_skills: USE_EXPERT_SKILLS ? 'true' : 'false', expert_skills_dir: EXPERT_SKILLS_DIR,
         budget: KERNEL_BUDGET, gpu_ids: spec.gpu_id, exp_root: `${EVAL_DIR}/kernels/_exp`,
@@ -928,6 +930,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
       const ext = await safeAgent(
         roleAgent('kernel_extractor', 'extract_op', 'Build a standalone op unittest for a head kernel.', {
           EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, KERNEL: h, GEMM_SYNTH,
+          ...(profile && profile.profile_workload_json ? { PROFILE_WORKLOAD_JSON: profile.profile_workload_json } : {}),
           CURRENT_FLAGS: curFlags, CURRENT_ENV: curEnv, SKILL_DIR: WORKFLOW_DIR,
           REQUIRE_DECODE_BUCKET: true, DECODE_M_BUCKETS: [1, CONC],
           PREFILL_M_NOTE: 'also include the profiled large prefill M (chunk size, ~thousands) per (N,K)',
@@ -977,7 +980,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
       const liveBaselineMs = (bake && Number.isFinite(bake.best_known_ms) && bake.best_known_ms > 0) ? bake.best_known_ms : 0;
       const deepDir = `${EVAL_DIR}/deep_head/${h.short_name}`;
       const sharedKb = `${deepDir}/SHARED_KB.md`;
-      const opSpec = { op_kind: ext.op_kind, shapes: ext.shapes || {}, dtype: ext.dtype || 'bf16', regime: h.regime || 'both', cuda_graph_safe: true };
+      const opSpec = { op_kind: ext.op_kind, shapes: ext.shapes || {}, dtype: ext.dtype || 'bf16', regime: h.regime || 'both', cuda_graph_safe: true, ...(ext.workload_path ? { workload_path: ext.workload_path } : {}) };
       const anchor = await safeAgent(
         `You are the ROOFLINE ANCHOR + shared-KB bootstrapper for DEEP cross-backend optimization of head op ${h.short_name} (${ext.op_kind}). ` +
         `Inputs: OP_TASK_DIR=${ext.task_dir}; shapes=${JSON.stringify(ext.shapes || {})}; dtype=${ext.dtype || '?'}; read ${EVAL_DIR}/env_report.json for the on-box device peak (FLOP/s + HBM bandwidth). ` +
@@ -1286,6 +1289,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
         const ext = await safeAgent(
           roleAgent('kernel_extractor', 'extract_op', 'Build a standalone op unittest for a head kernel.', {
             EVAL_DIR, MODEL_PATH, GPU_ID: gpu, WORKLOAD, KERNEL: h, GEMM_SYNTH,
+            ...(profile && profile.profile_workload_json ? { PROFILE_WORKLOAD_JSON: profile.profile_workload_json } : {}),
             CURRENT_FLAGS: curFlags, CURRENT_ENV: curEnv, SKILL_DIR: WORKFLOW_DIR,
             REQUIRE_DECODE_BUCKET: true, DECODE_M_BUCKETS: [1, CONC],
             PREFILL_M_NOTE: 'also include the profiled large prefill M (chunk size, ~thousands) per (N,K)',
@@ -1355,7 +1359,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
           al = await fastBoundedWorkflow({ scriptPath: KERNEL_WF_SCRIPT }, {
             kernel_path: j.ext.task_dir, workflow_dir: KERNEL_WF_DIR,
             mode: j.ap.route === 'rewrite' ? 'optimize' : 'author', target_language: lang,
-            op_spec: { op_kind: j.ext.op_kind, shapes: j.ext.shapes || {}, dtype: j.ext.dtype || 'bf16', regime: j.h.regime || '', cuda_graph_safe: true },
+            op_spec: { op_kind: j.ext.op_kind, shapes: j.ext.shapes || {}, dtype: j.ext.dtype || 'bf16', regime: j.h.regime || '', cuda_graph_safe: true, ...(j.ext.workload_path ? { workload_path: j.ext.workload_path } : {}) },
             perf_knowledge_dir: KERNEL_KNOWLEDGE_DIR,
             use_expert_skills: USE_EXPERT_SKILLS ? 'true' : 'false', expert_skills_dir: EXPERT_SKILLS_DIR,
             budget: KERNEL_BUDGET, gpu_ids: g[0], exp_root: `${EVAL_DIR}/kernels/_exp`,
@@ -1470,6 +1474,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
     const ext = await safeAgent(
       roleAgent('kernel_extractor', 'extract_op', 'Build a standalone op unittest for a head kernel.', {
         EVAL_DIR, MODEL_PATH, GPU_ID: h.gpu_id, WORKLOAD, KERNEL: h, GEMM_SYNTH,
+        ...(profile && profile.profile_workload_json ? { PROFILE_WORKLOAD_JSON: profile.profile_workload_json } : {}),
         CURRENT_FLAGS: curFlags, CURRENT_ENV: curEnv, SKILL_DIR: WORKFLOW_DIR,
         // The unittest MUST span BOTH regimes. Steady-state serving is decode/TPOT-bound, so a
         // head GEMM tuned only on GPU-time-dominant prefill M regresses decode and loses e2e.
@@ -1547,7 +1552,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
           al = await fastBoundedWorkflow({ scriptPath: KERNEL_WF_SCRIPT }, {
             kernel_path: ext.task_dir, workflow_dir: KERNEL_WF_DIR,
             mode: ap.route === 'rewrite' ? 'optimize' : 'author', target_language: lang,
-            op_spec: { op_kind: ext.op_kind, shapes: ext.shapes || {}, dtype: ext.dtype || 'bf16', regime: h.regime || '', cuda_graph_safe: true },
+            op_spec: { op_kind: ext.op_kind, shapes: ext.shapes || {}, dtype: ext.dtype || 'bf16', regime: h.regime || '', cuda_graph_safe: true, ...(ext.workload_path ? { workload_path: ext.workload_path } : {}) },
             perf_knowledge_dir: KERNEL_KNOWLEDGE_DIR,
             use_expert_skills: USE_EXPERT_SKILLS ? 'true' : 'false', expert_skills_dir: EXPERT_SKILLS_DIR,
             budget: KERNEL_BUDGET, gpu_ids: h.gpu_id, exp_root: `${EVAL_DIR}/kernels/_exp`,
@@ -1758,6 +1763,7 @@ while (want('kernel') && !TIME_DEADLINE_HIT && dispatched < BUDGET && (dispatche
       roleAgent('kernel_extractor', 'extract', 'Capture shapes + oracle; emit an immutable unittest task dir.', {
         EVAL_DIR, MODEL_PATH, GPU_ID: c.gpu_id, WORKLOAD, KERNEL: c,
         CURRENT_FLAGS: curFlags, CURRENT_ENV: curEnv, SKILL_DIR: WORKFLOW_DIR,
+        ...(profile && profile.profile_workload_json ? { PROFILE_WORKLOAD_JSON: profile.profile_workload_json } : {}),
       }),
       { phase: 'Milestone', label: `extract ${c.short_name}`, schema: EXTRACT_SCHEMA });
     if (!ext || ext.editable === false || ext.unittest_smoke !== 'pass' || !ext.task_dir) {

--- a/e2e_workflow/roles/kernel_extractor.md
+++ b/e2e_workflow/roles/kernel_extractor.md
@@ -96,11 +96,26 @@ Return JSON:
 }
 ```
 **`workload_path` (optional, performance alignment).** If `PROFILE_WORKLOAD_JSON` is in your inputs
-(the profiler's per-(shape,dtype) weighted model), slice out THIS kernel's entry (match by
-`short_name` / kernel name) and write just that kernel's `{cases:[…]}` to `<task_dir>/workload.json`,
-returning its path. kernel_workflow then benchmarks the real workload shapes weighted by their time
-contribution (correctness still uses the frozen oracle — this only steers timing). Omit the field if
-no workload model is available. This does NOT change the immutable oracle in any way.
+(the profiler's per-kernel WEIGHT SIGNAL from `parse_profile.py --workload-out`), produce a
+workload spec for THIS kernel by JOINING your `meta.json` shape cases with that weight signal — do NOT
+hand-slice or hand-weight it. The join is op_kind-aware and deterministic; run:
+```bash
+python3 "$SKILL_DIR/scripts/attribute_weights.py" \
+  --meta "<task_dir>/meta.json" \
+  --profile-weights "$PROFILE_WORKLOAD_JSON" \
+  --name-match "<the kernel's base symbol, e.g. _gemm_a8w8_blockscale_kernel>" \
+  --min-regime-share 0.3 \
+  --out "<task_dir>/workload.json"
+```
+Return that path as `workload_path`. The SHAPES always come from your `meta.json` (config-derived
+M-buckets for GEMM, captured cases for attn/editable) — `attribute_weights.py` only attaches a
+time-proportional WEIGHT per case from the profile, labelling each `weight_source`
+(`trace`/`regime`/`prior`). **Set `--min-regime-share 0.3` for serving** (this run's objective): the
+profiling window is often prefill-biased and would otherwise zero-weight decode — the floor guarantees
+decode (TPOT-critical) is never optimized away. Read the tool's `notes`; if it WARNS that a regime had
+zero profiled time, mention it in your `notes`. Correctness still uses the frozen oracle — this only
+steers timing. Omit `workload_path` if no weight signal is available (kernel_workflow then runs
+unweighted). This does NOT change the immutable oracle in any way.
 If extraction fails (can't hook the callable, no cases captured, or not editable), return
 `editable:false`/`unittest_smoke:"fail"` with a clear reason so the Architect re-routes or drops it.
 

--- a/e2e_workflow/roles/kernel_extractor.md
+++ b/e2e_workflow/roles/kernel_extractor.md
@@ -121,7 +121,26 @@ to build its weighted TIMING cases + the time-weighted metric. Also return the p
 (kernel_workflow reads it only to know the run is workload-aligned). The SHAPES always come from your
 `meta.json` (config-derived M-buckets for GEMM, captured cases for attn/editable) — `attribute_weights.py`
 only attaches a time-proportional WEIGHT per case + the in-regime `quant` operands, labelling each
-`weight_source` (`trace`/`regime`/`regime_floor`/`prior`). **Set `--min-regime-share 0.3` for serving**
+`weight_source` (`trace`/`regime`/`regime_prior`/`regime_floor`/`prior`).
+
+> **🔴 TAG EVERY CASE WITH ITS `regime` — the attribution is op_kind-aware for ALL kinds, not just GEMM.**
+> `attribute_weights.py` splits a kernel's profiled time into per-regime totals and distributes each
+> across that regime's cases. It needs to know which regime each case belongs to. How you supply that
+> depends on op_kind — but it is ALWAYS your job (the profiler stays regime-agnostic; it only measures):
+> - **gemm / moe** → the `decode_m_buckets` / `prefill_m_buckets` lists (regime is implicit in the
+>   bucket list). MoE reuses the GEMM engine with effective-M = `tokens*top_k/num_experts` per expert.
+> - **attn** → put `"regime": "prefill"|"decode"` on each `cases[]` entry. Time is split by KERNEL NAME
+>   (prefill FMHA vs paged/decode), so decode — which the server runs under a HIP/CUDA graph with its
+>   shape hidden — still gets its share instead of collapsing to a zero-weight prior.
+> - **linear-attn-recurrent / norm / elementwise / editable** → put `"regime"` on each `cases[]` entry
+>   (often all `"decode"` for a decode-path kernel). A graph-hidden kernel with no per-call shape then
+>   gets its total time distributed across your cases by the size prior (`weight_source:"regime_prior"`,
+>   larger-batch case dominant) rather than an unweighted geomean.
+>
+> If a case has no natural regime, leave `"regime": ""` — the total is pooled and size-split. Never
+> hand-write weights; only tag `regime` + supply shapes, and let the deterministic tool attribute.
+
+**Set `--min-regime-share 0.3` for serving**
 (this run's objective): the profiling window is often prefill-biased and would otherwise zero-weight
 decode — the floor guarantees decode (TPOT-critical) is never optimized away. Read the tool's `notes`
 and carry anything notable into your own `notes`. CORRECTNESS still uses the frozen golden cases

--- a/e2e_workflow/roles/kernel_extractor.md
+++ b/e2e_workflow/roles/kernel_extractor.md
@@ -60,15 +60,23 @@ file), `launcher_hint` (launcher seam), `bound_type`), `CURRENT_FLAGS`/`CURRENT_
    window; add it explicitly from WORKLOAD if the capture missed it.
 3. **Copy the editable source** into `kernel_src/` (the minimal owning subtree), so the kernel layer
    and the later overlay can diff against it.
-4. **Write `unittest.py`** — backend-agnostic and IMMUTABLE:
-   - Load `reference_io.pt`; reconstruct input tensors on the GPU (honor recorded dtype/device/
-     contiguity; for in-place-output kernels, restore the pre-call buffer as input).
-   - Call the CURRENT kernel entry point (import by the meta `module:attr`, or the copied
-     `kernel_src`), compare to the golden output with dtype-appropriate tolerance (bf16/fp16
-     rtol=atol=2e-2; fp8 looser; fp32 tight). Print PASS/FAIL per case.
-   - Time baseline-vs-current per case (warmup + repeats + cuda/hip synchronize), print
-     `per_case` `baseline_ms/optimized_ms/speedup` and the geomean — identical shape to the
-     single-kernel workflow so the kernel-layer Director/verify math is unchanged.
+4. **Write `unittest.py`** — backend-agnostic and IMMUTABLE. It is the SINGLE harness: it judges
+   correctness AND measures the workload-weighted speedup; there is no separate downstream perf harness.
+   - **Correctness** on the FROZEN golden cases: load `reference_io.pt`; reconstruct input tensors on
+     the GPU (honor recorded dtype/device/contiguity; for in-place-output kernels, restore the pre-call
+     buffer as input). Call the CURRENT kernel entry point (import by the meta `module:attr`, or the
+     copied `kernel_src`), compare to the golden output with dtype-appropriate tolerance (bf16/fp16
+     rtol=atol=2e-2; fp8 looser; fp32 tight). Print PASS/FAIL per case. This set is NEVER re-weighted.
+   - **Timing** on the WORKLOAD cases when `meta.workload` is present (see step 4b): build one timing
+     case per `meta.workload.cases[]` entry, each input tensor with its OWN `dims`+`dtype` and the case's
+     `quant` operands (fp8 + scales etc., in-regime — NOT bf16), random values (perf is value-
+     independent). Time baseline-vs-current per case (warmup + repeats + cuda/hip synchronize), print
+     `per_case` `baseline_ms/optimized_ms/speedup`. If `meta.workload` is absent, fall back to timing the
+     golden/captured cases (unweighted), exactly as before.
+   - **Metric**: print the geomean AND, when `meta.workload` is present, the PRIMARY time-weighted
+     speedup `GEAK_WEIGHTED_SPEEDUP = Σ_i weight_i / Σ_i (weight_i / speedup_i)` using each case's
+     `weight`. Keep the same `per_case`/geomean print shape so the kernel-layer Director/verify math is
+     unchanged; the weighted line is additive. The baseline per case is the ORIGINAL/in-regime path.
    - It must NOT import any backend by name and must NOT read anything outside the task dir, so it
      transparently judges a triton/HIP/CK/aiter/asm reimplementation.
 5. **Finalize `meta.json`**: set `build` (false for pure-Triton; true + a build cmd for HIP/CK/asm
@@ -95,10 +103,10 @@ Return JSON:
   "notes": "granularity choice, hidden state captured, anything unusual"
 }
 ```
-**`workload_path` (optional, performance alignment).** If `PROFILE_WORKLOAD_JSON` is in your inputs
-(the profiler's per-kernel WEIGHT SIGNAL from `parse_profile.py --workload-out`), produce a
-workload spec for THIS kernel by JOINING your `meta.json` shape cases with that weight signal — do NOT
-hand-slice or hand-weight it. The join is op_kind-aware and deterministic; run:
+**4b. Workload weighting (fold into `meta.json`, performance alignment).** If `PROFILE_WORKLOAD_JSON`
+is in your inputs (the profiler's per-kernel WEIGHT SIGNAL from `parse_profile.py --workload-out`),
+produce the weighted case set for THIS kernel by JOINING your `meta.json` shape cases with that weight
+signal — do NOT hand-slice or hand-weight it. The join is op_kind-aware and deterministic; run:
 ```bash
 python3 "$SKILL_DIR/scripts/attribute_weights.py" \
   --meta "<task_dir>/meta.json" \
@@ -107,15 +115,18 @@ python3 "$SKILL_DIR/scripts/attribute_weights.py" \
   --min-regime-share 0.3 \
   --out "<task_dir>/workload.json"
 ```
-Return that path as `workload_path`. The SHAPES always come from your `meta.json` (config-derived
-M-buckets for GEMM, captured cases for attn/editable) — `attribute_weights.py` only attaches a
-time-proportional WEIGHT per case from the profile, labelling each `weight_source`
-(`trace`/`regime`/`prior`). **Set `--min-regime-share 0.3` for serving** (this run's objective): the
-profiling window is often prefill-biased and would otherwise zero-weight decode — the floor guarantees
-decode (TPOT-critical) is never optimized away. Read the tool's `notes`; if it WARNS that a regime had
-zero profiled time, mention it in your `notes`. Correctness still uses the frozen oracle — this only
-steers timing. Omit `workload_path` if no weight signal is available (kernel_workflow then runs
-unweighted). This does NOT change the immutable oracle in any way.
+Then **merge `workload.json` into `meta.json` under the `"workload"` key** (same pattern as the regime
+merge), so the immutable oracle is self-contained and `unittest.py` (step 4) reads `meta.workload.cases`
+to build its weighted TIMING cases + the time-weighted metric. Also return the path as `workload_path`
+(kernel_workflow reads it only to know the run is workload-aligned). The SHAPES always come from your
+`meta.json` (config-derived M-buckets for GEMM, captured cases for attn/editable) — `attribute_weights.py`
+only attaches a time-proportional WEIGHT per case + the in-regime `quant` operands, labelling each
+`weight_source` (`trace`/`regime`/`regime_floor`/`prior`). **Set `--min-regime-share 0.3` for serving**
+(this run's objective): the profiling window is often prefill-biased and would otherwise zero-weight
+decode — the floor guarantees decode (TPOT-critical) is never optimized away. Read the tool's `notes`
+and carry anything notable into your own `notes`. CORRECTNESS still uses the frozen golden cases
+(step 4); weighting only shapes the timing set. Omit the merge + `workload_path` if no weight signal is
+available (`unittest.py` then times unweighted).
 If extraction fails (can't hook the callable, no cases captured, or not editable), return
 `editable:false`/`unittest_smoke:"fail"` with a clear reason so the Architect re-routes or drops it.
 
@@ -161,8 +172,10 @@ Then HONOR it:
   → engine crash. This is non-negotiable for attention.
 - **Compile** (`regime.compile`): if `torch_compile`, the perf BASELINE is the COMPILED/fused path, not
   unfused eager — record the baseline against the fused path or the speedup is a strawman.
-`attribute_weights.py` re-reads `meta.regime` and will flag a `regime_warning` (e.g. seam <2% live GPU,
-fp8-KV, compiled-baseline) — if it warns, fix the extraction before proceeding.
+Building the oracle in-regime is YOUR job here — there is no downstream "regime warning"/gate to fall
+back on. If the live seam genuinely cannot be reproduced in-regime offline (e.g. the op only exists
+fused inside the torch.compile graph, or routing-dependent MoE token counts), say so in `notes` and
+report `editable:false`/drop rather than freeze an out-of-regime oracle nobody should trust.
 
 ### op task-dir contract (what op_bench.py + Op Benchmarker expect)
 ```
@@ -184,8 +197,11 @@ fp8-KV, compiled-baseline) — if it warns, fix the extraction before proceeding
 3. (Only if a real activation distribution matters) capture a real `(A,B,bias,output)` via the same
    capture overlay as PHASE=extract, save as `reference_io.pt` with keys `A,B,bias,output`.
 4. Write an immutable `unittest.py` that loads/synthesizes `A,B,bias`, computes `ref = A·Bᵀ(+bias)` with
-   the default backend once, then times the current path and checks a candidate against `ref`
-   (bf16 rtol=atol=2e-2). Same per-case/geomean print shape as the kernel-layer unittest.
+   the default (in-regime) backend once, then times the current path and checks a candidate against `ref`
+   (bf16 rtol=atol=2e-2). Same per-case/geomean print shape as the kernel-layer unittest, AND — when
+   `meta.workload` is present — its TIMING cases are the weighted `meta.workload.cases[]` (each built
+   with its own dims/dtype/`quant` operands) and it prints the time-weighted
+   `GEAK_WEIGHTED_SPEEDUP = Σ wᵢ/Σ(wᵢ/speedupᵢ)` as the PRIMARY metric (geomean stays as secondary).
 
 #### Quantized GEMM (int4/fp8 W*A16, compressed-tensors / GPTQ-AWQ / A4W4) — ANTI-CHEAT ORACLE CONTRACT (mandatory)
 For a **quantized-weight** head (e.g. the int4 W4A16 `fused_moe_kernel_gptq_awq` MoE GEMM), the naive
@@ -223,6 +239,9 @@ force real compact-operand compute:
    SERVER flag, so the Op Benchmarker delegates Tier-A attn swaps to the Config Tuner fast path; the op
    task dir mainly validates the oracle + enables Tier-C Triton-FA rewrites.
 4. Immutable `unittest.py`: load the captured tensors, run the current attention entry, check vs oracle.
+   Timing follows the SAME rule as the kernel-layer unittest: weighted `meta.workload.cases[]` (built
+   in-regime, incl. the fp8 KV layout when `regime.kv_cache_dtype==fp8`) + the time-weighted
+   `GEAK_WEIGHTED_SPEEDUP` as PRIMARY when `meta.workload` is present, else unweighted geomean.
 
 5. Finalize `meta.json` with the `reference_io_sha256` (when an oracle file exists) and smoke-test
    `op_bench.py --task <dir> --backends hipblaslt --repeats 5` (gemm) so the harness is proven before

--- a/e2e_workflow/roles/kernel_extractor.md
+++ b/e2e_workflow/roles/kernel_extractor.md
@@ -141,6 +141,29 @@ per-(shape,dtype) weighted workload model — slice this kernel's cases into `wo
 > the live-captured `(M,N,K)`/dtype as authoritative whenever they disagree. Note any correction in
 > `notes`.
 
+### Resolve the ONLINE REGIME first (it decides the seam, the dtypes, and the baseline)
+The #1 cause of "isolated win, e2e loss" is testing in a regime the live server never uses. Before
+capturing anything, resolve the regime from the SERVER LAUNCH FLAGS + model config and write it into
+`meta.json` so every step (oracle, dtypes, baseline, weight attribution) matches online:
+```bash
+python3 "$SKILL_DIR/scripts/parse_regime.py" \
+  --server-args "$CURRENT_FLAGS" --model-config "$MODEL_PATH/config.json" \
+  --out "<task_dir>/regime.json"
+# then merge regime.json into meta.json under the "regime" key
+```
+Then HONOR it:
+- **Quantization** (`regime.quant`): pick the seam that is LIVE under this quant. If the server runs
+  `--quantization fp8`, the real GEMM seam is the fp8 path (Fp8LinearMethod / a8w8) — an UNQUANTIZED gemm
+  seam only serves lm_head/embeddings and must NOT be extracted as if it were hot (it will mis-attribute
+  GPU% and test a dead shape → e2e loss). Build operands in the quantized form (fp8 + scales), not bf16.
+- **KV cache** (`regime.kv_cache_dtype`): if `fp8`, capture the oracle and write the kernel against the
+  **fp8 KV layout/stride**. A bf16-hardcoded KV kernel reads fp8 bytes with the wrong stride → GPU fault
+  → engine crash. This is non-negotiable for attention.
+- **Compile** (`regime.compile`): if `torch_compile`, the perf BASELINE is the COMPILED/fused path, not
+  unfused eager — record the baseline against the fused path or the speedup is a strawman.
+`attribute_weights.py` re-reads `meta.regime` and will flag a `regime_warning` (e.g. seam <2% live GPU,
+fp8-KV, compiled-baseline) — if it warns, fix the extraction before proceeding.
+
 ### op task-dir contract (what op_bench.py + Op Benchmarker expect)
 ```
 <EVAL_DIR>/kernels/<short_name>_task/

--- a/e2e_workflow/roles/kernel_extractor.md
+++ b/e2e_workflow/roles/kernel_extractor.md
@@ -91,9 +91,16 @@ Return JSON:
   "build": false,
   "unittest_smoke": "pass|fail",
   "reference_io_sha256": "...",
+  "workload_path": "<task_dir>/workload.json",
   "notes": "granularity choice, hidden state captured, anything unusual"
 }
 ```
+**`workload_path` (optional, performance alignment).** If `PROFILE_WORKLOAD_JSON` is in your inputs
+(the profiler's per-(shape,dtype) weighted model), slice out THIS kernel's entry (match by
+`short_name` / kernel name) and write just that kernel's `{cases:[…]}` to `<task_dir>/workload.json`,
+returning its path. kernel_workflow then benchmarks the real workload shapes weighted by their time
+contribution (correctness still uses the frozen oracle — this only steers timing). Omit the field if
+no workload model is available. This does NOT change the immutable oracle in any way.
 If extraction fails (can't hook the callable, no cases captured, or not editable), return
 `editable:false`/`unittest_smoke:"fail"` with a clear reason so the Architect re-routes or drops it.
 
@@ -108,7 +115,8 @@ needs an op task dir the **Op Benchmarker** can bake-off across backends. `edit=
 Inputs: `EVAL_DIR`, `MODEL_PATH`, `GPU_ID`, `WORKLOAD`, `KERNEL` (Architect head candidate: short_name,
 op_kind=gemm|attn, the profiled `shapes`, dtype, regime, `target_callable` for attn, and OPTIONAL
 TraceLens `source_hint`/`launcher_hint`/`bound_type`), `GEMM_SYNTH` (bool, default true),
-`CURRENT_FLAGS`/`CURRENT_ENV`, `SKILL_DIR`.
+`CURRENT_FLAGS`/`CURRENT_ENV`, `SKILL_DIR`, and OPTIONAL `PROFILE_WORKLOAD_JSON` (the profiler's
+per-(shape,dtype) weighted workload model — slice this kernel's cases into `workload_path`, see below).
 
 > **TraceLens shape double-check (mandatory when the shapes came from TraceLens).** If `KERNEL.shapes`
 > originated from the upstream `analysis.md`/`kernel_candidates.json` prior, treat them ONLY as a

--- a/e2e_workflow/roles/profiler.md
+++ b/e2e_workflow/roles/profiler.md
@@ -119,8 +119,14 @@ degrade to whatever is available, and if both analysis.md and trace are unusable
    TRACE=$(ls -t "$PDIR"/*.json.gz "$PDIR"/*.json 2>/dev/null | head -1)
    python3 "$EVAL_DIR/parse_profile.py" --torch-trace "$TRACE" \
      ${ROCPROF_DIR:+--rocprof-dir "$ROCPROF_DIR"} \
-     --top 25 --out "$EVAL_DIR/profile/round_${ROUND}/profile_topN"
+     --top 25 --out "$EVAL_DIR/profile/round_${ROUND}/profile_topN" \
+     --workload-out "$EVAL_DIR/profile/round_${ROUND}/profile_workload.json"
    ```
+   The extra `--workload-out` writes the per-(shape,dtype) WORKLOAD MODEL (each top kernel's real
+   shape/dtype case distribution with a time-proportional weight). The Kernel Extractor slices the
+   target kernel's cases out of this so kernel_workflow benchmarks the shapes the workload actually
+   hits. It needs the torch trace's `Input Dims` (record_shapes); if shapes are absent the cases come
+   out `weight_source:"regime_prior"` — note that in `notes`. Report its path as `profile_workload_json`.
 4. Sanity-read `profile_topN.md`. Resolve any `other`-classified top entries before finishing: grep
    the `short_name` under the serving-stack package dir (sglang/vllm, from `env_info.txt`) to identify
    it, and note the correct class in `notes` so the Architect routes it right. Flag same-named kernels appearing with BOTH large-M and small-M shapes

--- a/e2e_workflow/roles/profiler.md
+++ b/e2e_workflow/roles/profiler.md
@@ -10,7 +10,15 @@ classification semantics) and `SKILL_DIR/knowledge/sglang_internals.md` (profile
 
 ## Discipline (a bad trace misroutes the whole run)
 - Profile with the EXACT ISL/OSL/concurrency as the throughput bench, AFTER warmup.
-- Bounded window (`--profile-num-steps`, default 5) so the trace stays parseable.
+- **Capture the STEADY-STATE MIX, not a cold prefill burst.** `bench_e2e.sh` (PROFILE=1) now warms a
+  saturated load and captures a mid-stream window (`adapter_profile_window`), so the trace contains
+  prefill chunks AND decode steps interleaved as the scheduler really runs them. A cold burst profiled
+  from step 0 only sees the prefill ramp (TTFT) and misses decode — if your trace has ONLY large-M
+  prefill shapes and no decode-batch entries, it was captured wrong; re-profile. Note that decode often
+  runs under a CUDA/HIP graph, so its kernels may appear WITHOUT `Input Dims` (shape-hidden); that is
+  expected — decode shapes are recovered downstream from config (decode batch = concurrency), not the
+  trace. Tune the window via `PROFILE_NUM_STEPS` / `PROFILE_WARMUP_SEC` / `PROFILE_NUM_PROMPTS`.
+- Bounded window (`--profile-num-steps`, default 40) so the trace stays parseable but spans into decode.
 - `total_gpu_time_ms` is summed kernel duration in the window — use it for RELATIVE %gpu ranking, not
   as the throughput number (that's the Director's bench).
 - Prefer BOTH sources when available: rocprofv3 gives authoritative HW durations, the torch trace

--- a/e2e_workflow/scripts/adapters/sglang.sh
+++ b/e2e_workflow/scripts/adapters/sglang.sh
@@ -48,6 +48,9 @@ adapter_bench() {
     extra=(--profile --profile-num-steps "$PROFILE_NUM_STEPS"
            --profile-output-dir "$PROFILE_DIR" --profile-prefix e2e)
   fi
+  # Optional request-rate (req/s) to STAGGER arrivals so sequences sit at different prefill/decode
+  # phases — used by the steady-state profiling path. Empty => inf (max_concurrency still caps).
+  [ -n "${REQUEST_RATE:-}" ] && extra+=(--request-rate "$REQUEST_RATE")
   python -m sglang.bench_serving \
     --backend sglang --base-url "$BASE_URL" --model "$MODEL" \
     --dataset-name random --random-input-len "$ISL" --random-output-len "$OSL" --random-range-ratio 1.0 \
@@ -56,4 +59,32 @@ adapter_bench() {
     --output-file "$RESULT_JSONL" "${extra[@]}"
   # sglang.bench_serving appends a result json line (output_throughput, median_ttft_ms, median_tpot_ms)
   # to --output-file, which is exactly the dispatcher's canonical schema. Nothing else to do.
+}
+
+# adapter_profile_window — capture a profiler window on the ALREADY-RUNNING, warm, mid-load server via
+# sglang's HTTP profiler, so the trace reflects the real continuous-batching steady-state mix (prefill
+# chunks + decode interleaved) instead of a cold prefill ramp. record_shapes=true so the parser gets
+# Input Dims for shape attribution. Called by bench_e2e.sh AFTER a sustained background load is warm.
+adapter_profile_window() {
+  local before after
+  before=$(ls "$PROFILE_DIR"/*.trace.json* 2>/dev/null | wc -l)
+  # num_steps set => the server records that many forward steps then auto-saves (async; returns at once).
+  if ! curl -sf -X POST "${BASE_URL}/start_profile" -H 'Content-Type: application/json' \
+        -d "{\"output_dir\":\"${PROFILE_DIR}\",\"num_steps\":${PROFILE_NUM_STEPS},\"record_shapes\":true}" \
+        >/dev/null 2>&1; then
+    echo "!!! /start_profile request failed (sglang HTTP profiler unavailable?)" >&2
+    return 1
+  fi
+  # wait for a NEW trace to land (server saves after num_steps forward passes)
+  local deadline=$(( $(date +%s) + ${PROFILE_WINDOW_TIMEOUT:-180} ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    after=$(ls "$PROFILE_DIR"/*.trace.json* 2>/dev/null | wc -l)
+    [ "$after" -gt "$before" ] && { sleep 2; return 0; }   # +2s for the write to flush
+    sleep 3
+  done
+  # num_steps may not be honored on some builds — force a stop and re-check
+  curl -sf -X POST "${BASE_URL}/stop_profile" >/dev/null 2>&1 || true
+  sleep 3
+  after=$(ls "$PROFILE_DIR"/*.trace.json* 2>/dev/null | wc -l)
+  [ "$after" -gt "$before" ]
 }

--- a/e2e_workflow/scripts/attribute_weights.py
+++ b/e2e_workflow/scripts/attribute_weights.py
@@ -88,8 +88,7 @@ def attribute_gemm(meta, entries, notes):
             mblk = grid / nblk
             is_decode = mblk <= 1.5
         if is_decode is None:
-            is_decode = False  # resolved after the loop via median split if needed
-            grid_vals[-1] = (grid, kw, k)  # mark for second pass
+            grid_vals[-1] = (grid, kw, k)  # mark for second-pass median split
             continue
         if is_decode:
             decode_us += kw
@@ -141,7 +140,7 @@ def attribute_gemm(meta, entries, notes):
             continue
         if total <= 0:
             # The profile window showed ZERO time for a regime that meta says exists. This is almost
-            # always a capture-口径 artifact (e.g. a prefill-dominated profiling window misses decode),
+            # always a capture-window artifact (e.g. a prefill-dominated profiling window misses decode),
             # NOT proof the regime is free. Emit the cases at weight 0 (prior) so they are still
             # benchmarked + visible, and warn loudly. Use --min-regime-share to floor it for serving.
             notes.append(f"WARNING: regime '{regime}' has meta buckets {buckets} but ZERO profiled "
@@ -230,7 +229,7 @@ def _distribute(mcases, regime_us, matched, notes, src="regime"):
     """THE shared case-based engine. For each meta case: if a profiled shape matched it -> trace
     weight; else split its regime's unmatched total (`regime_us[regime]`) across that regime's
     unmatched members by the size prior. A regime meta declares but the profile timed at ZERO ->
-    weight 0 prior + loud warning (a capture-口径 artifact, not proof it's free; floor it via
+    weight 0 prior + loud warning (a capture-window artifact, not proof it's free; floor it via
     --min-regime-share). `src` labels the prior weights (regime|regime_prior)."""
     out = []
     by_regime = {}
@@ -530,8 +529,11 @@ def _quant_block(meta, regime):
 
 
 def _base_token(short_name):
-    """A stable substring for matching specialized kernel names (drop shape/dim noise)."""
-    t = re.split(r"[ \d]", short_name.strip())[0] if short_name else ""
+    """A stable substring for matching specialized kernel names (drop trailing shape/dim noise).
+    Keeps embedded digits that are part of the name (e.g. a8w8) — only strips a trailing _NNN suffix."""
+    t = short_name.strip() if short_name else ""
+    t = t.split()[0]  # drop anything after whitespace (autotune params)
+    t = re.sub(r"_\d+$", "", t)  # strip trailing numeric suffix (_128, _2048)
     return t or short_name
 
 

--- a/e2e_workflow/scripts/attribute_weights.py
+++ b/e2e_workflow/scripts/attribute_weights.py
@@ -266,12 +266,18 @@ def main():
                          "this fraction of total weight, even if the profile under-captured it (e.g. a "
                          "prefill-only window). 0 (default) = faithful to the profile. For decode-"
                          "critical serving, set e.g. 0.3 so decode is never optimized away.")
+    ap.add_argument("--live-pct-min", type=float, default=2.0,
+                    help="if the matched seam's total %%GPU in the (online-captured) profile is below "
+                         "this, flag regime_warning: the seam is probably NOT the live kernel under the "
+                         "online regime (e.g. an unquantized GEMM that only serves lm_head when the "
+                         "server runs --quantization fp8). Default 2%%.")
     ap.add_argument("--out", required=True, help="output workload-v1 json")
     args = ap.parse_args()
 
     with open(args.meta) as fh:
         meta = json.load(fh)
     op_kind = (meta.get("op_kind") or "").lower()
+    regime = meta.get("regime") or {}      # written by the extractor from parse_regime.py
     name_match = args.name_match or _base_token(meta.get("short_name", ""))
     entries = load_profile_entries(args.profile_weights, name_match)
 
@@ -299,11 +305,23 @@ def main():
     for c in cases:
         c["weight_norm"] = round(c.get("weight", 0.0) / wsum, 6)
 
+    # ---- REGIME: dtype/quant for the cases + live-seam guard ----
+    quant = _quant_block(meta, regime)
+    for c in cases:                        # stamp quant onto each case so the harness builds the
+        c.setdefault("quant", quant)       # SAME operands online uses (fp8 + scales, not bf16)
+    # live %GPU of THIS seam under the online regime (profile was captured on the real server).
+    live_pct = round(sum(float(k.get("pct_gpu_time", 0.0)) for k in entries), 3)
+    regime_warning = _regime_warnings(regime, op_kind, entries, live_pct, args.live_pct_min, notes)
+
     out = {
         "schema": "workload-v1",
         "op_kind": op_kind,
         "kernel": meta.get("short_name", ""),
         "name_match": name_match,
+        "regime": regime,                  # quant / kv_cache_dtype / compile / attention_backend
+        "quant": quant,                    # per-operand dtypes + scales for THIS kernel
+        "live_pct_gpu": live_pct,          # this seam's share of GPU time under the online regime
+        "regime_warning": regime_warning,  # non-empty => seam/regime mismatch; don't trust the weight
         "num_cases": len(cases),
         "weights_provenance": _provenance(cases),
         "cases": cases,
@@ -356,6 +374,47 @@ def _apply_regime_floor(cases, floor, notes):
             if c.get("regime") in rest_regimes:
                 c["weight"] *= scale
     notes.append(f"applied --min-regime-share {floor}: floored regimes {floored}.")
+
+
+def _quant_block(meta, regime):
+    """Per-operand dtypes + quant so the harness builds the SAME inputs the live kernel sees.
+    meta (the captured/synthesized op) wins on operand specifics; regime fills gaps from launch flags."""
+    rq = (regime or {}).get("quant") or {}
+    return {
+        "scheme": meta.get("quant_scheme") or rq.get("method") or "none",
+        "weight_dtype": meta.get("dtype") or rq.get("weight_dtype") or "",
+        "act_dtype": rq.get("act_dtype") or meta.get("dtype") or "",
+        "out_dtype": meta.get("out_dtype") or "",
+        "weight_block_size": meta.get("weight_block_size") or rq.get("block_size"),
+        "scale_dtype": "float32",
+        "kv_cache_dtype": (regime or {}).get("kv_cache_dtype", ""),
+    }
+
+
+def _regime_warnings(regime, op_kind, entries, live_pct, live_pct_min, notes):
+    """Catch the 'isolated win, e2e loss' class BEFORE optimization. Returns a warning string ('' if ok)."""
+    warns = []
+    q = (regime or {}).get("quant") or {}
+    method = (q.get("method") or "none")
+    # (1) live-seam guard: the profile is captured on the REAL online server, so the live kernel carries
+    #     the GPU time. A near-zero share means this seam isn't what the workload actually runs (the
+    #     classic unquantized-GEMM-serving-only-lm_head trap under --quantization fp8).
+    if entries and live_pct < live_pct_min:
+        warns.append(f"seam is only {live_pct}% GPU under the online regime (quant={method}); it is "
+                     f"probably NOT the live kernel — verify the seam (e.g. unquantized GEMM serving "
+                     f"only lm_head). Do NOT trust its weight/speedup for e2e.")
+    # (2) attention KV dtype: a kernel hardcoding bf16 KV will fault under fp8 KV (bf16 stride over fp8).
+    if op_kind in ("attn", "attention") and (regime or {}).get("kv_cache_dtype") in ("fp8", "fp8_e4m3", "fp8_e5m2"):
+        warns.append("online kv-cache-dtype=fp8: the attention oracle + kernel MUST use the fp8 KV "
+                     "layout/stride, else a bf16-stride read over fp8 bytes faults. Verify the captured "
+                     "KV dtype matches.")
+    # (3) compile baseline: norm/elementwise fused online via torch.compile -> eager ref is a strawman.
+    if (regime or {}).get("compile") == "torch_compile" and op_kind in ("norm", "reduction_norm", "elementwise", "rmsnorm", ""):
+        warns.append("online uses torch.compile fusion: the perf baseline must be the COMPILED/fused "
+                     "path, not unfused eager, or the speedup is a strawman.")
+    if warns:
+        notes.extend(warns)
+    return " ".join(warns)
 
 
 def _base_token(short_name):

--- a/e2e_workflow/scripts/attribute_weights.py
+++ b/e2e_workflow/scripts/attribute_weights.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Unified, op_kind-aware WEIGHT ATTRIBUTION (the "Tier 2" of workload alignment).
+
+The shape/case set for EVERY kernel type comes from the extractor's `meta.json` (the same shapes the
+oracle + unittest use — config-derived M-buckets for GEMM, captured tensor cases for attn/editable
+kernels). The profile only supplies a WEIGHT SIGNAL (per-kernel wall-clock time, from
+`parse_profile.py --workload-out`). This script JOINS the two: it attributes the profiled time onto
+meta's shape cases so the harness can benchmark exactly those cases, weighted by their real
+contribution. ALL kernel-type-specific logic lives here, in ONE place, behind an op_kind switch.
+
+It NEVER fabricates a shape — shapes only ever come from meta. When it cannot attribute precisely it
+falls back to a coarser, explicitly-labelled weight (`weight_source`) so downstream knows the fidelity:
+  trace   - matched to a real per-call shape in the profile (precise per-case weight)
+  regime  - profiled time split decode/prefill (measured per regime), distributed within the regime
+            by a documented prior (decode -> the full-batch bucket; prefill -> larger chunks)
+  prior   - no usable profile signal; even weight across the meta cases (logged, low confidence)
+
+Output: a workload-v1 json (the WORKLOAD_SPEC kernel_workflow's benchmark_engineer consumes):
+  {schema:"workload-v1", op_kind, kernel, num_cases,
+   cases:[{name, dims:[[...]], dtypes:[...], count, weight, weight_norm, weight_source, regime}], notes}
+
+Stdlib only.
+"""
+import argparse, json, math, re, sys
+
+
+# --------------------------------------------------------------------------- #
+# profile weight signal (parse_profile.py --workload-out output)
+# --------------------------------------------------------------------------- #
+def load_profile_entries(path, name_match):
+    """Return the profile 'kernel' entries whose name matches (substring, case-insensitive).
+    For a triton GEMM these are the many autotune-specialized names of ONE logical kernel."""
+    with open(path) as fh:
+        wl = json.load(fh)
+    nm = (name_match or "").lower()
+    out = []
+    for k in wl.get("kernels", []):
+        if not nm or nm in k.get("name", "").lower() or nm in k.get("short_name", "").lower():
+            out.append(k)
+    return out
+
+
+def _field(name, key):
+    m = re.search(key + r"_(\d+)", name)
+    return int(m.group(1)) if m else None
+
+
+# --------------------------------------------------------------------------- #
+# GEMM: cases = config M-buckets x (fixed N,K); weight = profiled time split by regime
+# --------------------------------------------------------------------------- #
+def attribute_gemm(meta, entries, notes):
+    a_shape = meta.get("a_shape") or ["M", None]   # [M, K]
+    b_shape = meta.get("b_shape") or [None, None]  # [N, K]
+    K = a_shape[1] if len(a_shape) > 1 else None
+    N = b_shape[0] if b_shape else None
+    in_dt = meta.get("dtype", "")
+    decode = list(meta.get("decode_m_buckets") or [])
+    prefill = list(meta.get("prefill_m_buckets") or [])
+    if not (decode or prefill):
+        # no regime split in meta -> treat every m_bucket as its own (prefill-like) case
+        prefill = list(meta.get("m_buckets") or [])
+
+    # ---- classify each profiled specialized-name into decode/prefill, sum its time ----
+    # A triton GEMM hides M behind the launch grid. We do NOT need exact M, only regime:
+    # M_blocks ~ GRID_MN / ceil(N/BLOCK_N); M_blocks<=~1 => decode (single M-tile), else prefill.
+    decode_us = 0.0
+    prefill_us = 0.0
+    matched_by_shape = {}   # bucket_M -> summed weight, when the profile DID expose a real shape
+    grid_vals = []
+    for k in entries:
+        kw = sum(c.get("weight", 0.0) for c in k.get("cases", []))
+        # (a) precise: profile exposed a real input shape for this launch
+        real = next((c for c in k.get("cases", []) if c.get("dims")), None)
+        if real and real["dims"]:
+            m = real["dims"][0][0] if real["dims"][0] else None
+            if isinstance(m, int):
+                bucket = _nearest(m, decode + prefill)
+                matched_by_shape[bucket] = matched_by_shape.get(bucket, 0.0) + kw
+                continue
+        # (b) regime via grid magnitude
+        name = k.get("name", "")
+        grid = _field(name, "GRID_MN")
+        bn = _field(name, "BLOCK_SIZE_N")
+        grid_vals.append((grid, kw))
+        is_decode = None
+        if grid and bn and N:
+            nblk = math.ceil(N / bn)
+            mblk = grid / nblk
+            is_decode = mblk <= 1.5
+        if is_decode is None:
+            is_decode = False  # resolved after the loop via median split if needed
+            grid_vals[-1] = (grid, kw, k)  # mark for second pass
+            continue
+        if is_decode:
+            decode_us += kw
+        else:
+            prefill_us += kw
+
+    # second pass: any launches we couldn't classify by N/BLOCK_N -> split by GRID_MN median
+    unresolved = [g for g in grid_vals if len(g) == 3]
+    if unresolved:
+        gs = sorted(g[0] for g in unresolved if g[0])
+        med = gs[len(gs) // 2] if gs else 0
+        notes.append(f"{len(unresolved)} launches classified by GRID_MN median split (median={med}); "
+                     "N/BLOCK_N not parseable for them.")
+        for g in unresolved:
+            grid, kw = g[0], g[1]
+            if grid and grid <= med:
+                decode_us += kw
+            else:
+                prefill_us += kw
+
+    cases = []
+
+    def emit(M, regime, weight, src):
+        dims = [[M, K], [N, K]]
+        cases.append({
+            "name": f"{regime}_M{M}",
+            "dims": dims,
+            "dtypes": [in_dt, in_dt],
+            "count": None,
+            "weight": round(weight, 3),
+            "weight_source": src,
+            "regime": regime,
+            "m": M,
+        })
+
+    # ---- precise per-bucket weights where the profile gave real shapes ----
+    used_shape_buckets = set()
+    for bucket, w in matched_by_shape.items():
+        regime = "decode" if bucket in decode else "prefill"
+        emit(bucket, regime, w, "trace")
+        used_shape_buckets.add(bucket)
+
+    # ---- regime totals distributed across the remaining buckets ----
+    rem_decode = [m for m in decode if m not in used_shape_buckets]
+    rem_prefill = [m for m in prefill if m not in used_shape_buckets]
+    for buckets, total, regime in ((rem_decode, decode_us, "decode"),
+                                   (rem_prefill, prefill_us, "prefill")):
+        if not buckets:
+            continue
+        if total <= 0:
+            # The profile window showed ZERO time for a regime that meta says exists. This is almost
+            # always a capture-口径 artifact (e.g. a prefill-dominated profiling window misses decode),
+            # NOT proof the regime is free. Emit the cases at weight 0 (prior) so they are still
+            # benchmarked + visible, and warn loudly. Use --min-regime-share to floor it for serving.
+            notes.append(f"WARNING: regime '{regime}' has meta buckets {buckets} but ZERO profiled "
+                         f"time — likely a prefill/decode-biased profiling window. Decode-critical "
+                         f"serving should set --min-regime-share to avoid ignoring it.")
+            for M in buckets:
+                emit(M, regime, 0.0, "prior")
+            continue
+        for M, frac in _within_regime_split(buckets, regime):
+            emit(M, regime, total * frac, "regime")
+    return cases
+
+
+def _within_regime_split(buckets, regime):
+    """Distribute a regime's measured total time across its config buckets (documented prior, since
+    the profile gives the regime total but not per-bucket counts for a shape-hidden GEMM).
+      decode  -> steady-state serving runs at ~full batch, so the largest decode bucket (==CONC)
+                 dominates; tiny M is transient.
+      prefill -> larger chunks carry proportionally more time (more FLOPs), so split ~proportional to M.
+    """
+    buckets = sorted(buckets)
+    if regime == "decode":
+        # 80% on the full-batch bucket, the rest spread over the smaller ones
+        if len(buckets) == 1:
+            return [(buckets[0], 1.0)]
+        big = buckets[-1]
+        rest = buckets[:-1]
+        out = [(big, 0.8)]
+        for M in rest:
+            out.append((M, 0.2 / len(rest)))
+        return out
+    # prefill: proportional to M
+    s = float(sum(buckets)) or 1.0
+    return [(M, M / s) for M in buckets]
+
+
+def _nearest(m, buckets):
+    return min(buckets, key=lambda b: abs(b - m)) if buckets else m
+
+
+# --------------------------------------------------------------------------- #
+# Generic (attn / norm / elementwise / linear-attn / editable): meta carries captured cases with
+# explicit shapes; the profile usually exposes the same shapes -> match per case.
+# --------------------------------------------------------------------------- #
+def attribute_generic(meta, entries, notes):
+    meta_cases = meta.get("cases") or []
+    # gather all profiled cases (with real dims) across the matched kernel entries
+    prof = []
+    for k in entries:
+        for c in k.get("cases", []):
+            if c.get("dims"):
+                prof.append(c)
+    cases = []
+    if not meta_cases:
+        # no explicit meta case list -> just pass the profile's own per-(shape,dtype) weights through
+        for c in prof:
+            cases.append({
+                "name": _shape_name(c["dims"]),
+                "dims": c["dims"], "dtypes": c.get("dtypes", []),
+                "count": c.get("count"), "weight": c.get("weight", 0.0),
+                "weight_source": "trace", "regime": "",
+            })
+        if not cases:
+            notes.append("no meta cases and no profiled shapes; nothing to weight.")
+        return cases
+
+    for mc in meta_cases:
+        dims = mc.get("input_shapes") or mc.get("dims") or []
+        dtypes = mc.get("input_dtypes") or mc.get("dtypes") or []
+        match = _best_shape_match(dims, prof)
+        if match is not None:
+            cases.append({
+                "name": mc.get("sig") or _shape_name(dims),
+                "dims": dims, "dtypes": dtypes,
+                "count": match.get("count"), "weight": match.get("weight", 0.0),
+                "weight_source": "trace", "regime": "",
+            })
+        else:
+            cases.append({
+                "name": mc.get("sig") or _shape_name(dims),
+                "dims": dims, "dtypes": dtypes, "count": None, "weight": 0.0,
+                "weight_source": "prior", "regime": "",
+            })
+    if any(c["weight_source"] == "prior" for c in cases):
+        notes.append("some meta cases had no matching profiled shape -> weight=0 prior (logged).")
+    return cases
+
+
+def _shape_name(dims):
+    return "x".join("_".join(str(d) for d in t) for t in dims if t)[:60] or "case"
+
+
+def _best_shape_match(dims, prof):
+    """Match a meta case's shapes to a profiled case. Exact first; else first-operand outer-dim nearest."""
+    key = json.dumps([d for d in dims if d])
+    for c in prof:
+        if json.dumps([d for d in c["dims"] if d]) == key:
+            return c
+    # fuzzy: same first-operand trailing dims, nearest leading (token) dim
+    if dims and dims[0]:
+        lead, tail = dims[0][0], dims[0][1:]
+        best, bestd = None, None
+        for c in prof:
+            if c["dims"] and c["dims"][0][1:] == tail and isinstance(c["dims"][0][0], int):
+                d = abs(c["dims"][0][0] - lead) if isinstance(lead, int) else 0
+                if bestd is None or d < bestd:
+                    best, bestd = c, d
+        return best
+    return None
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--meta", required=True, help="extractor meta.json (the shape contract)")
+    ap.add_argument("--profile-weights", required=True,
+                    help="parse_profile.py --workload-out json (the weight signal)")
+    ap.add_argument("--name-match", default="",
+                    help="substring to select this kernel's profile entries (default: meta short_name)")
+    ap.add_argument("--min-regime-share", type=float, default=0.0,
+                    help="floor: guarantee each regime (decode/prefill) present in meta gets at least "
+                         "this fraction of total weight, even if the profile under-captured it (e.g. a "
+                         "prefill-only window). 0 (default) = faithful to the profile. For decode-"
+                         "critical serving, set e.g. 0.3 so decode is never optimized away.")
+    ap.add_argument("--out", required=True, help="output workload-v1 json")
+    args = ap.parse_args()
+
+    with open(args.meta) as fh:
+        meta = json.load(fh)
+    op_kind = (meta.get("op_kind") or "").lower()
+    name_match = args.name_match or _base_token(meta.get("short_name", ""))
+    entries = load_profile_entries(args.profile_weights, name_match)
+
+    notes = []
+    if not entries:
+        notes.append(f"no profile entries matched name '{name_match}'; weights are prior only.")
+
+    if op_kind == "gemm":
+        cases = attribute_gemm(meta, entries, notes)
+    else:
+        # attn / moe / norm / elementwise / editable all carry explicit shapes in meta -> generic path.
+        if op_kind == "moe":
+            notes.append("op_kind=moe: per-expert token counts are routing-dependent; weights are "
+                         "shape-matched where possible, else prior. Treat as low-confidence.")
+        cases = attribute_generic(meta, entries, notes)
+
+    # optional regime floor (serving decode-protection): redistribute so each regime present in meta
+    # gets >= min_regime_share of the total. Applied BEFORE normalization, on raw weights.
+    if args.min_regime_share > 0:
+        _apply_regime_floor(cases, args.min_regime_share, notes)
+
+    # normalize weights within the kernel
+    cases.sort(key=lambda c: c.get("weight", 0.0), reverse=True)
+    wsum = sum(c.get("weight", 0.0) for c in cases) or 1.0
+    for c in cases:
+        c["weight_norm"] = round(c.get("weight", 0.0) / wsum, 6)
+
+    out = {
+        "schema": "workload-v1",
+        "op_kind": op_kind,
+        "kernel": meta.get("short_name", ""),
+        "name_match": name_match,
+        "num_cases": len(cases),
+        "weights_provenance": _provenance(cases),
+        "cases": cases,
+        "notes": " ".join(notes),
+    }
+    with open(args.out, "w") as fh:
+        fh.write(json.dumps(out, indent=2))
+    sys.stderr.write(f"wrote {args.out}: {len(cases)} cases, provenance={out['weights_provenance']}\n")
+    print(json.dumps({"out": args.out, "num_cases": len(cases),
+                      "weights_provenance": out["weights_provenance"], "notes": out["notes"]}))
+
+
+def _apply_regime_floor(cases, floor, notes):
+    """Ensure each regime present in meta holds >= `floor` of total weight. Within a floored regime,
+    distribute by the same documented prior as _within_regime_split. Only meaningful with >=2 regimes."""
+    regimes = sorted({c.get("regime") for c in cases if c.get("regime")})
+    if len(regimes) < 2:
+        return
+    total = sum(c.get("weight", 0.0) for c in cases) or 1.0
+    floored = [r for r in regimes
+               if sum(c["weight"] for c in cases if c.get("regime") == r) / total < floor]
+    if not floored:
+        return
+    if floor * len(floored) >= 1.0:
+        notes.append(f"min-regime-share {floor} x {len(floored)} floored regimes >= 1.0; skipped.")
+        return
+    # Each floored regime -> exactly floor*total; the non-floored regimes share the remainder,
+    # scaled down proportionally to their current weights.
+    for r in floored:
+        share = floor * total
+        members = [c for c in cases if c.get("regime") == r]
+        ms = [c["m"] for c in members if "m" in c]
+        if len(ms) == len(members):                       # GEMM-style: split by M bucket
+            frac_by_m = dict(_within_regime_split(ms, r))
+            for c in members:
+                c["weight"] = share * frac_by_m.get(c["m"], 1.0 / len(members))
+                if c.get("weight_source") == "prior":
+                    c["weight_source"] = "regime_floor"
+        else:                                             # no per-case M: even split
+            for c in members:
+                c["weight"] = share / len(members)
+                if c.get("weight_source") == "prior":
+                    c["weight_source"] = "regime_floor"
+    rest_regimes = [r for r in regimes if r not in floored]
+    rest_total = sum(c["weight"] for c in cases if c.get("regime") in rest_regimes)
+    keep = total * (1.0 - floor * len(floored))
+    if rest_total > 0:
+        scale = keep / rest_total
+        for c in cases:
+            if c.get("regime") in rest_regimes:
+                c["weight"] *= scale
+    notes.append(f"applied --min-regime-share {floor}: floored regimes {floored}.")
+
+
+def _base_token(short_name):
+    """A stable substring for matching specialized kernel names (drop shape/dim noise)."""
+    t = re.split(r"[ \d]", short_name.strip())[0] if short_name else ""
+    return t or short_name
+
+
+def _provenance(cases):
+    srcs = sorted({c.get("weight_source", "prior") for c in cases})
+    return srcs[0] if len(srcs) == 1 else "mixed(" + "+".join(srcs) + ")"
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e_workflow/scripts/attribute_weights.py
+++ b/e2e_workflow/scripts/attribute_weights.py
@@ -266,11 +266,6 @@ def main():
                          "this fraction of total weight, even if the profile under-captured it (e.g. a "
                          "prefill-only window). 0 (default) = faithful to the profile. For decode-"
                          "critical serving, set e.g. 0.3 so decode is never optimized away.")
-    ap.add_argument("--live-pct-min", type=float, default=2.0,
-                    help="if the matched seam's total %%GPU in the (online-captured) profile is below "
-                         "this, flag regime_warning: the seam is probably NOT the live kernel under the "
-                         "online regime (e.g. an unquantized GEMM that only serves lm_head when the "
-                         "server runs --quantization fp8). Default 2%%.")
     ap.add_argument("--out", required=True, help="output workload-v1 json")
     args = ap.parse_args()
 
@@ -305,13 +300,10 @@ def main():
     for c in cases:
         c["weight_norm"] = round(c.get("weight", 0.0) / wsum, 6)
 
-    # ---- REGIME: dtype/quant for the cases + live-seam guard ----
+    # ---- REGIME: per-operand dtype/quant so the harness builds the SAME operands the live kernel sees ----
     quant = _quant_block(meta, regime)
     for c in cases:                        # stamp quant onto each case so the harness builds the
         c.setdefault("quant", quant)       # SAME operands online uses (fp8 + scales, not bf16)
-    # live %GPU of THIS seam under the online regime (profile was captured on the real server).
-    live_pct = round(sum(float(k.get("pct_gpu_time", 0.0)) for k in entries), 3)
-    regime_warning = _regime_warnings(regime, op_kind, entries, live_pct, args.live_pct_min, notes)
 
     out = {
         "schema": "workload-v1",
@@ -320,8 +312,6 @@ def main():
         "name_match": name_match,
         "regime": regime,                  # quant / kv_cache_dtype / compile / attention_backend
         "quant": quant,                    # per-operand dtypes + scales for THIS kernel
-        "live_pct_gpu": live_pct,          # this seam's share of GPU time under the online regime
-        "regime_warning": regime_warning,  # non-empty => seam/regime mismatch; don't trust the weight
         "num_cases": len(cases),
         "weights_provenance": _provenance(cases),
         "cases": cases,
@@ -389,32 +379,6 @@ def _quant_block(meta, regime):
         "scale_dtype": "float32",
         "kv_cache_dtype": (regime or {}).get("kv_cache_dtype", ""),
     }
-
-
-def _regime_warnings(regime, op_kind, entries, live_pct, live_pct_min, notes):
-    """Catch the 'isolated win, e2e loss' class BEFORE optimization. Returns a warning string ('' if ok)."""
-    warns = []
-    q = (regime or {}).get("quant") or {}
-    method = (q.get("method") or "none")
-    # (1) live-seam guard: the profile is captured on the REAL online server, so the live kernel carries
-    #     the GPU time. A near-zero share means this seam isn't what the workload actually runs (the
-    #     classic unquantized-GEMM-serving-only-lm_head trap under --quantization fp8).
-    if entries and live_pct < live_pct_min:
-        warns.append(f"seam is only {live_pct}% GPU under the online regime (quant={method}); it is "
-                     f"probably NOT the live kernel — verify the seam (e.g. unquantized GEMM serving "
-                     f"only lm_head). Do NOT trust its weight/speedup for e2e.")
-    # (2) attention KV dtype: a kernel hardcoding bf16 KV will fault under fp8 KV (bf16 stride over fp8).
-    if op_kind in ("attn", "attention") and (regime or {}).get("kv_cache_dtype") in ("fp8", "fp8_e4m3", "fp8_e5m2"):
-        warns.append("online kv-cache-dtype=fp8: the attention oracle + kernel MUST use the fp8 KV "
-                     "layout/stride, else a bf16-stride read over fp8 bytes faults. Verify the captured "
-                     "KV dtype matches.")
-    # (3) compile baseline: norm/elementwise fused online via torch.compile -> eager ref is a strawman.
-    if (regime or {}).get("compile") == "torch_compile" and op_kind in ("norm", "reduction_norm", "elementwise", "rmsnorm", ""):
-        warns.append("online uses torch.compile fusion: the perf baseline must be the COMPILED/fused "
-                     "path, not unfused eager, or the speedup is a strawman.")
-    if warns:
-        notes.extend(warns)
-    return " ".join(warns)
 
 
 def _base_token(short_name):

--- a/e2e_workflow/scripts/attribute_weights.py
+++ b/e2e_workflow/scripts/attribute_weights.py
@@ -183,50 +183,195 @@ def _nearest(m, buckets):
 
 
 # --------------------------------------------------------------------------- #
-# Generic (attn / norm / elementwise / linear-attn / editable): meta carries captured cases with
-# explicit shapes; the profile usually exposes the same shapes -> match per case.
+# Case-based op_kinds (attn / linear-attn-recurrent / norm / elementwise / editable): meta carries
+# explicit shape cases, EACH TAGGED WITH A `regime` by the extractor. They all share ONE distribution
+# engine (`_distribute`); each op_kind differs only in its thin REGIME CLASSIFIER — how it splits the
+# kernel's profiled time into per-regime totals. GEMM/MoE keep the precise grid-based path above; this
+# is the unification for everything the trace can't pin to a shape (e.g. HIP/CUDA-graph decode).
 # --------------------------------------------------------------------------- #
-def attribute_generic(meta, entries, notes):
-    meta_cases = meta.get("cases") or []
-    # gather all profiled cases (with real dims) across the matched kernel entries
+def _case_size(dims):
+    """Size proxy for a case = element count of its first (principal) operand (e.g. tokens x feature,
+    batch x packed-dim). time ~ this proxy, so within a regime the larger-batch case gets more weight."""
+    for t in dims:
+        if t and all(isinstance(x, int) for x in t):
+            p = 1
+            for x in t:
+                p *= x
+            return p
+    return 1
+
+
+def _norm_meta_cases(meta):
+    """Normalize meta.cases -> [{name, dims, dtypes, regime, size}] (regime tagged by the extractor)."""
+    out = []
+    for mc in meta.get("cases") or []:
+        dims = mc.get("input_shapes") or mc.get("dims") or []
+        out.append({
+            "name": mc.get("sig") or mc.get("name") or _shape_name(dims),
+            "dims": dims,
+            "dtypes": mc.get("input_dtypes") or mc.get("dtypes") or [],
+            "regime": (mc.get("regime") or "").lower(),
+            "size": _case_size(dims),
+        })
+    return out
+
+
+def _members_split(members):
+    """Fractions to split a regime's total time across its member cases, proportional to the size
+    proxy (time ~ elements). Falls back to even split when sizes are unknown."""
+    sizes = [m["size"] for m in members]
+    ssum = sum(sizes)
+    if ssum <= 0:
+        return [(m, 1.0 / len(members)) for m in members]
+    return [(m, s / ssum) for m, s in zip(members, sizes)]
+
+
+def _distribute(mcases, regime_us, matched, notes, src="regime"):
+    """THE shared case-based engine. For each meta case: if a profiled shape matched it -> trace
+    weight; else split its regime's unmatched total (`regime_us[regime]`) across that regime's
+    unmatched members by the size prior. A regime meta declares but the profile timed at ZERO ->
+    weight 0 prior + loud warning (a capture-口径 artifact, not proof it's free; floor it via
+    --min-regime-share). `src` labels the prior weights (regime|regime_prior)."""
+    out = []
+    by_regime = {}
+    for c in mcases:
+        if c["name"] in matched:
+            m = matched[c["name"]]
+            out.append({"name": c["name"], "dims": c["dims"], "dtypes": c["dtypes"],
+                        "count": m.get("count"), "weight": round(m.get("weight", 0.0), 3),
+                        "weight_source": "trace", "regime": c["regime"]})
+        else:
+            by_regime.setdefault(c["regime"], []).append(c)
+    for regime, members in by_regime.items():
+        total = regime_us.get(regime, 0.0)
+        if total <= 0:
+            if regime:
+                notes.append(f"WARNING: regime '{regime}' present in meta but ZERO profiled time — "
+                             "likely a capture-biased window; set --min-regime-share to keep it.")
+            for c in members:
+                out.append({"name": c["name"], "dims": c["dims"], "dtypes": c["dtypes"],
+                            "count": None, "weight": 0.0, "weight_source": "prior", "regime": regime})
+            continue
+        for c, frac in _members_split(members):
+            out.append({"name": c["name"], "dims": c["dims"], "dtypes": c["dtypes"],
+                        "count": None, "weight": round(total * frac, 3),
+                        "weight_source": src, "regime": regime})
+    return out
+
+
+def _collect_prof(entries):
     prof = []
     for k in entries:
         for c in k.get("cases", []):
             if c.get("dims"):
                 prof.append(c)
-    cases = []
-    if not meta_cases:
-        # no explicit meta case list -> just pass the profile's own per-(shape,dtype) weights through
-        for c in prof:
-            cases.append({
-                "name": _shape_name(c["dims"]),
-                "dims": c["dims"], "dtypes": c.get("dtypes", []),
-                "count": c.get("count"), "weight": c.get("weight", 0.0),
-                "weight_source": "trace", "regime": "",
-            })
-        if not cases:
-            notes.append("no meta cases and no profiled shapes; nothing to weight.")
-        return cases
+    return prof
 
-    for mc in meta_cases:
-        dims = mc.get("input_shapes") or mc.get("dims") or []
-        dtypes = mc.get("input_dtypes") or mc.get("dtypes") or []
-        match = _best_shape_match(dims, prof)
-        if match is not None:
-            cases.append({
-                "name": mc.get("sig") or _shape_name(dims),
-                "dims": dims, "dtypes": dtypes,
-                "count": match.get("count"), "weight": match.get("weight", 0.0),
-                "weight_source": "trace", "regime": "",
-            })
+
+def _total_time(entries):
+    return sum(c.get("weight", 0.0) for k in entries for c in k.get("cases", []))
+
+
+def _shape_match_pass(mcases, prof):
+    """Match each meta case to a profiled (real-shape) case. Returns {case_name: prof_case} and the
+    summed matched weight."""
+    matched, matched_w = {}, 0.0
+    for c in mcases:
+        m = _best_shape_match(c["dims"], prof)
+        if m is not None:
+            matched[c["name"]] = m
+            matched_w += m.get("weight", 0.0)
+    return matched, matched_w
+
+
+def _classify_attn(mcases, entries, matched_w, total_w, notes):
+    """Attention regime classifier: a serving attn kernel runs in two regimes that the kernel NAME
+    discriminates — prefill (`...prefill...`, big-q causal FMHA) vs decode (`...paged...`/`...decode...`,
+    q=1 over the KV cache, usually graph-hidden). Split the UNMATCHED profiled time into those two
+    regime totals by name; whatever can't be named falls to the regime mix present in meta by size."""
+    decode_us = prefill_us = other_us = 0.0
+    for k in entries:
+        kw = sum(c.get("weight", 0.0) for c in k.get("cases", []) if not c.get("dims"))  # unmatched only
+        name = (k.get("name", "") + " " + k.get("short_name", "")).lower()
+        if any(t in name for t in ("decode", "paged", "_gqa", "mqa_decode")):
+            decode_us += kw
+        elif any(t in name for t in ("prefill", "context", "varlen", "fwd")):
+            prefill_us += kw
         else:
-            cases.append({
-                "name": mc.get("sig") or _shape_name(dims),
-                "dims": dims, "dtypes": dtypes, "count": None, "weight": 0.0,
-                "weight_source": "prior", "regime": "",
-            })
-    if any(c["weight_source"] == "prior" for c in cases):
-        notes.append("some meta cases had no matching profiled shape -> weight=0 prior (logged).")
+            other_us += kw
+    regime_us = {"decode": decode_us, "prefill": prefill_us}
+    if other_us > 0:  # spread unnamed remainder across whatever regimes meta declares, by size
+        regs = {c["regime"] for c in mcases if c["regime"]}
+        sz = {r: sum(c["size"] for c in mcases if c["regime"] == r) for r in regs}
+        ssum = sum(sz.values()) or 1.0
+        for r in regs:
+            regime_us[r] = regime_us.get(r, 0.0) + other_us * sz[r] / ssum
+        notes.append(f"attn: {other_us:.0f}us of unnamed launches spread across meta regimes by size.")
+    return regime_us
+
+
+def _classify_fallback(mcases, entries, matched_w, total_w, notes):
+    """Generic classifier (recurrent / norm / elementwise / editable): no name-based regime signal.
+    Assign ALL unmatched profiled time to the regime(s) the extractor tagged on the cases — if the
+    cases share a single regime (e.g. a pure-decode recurrent kernel) it all lands there; if they
+    span regimes (or are untagged) it is pooled and the within-regime size prior splits it. This is
+    what lets a HIP/CUDA-graph kernel (shapes hidden) still get a real time-proportional weight."""
+    remainder = total_w - matched_w
+    regs = [r for r in {c["regime"] for c in mcases}]
+    if remainder <= 0:
+        return {}
+    # pool everything; distribute across regimes proportional to each regime's total size, so a single
+    # tagged regime gets 100% and multi-regime splits by size (then _members_split splits within).
+    sz = {r: sum(c["size"] for c in mcases if c["regime"] == r) for r in regs}
+    ssum = sum(sz.values()) or 1.0
+    out = {r: remainder * (sz[r] / ssum) for r in regs}
+    notes.append(f"distributed {remainder:.0f}us of unattributed kernel time across "
+                 f"{len(mcases)} shape-hidden case(s) by size prior (regime_prior) — shapes absent "
+                 "from the trace (e.g. HIP/CUDA-graph decode); larger-batch case dominates.")
+    return out
+
+
+def attribute_attn(meta, entries, notes):
+    mcases = _norm_meta_cases(meta)
+    if not mcases:                      # no explicit cases -> degrade to pass-through of profiled shapes
+        return _passthrough(entries, notes)
+    prof = _collect_prof(entries)
+    matched, matched_w = _shape_match_pass(mcases, prof)
+    total_w = _total_time(entries)
+    regime_us = _classify_attn(mcases, entries, matched_w, total_w, notes)
+    return _distribute(mcases, regime_us, matched, notes, src="regime")
+
+
+def attribute_moe(meta, entries, notes):
+    """MoE grouped-GEMM = a GEMM whose effective M per expert = tokens*top_k/num_experts (routing-
+    dependent). The extractor bakes that effective M into decode/prefill m_buckets, so MoE reuses the
+    precise grid-based GEMM engine; routing skew makes the weights lower-confidence (noted)."""
+    notes.append("op_kind=moe: per-expert token counts are routing-dependent; effective-M buckets "
+                 "from meta drive a GEMM-style regime split. Treat weights as lower-confidence.")
+    return attribute_gemm(meta, entries, notes)
+
+
+def attribute_generic(meta, entries, notes):
+    mcases = _norm_meta_cases(meta)
+    if not mcases:
+        return _passthrough(entries, notes)
+    prof = _collect_prof(entries)
+    matched, matched_w = _shape_match_pass(mcases, prof)
+    total_w = _total_time(entries)
+    regime_us = _classify_fallback(mcases, entries, matched_w, total_w, notes)
+    src = "regime_prior" if regime_us else "prior"
+    return _distribute(mcases, regime_us, matched, notes, src=src)
+
+
+def _passthrough(entries, notes):
+    """No meta cases at all -> emit the profile's own per-(shape,dtype) weights verbatim."""
+    cases = []
+    for c in _collect_prof(entries):
+        cases.append({"name": _shape_name(c["dims"]), "dims": c["dims"], "dtypes": c.get("dtypes", []),
+                      "count": c.get("count"), "weight": c.get("weight", 0.0),
+                      "weight_source": "trace", "regime": ""})
+    if not cases:
+        notes.append("no meta cases and no profiled shapes; nothing to weight.")
     return cases
 
 
@@ -280,13 +425,16 @@ def main():
     if not entries:
         notes.append(f"no profile entries matched name '{name_match}'; weights are prior only.")
 
+    # op_kind-aware attribution. gemm/moe use the precise grid/bucket engine; attn and the case-based
+    # kinds (recurrent / norm / elementwise / editable) share the _distribute engine, differing only
+    # in their thin regime classifier. All roads produce the same {..., regime, weight_source} schema.
     if op_kind == "gemm":
         cases = attribute_gemm(meta, entries, notes)
+    elif op_kind == "moe":
+        cases = attribute_moe(meta, entries, notes)
+    elif op_kind == "attn":
+        cases = attribute_attn(meta, entries, notes)
     else:
-        # attn / moe / norm / elementwise / editable all carry explicit shapes in meta -> generic path.
-        if op_kind == "moe":
-            notes.append("op_kind=moe: per-expert token counts are routing-dependent; weights are "
-                         "shape-matched where possible, else prior. Treat as low-confidence.")
         cases = attribute_generic(meta, entries, notes)
 
     # optional regime floor (serving decode-protection): redistribute so each regime present in meta

--- a/e2e_workflow/scripts/bench_e2e.sh
+++ b/e2e_workflow/scripts/bench_e2e.sh
@@ -19,7 +19,13 @@
 #   adapter_bench  NUMP MAXC PROF   -> run ONE bench (random ISL/OSL), append a result JSON line to
 #                                      $RESULT_JSONL with canonical keys (output_throughput,
 #                                      median_ttft_ms, median_tpot_ms). PROF=1 => also emit a trace
-#                                      into $PROFILE_DIR.
+#                                      into $PROFILE_DIR. Honors optional REQUEST_RATE (req/s; empty=inf)
+#                                      to stagger arrivals.
+#   adapter_profile_window          -> OPTIONAL. Capture a profiler window (PROFILE_NUM_STEPS steps,
+#                                      record_shapes) on the ALREADY-RUNNING, warm, mid-load server, so
+#                                      the trace is the real steady-state prefill+decode MIX rather than
+#                                      a cold prefill ramp. If undefined, the PROFILE step falls back to
+#                                      a (less faithful) saturated PROF=1 bench.
 #
 # KEY OUTPUTS (written to $OUT_DIR):
 #   bench_runs.jsonl       one bench result object per repeat
@@ -204,7 +210,20 @@ fi
 # ---- modes ----
 REUSE_SERVER=${REUSE_SERVER:-0}       # 1 = a warm server is already up at HOST:PORT; don't launch/kill
 PROFILE=${PROFILE:-0}                 # 1 = also capture a profiler trace
-PROFILE_NUM_STEPS=${PROFILE_NUM_STEPS:-5}
+# Profiling is meant to capture the REAL continuous-batching steady state — prefill chunks and decode
+# steps interleaved as the scheduler actually runs them — NOT a cold prefill burst. So we profile a
+# WINDOW in the middle of a sustained, saturated load (see the PROFILE block below). Tunables:
+PROFILE_NUM_STEPS=${PROFILE_NUM_STEPS:-40}   # forward steps to capture. 5 couldn't even clear prefill
+                                             # (prefill ~ceil(tot_in/chunk) steps); ~40 spans into the
+                                             # mixed decode steady state. Decode is steady so a few tens
+                                             # is plenty; >100 just bloats the trace.
+PROFILE_WARMUP_SEC=${PROFILE_WARMUP_SEC:-15} # let the load pass the initial synchronized prefill ramp
+                                             # (≈TTFT) so the profiled window lands in the real mix.
+PROFILE_NUM_PROMPTS=${PROFILE_NUM_PROMPTS:-$((CONC * 4))}  # >CONC so the queue stays full and short
+                                             # (range-ratio>0) requests get replaced -> phases de-sync.
+PROFILE_REQUEST_RATE=${PROFILE_REQUEST_RATE:-}            # optional req/s to stagger arrivals; empty
+                                             # = inf (max_concurrency still caps in-flight at CONC).
+PROFILE_WINDOW_TIMEOUT=${PROFILE_WINDOW_TIMEOUT:-180}     # max wait for the trace file to appear.
 OUT_DIR=${OUT_DIR:-$(pwd)/e2e_bench_out}
 LOG=${LOG:-$OUT_DIR/server.log}
 
@@ -217,6 +236,7 @@ RESULT_JSONL="$OUT_DIR/bench_runs.jsonl"
 # export everything the adapter reads
 export MODEL HOST PORT TP GPU MEM_FRACTION EXTRA_SERVER_ARGS EXTRA_ENV OVERLAY_PYTHONPATH
 export ISL OSL CONC SEED PROFILE PROFILE_DIR PROFILE_NUM_STEPS BASE_URL RESULT_JSONL LOG
+export PROFILE_WARMUP_SEC PROFILE_NUM_PROMPTS PROFILE_REQUEST_RATE PROFILE_WINDOW_TIMEOUT
 export NUM_PROMPTS NUM_WARMUPS RANDOM_RANGE_RATIO BENCH_CLIENT
 export BENCH_TRUST_REMOTE_CODE HF_HUB_TRUST_REMOTE_CODE
 
@@ -290,11 +310,39 @@ for r in $(seq 1 "$REPEATS"); do
   adapter_bench "$NUM_PROMPTS" "$CONC" 0 || echo "!!! bench repeat $r failed (continuing)"
 done
 
-# ---- optional profile trace ----
+# ---- optional profile trace (STEADY-STATE MIX, not a cold prefill burst) ----
+# Real serving is continuous batching: at any instant some sequences are prefilling (chunks) and others
+# decoding, interleaved by the scheduler. A cold burst profiled from step 0 captures only the prefill
+# ramp (TTFT) and misses decode entirely (see knowledge/profile_parse.md). So we instead drive a
+# sustained, saturated load and profile a WINDOW once it has reached the mixed steady state.
 if [ "$PROFILE" = "1" ]; then
-  echo ">>> Profiling bench ($PROFILE_NUM_STEPS steps) ..."
   mkdir -p "$PROFILE_DIR"
-  adapter_bench "$CONC" "$CONC" 1 || echo "!!! profile run failed"
+  if declare -F adapter_profile_window >/dev/null; then
+    echo ">>> Profiling steady-state mix: warm ${PROFILE_WARMUP_SEC}s on a saturated load " \
+         "(${PROFILE_NUM_PROMPTS} prompts, conc ${CONC}${PROFILE_REQUEST_RATE:+, rate ${PROFILE_REQUEST_RATE}/s}), " \
+         "then capture ${PROFILE_NUM_STEPS} steps ..."
+    # Sustained background load (NOT timed, NOT profiled). Varied OSL (RANDOM_RANGE_RATIO>0) + more
+    # prompts than CONC means early finishers are replaced by fresh arrivals, so the in-flight
+    # sequences de-synchronize into a realistic prefill+decode mix.
+    REQUEST_RATE="${PROFILE_REQUEST_RATE}" \
+      adapter_bench "$PROFILE_NUM_PROMPTS" "$CONC" 0 >/dev/null 2>&1 &
+    _bg_load=$!
+    sleep "$PROFILE_WARMUP_SEC"
+    if kill -0 "$_bg_load" 2>/dev/null; then
+      adapter_profile_window || echo "!!! profile window failed"
+    else
+      echo "!!! background load exited before the profile window (load too short?) — falling back"
+      adapter_bench "$PROFILE_NUM_PROMPTS" "$CONC" 1 || echo "!!! profile run failed"
+    fi
+    kill "$_bg_load" 2>/dev/null || true; wait "$_bg_load" 2>/dev/null || true
+  else
+    # Backend without an HTTP profiler hook: can't profile a mid-stream window, but at least avoid the
+    # pure cold burst — send more prompts so the queue stays full past the prefill ramp and the captured
+    # steps include some decode. (Still less faithful than the windowed path; note it.)
+    echo ">>> Profiling (no window hook for $BACKEND; ${PROFILE_NUM_PROMPTS} prompts, ${PROFILE_NUM_STEPS} steps) ..."
+    REQUEST_RATE="${PROFILE_REQUEST_RATE}" \
+      adapter_bench "$PROFILE_NUM_PROMPTS" "$CONC" 1 || echo "!!! profile run failed"
+  fi
   echo ">>> Trace(s) in $PROFILE_DIR"
 fi
 

--- a/e2e_workflow/scripts/parse_profile.py
+++ b/e2e_workflow/scripts/parse_profile.py
@@ -135,19 +135,31 @@ def parse_torch_trace(path):
         dur = float(e.get("dur", 0.0) or 0.0)
         total_us += dur
         launches += 1
-        d = agg.setdefault(name, {"calls": 0, "total_us": 0.0, "shapes": set(), "dtypes": set()})
+        d = agg.setdefault(name, {"calls": 0, "total_us": 0.0, "shapes": set(),
+                                  "dtypes": set(), "by_case": {}})
         d["calls"] += 1
         d["total_us"] += dur
         ext = e.get("args", {}).get("External id")
+        sig = ""           # shape signature (json of non-empty input dims)
+        dtype_sig = ""     # dtype signature (json of per-tensor input types)
         if ext in op_by_ext:
             dims, types = op_by_ext[ext]
             sig = json.dumps([x for x in dims if x])
             if len(d["shapes"]) < 5:
                 d["shapes"].add(sig)
             if types:
-                for t in types:
-                    if t:
-                        d["dtypes"].add(t)
+                dts = [t for t in types if t]
+                if dts:
+                    dtype_sig = json.dumps(dts)
+                for t in dts:
+                    d["dtypes"].add(t)
+        # UNCAPPED per-(shape,dtype) breakdown — the workload model needs the full
+        # call-count distribution, not just the first 5 distinct shapes. Empty sigs
+        # (kernel launched with no linked cpu_op / no Input Dims, e.g. graph replay)
+        # collapse into one "shape unknown" bucket that build_workload() flags.
+        c = d["by_case"].setdefault((sig, dtype_sig), {"count": 0, "total_us": 0.0})
+        c["count"] += 1
+        c["total_us"] += dur
     return agg, total_us, launches
 
 
@@ -242,6 +254,67 @@ def build_summary(agg, total_us, launches, source, top_n, enrich=None):
     }
 
 
+def build_workload(agg, total_us, top_n, target=""):
+    """Per-kernel WORKLOAD MODEL: the shape+dtype case distribution a kernel actually sees in
+    the real workload, with a time-proportional weight per case.
+
+    For each kernel and each distinct (input shapes, input dtypes) it was called with, emit:
+      count                how many launches had this shape+dtype
+      baseline_latency_ms  measured per-call latency of the ORIGINAL kernel for this case
+      weight               total time this case contributes (= count * latency, in us); this is
+                           the workload-time weight the harness uses for the time-weighted metric
+      weight_source        "trace" when the shape was recovered, else "regime_prior" (shape hidden
+                           behind a graph-replay launch — count/time are real, shape is not)
+
+    This feeds the kernel_workflow harness so it benchmarks the SAME shapes/dtypes the workload
+    hits, weighted by their real wall-clock contribution. Correctness is unaffected (it stays on
+    the frozen reference_io.pt oracle); this is a performance-measurement model only.
+    """
+    items = sorted(agg.items(), key=lambda kv: kv[1]["total_us"], reverse=True)
+    if target:
+        items = [(n, d) for (n, d) in items if target.lower() in n.lower()]
+    kernels = []
+    for name, d in items[:top_n]:
+        cls, backend, editable, hint = classify(name)
+        by_case = d.get("by_case") or {}
+        cases = []
+        for (sig, dtype_sig), c in by_case.items():
+            dims = json.loads(sig) if sig else []
+            dtypes = json.loads(dtype_sig) if dtype_sig else []
+            count = c["count"]
+            tot_us = c["total_us"]
+            cases.append({
+                "dims": dims,
+                "dtypes": dtypes,
+                "count": count,
+                "baseline_latency_ms": round(tot_us / 1000.0 / max(count, 1), 6),
+                "weight": round(tot_us, 3),            # total us contributed in the workload
+                "weight_source": "trace" if dims else "regime_prior",
+            })
+        cases.sort(key=lambda x: x["weight"], reverse=True)
+        wsum = sum(x["weight"] for x in cases) or 1.0
+        for x in cases:
+            x["weight_norm"] = round(x["weight"] / wsum, 6)
+        kernels.append({
+            "name": name,
+            "short_name": short_name(name),
+            "classification": cls,
+            "backend_guess": backend,
+            "editable": editable,
+            "calls": d["calls"],
+            "total_ms": round(d["total_us"] / 1000.0, 4),
+            "pct_gpu_time": round(100.0 * d["total_us"] / total_us, 2) if total_us else 0.0,
+            "num_cases": len(cases),
+            "cases": cases,
+        })
+    return {
+        "schema": "workload-v1",
+        "total_gpu_time_ms": round(total_us / 1000.0, 4),
+        "num_kernels": len(kernels),
+        "kernels": kernels,
+    }
+
+
 def to_markdown(summ):
     L = []
     L.append(f"# Profile Top-{len(summ['top_kernels'])} — standardized summary\n")
@@ -270,6 +343,11 @@ def main():
     ap.add_argument("--rocprof-dir", default="")
     ap.add_argument("--top", type=int, default=25)
     ap.add_argument("--out", default="", help="path prefix; writes <out>.json and <out>.md")
+    ap.add_argument("--workload-out", default="",
+                    help="also write the per-(shape,dtype) weighted WORKLOAD MODEL json here "
+                         "(for the kernel_workflow harness; needs --torch-trace for shapes)")
+    ap.add_argument("--target", default="",
+                    help="optional kernel-name substring filter for --workload-out")
     args = ap.parse_args()
 
     if not args.torch_trace and not args.rocprof_dir:
@@ -297,6 +375,17 @@ def main():
         with open(args.out + ".md", "w") as fh:
             fh.write(md)
         sys.stderr.write(f"wrote {args.out}.json and {args.out}.md\n")
+
+    # Workload model (shape+dtype weighted cases). Per-shape data lives only in the torch trace;
+    # rocprof alone yields shape-unknown buckets (weight_source=regime_prior). Prefer the trace agg.
+    if args.workload_out:
+        w_agg = torch_agg if torch_agg else rp_agg
+        w_tot = torch_total if torch_agg else rp_total
+        wl = build_workload(w_agg or {}, w_tot or 0.0, args.top, args.target)
+        with open(args.workload_out, "w") as fh:
+            fh.write(json.dumps(wl, indent=2))
+        sys.stderr.write(f"wrote {args.workload_out} ({wl['num_kernels']} kernels)\n")
+
     print(md)
 
 

--- a/e2e_workflow/scripts/parse_profile.py
+++ b/e2e_workflow/scripts/parse_profile.py
@@ -255,8 +255,11 @@ def build_summary(agg, total_us, launches, source, top_n, enrich=None):
 
 
 def build_workload(agg, total_us, top_n, target=""):
-    """Per-kernel WORKLOAD MODEL: the shape+dtype case distribution a kernel actually sees in
-    the real workload, with a time-proportional weight per case.
+    """Per-kernel WEIGHT SIGNAL: each kernel's profiled time + (when the trace exposed them) its
+    per-(shape,dtype) call distribution. This is the raw input to `attribute_weights.py`, which JOINS
+    it with the extractor's `meta.json` shape cases (op_kind-aware) to produce the final WORKLOAD_SPEC
+    the harness consumes. This script stays kernel-type-agnostic: it never invents shapes and never
+    decides regimes — it only reports what the trace measured.
 
     For each kernel and each distinct (input shapes, input dtypes) it was called with, emit:
       count                how many launches had this shape+dtype

--- a/e2e_workflow/scripts/parse_regime.py
+++ b/e2e_workflow/scripts/parse_regime.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Parse the ONLINE serving REGIME from the server launch flags (+ model config).
+
+The #1 cause of "isolated win, e2e loss" is a microbench that runs in a regime the live server never
+uses: testing an UNQUANTIZED gemm when the server runs `--quantization fp8` (so the real seam is the
+fp8 path and the unquantized one only serves lm_head), verifying attention under bf16 KV when the
+server runs `--kv-cache-dtype fp8` (bf16 stride over fp8 bytes -> GPU fault), or comparing a Triton
+norm against eager when the server fuses it via torch.compile (strawman baseline).
+
+None of that is visible in a shape. It lives in the LAUNCH FLAGS and the model's own quant config. This
+parser turns those into a `regime` descriptor that the extractor writes into meta.json, so every
+downstream step (oracle capture, baseline choice, shape/dtype, weight attribution) matches online.
+
+Output (json):
+{
+  "quant": {"method": "fp8|fp8_blockscale|awq|gptq|compressed-tensors|none",
+            "weight_dtype": "fp8_e4m3fnuz|int4|...", "act_dtype": "fp8|bf16|...",
+            "block_size": [..]|null, "source": "flag|model_config|none"},
+  "kv_cache_dtype": "fp8|bf16|auto",
+  "compile": "torch_compile|eager",      # the baseline-relevant fusion state
+  "cuda_graph": true|false,
+  "attention_backend": "<str>|''",
+  "notes": "..."
+}
+
+Stdlib only.
+"""
+import argparse, json, os, re, sys
+
+
+def _tokenize(server_args):
+    """Split a launch flag string into a {flag: value} map. Handles `--k v`, `--k=v`, and bare flags."""
+    toks = (server_args or "").split()
+    out = {}
+    i = 0
+    while i < len(toks):
+        t = toks[i]
+        if t.startswith("--"):
+            key = t[2:]
+            if "=" in key:
+                k, v = key.split("=", 1)
+                out[k] = v
+            elif i + 1 < len(toks) and not toks[i + 1].startswith("--"):
+                out[key] = toks[i + 1]
+                i += 1
+            else:
+                out[key] = True   # bare boolean flag
+        i += 1
+    return out
+
+
+def _load_model_quant(model_config_path):
+    """Read the model's own quantization_config from config.json (a pre-quantized checkpoint)."""
+    if not model_config_path or not os.path.isfile(model_config_path):
+        return None
+    try:
+        with open(model_config_path) as fh:
+            cfg = json.load(fh)
+    except Exception:
+        return None
+    qc = cfg.get("quantization_config") or cfg.get("compression_config")
+    if not qc:
+        return None
+    method = (qc.get("quant_method") or qc.get("format") or qc.get("method") or "").lower()
+    # fp8 block-scale (e.g. DeepSeek/Qwen fp8) exposes weight_block_size
+    block = qc.get("weight_block_size") or qc.get("block_size")
+    fmt = (qc.get("fmt") or qc.get("activation_scheme") or "").lower()
+    wdt = "fp8_e4m3" if "fp8" in method or "fp8" in fmt else (
+        "int4" if ("4" in method or "awq" in method or "gptq" in method) else method or "")
+    return {"method": method or "fp8", "weight_dtype": wdt, "block_size": block, "fmt": fmt}
+
+
+def parse_regime(server_args, model_config_path=""):
+    flags = _tokenize(server_args)
+    notes = []
+
+    # ---- quantization: flag wins, else the model's own config ----
+    q_flag = flags.get("quantization")
+    model_q = _load_model_quant(model_config_path)
+    quant = {"method": "none", "weight_dtype": "", "act_dtype": "", "block_size": None, "source": "none"}
+    if isinstance(q_flag, str) and q_flag:
+        ql = q_flag.lower()
+        quant = {
+            "method": ql,
+            "weight_dtype": "fp8_e4m3" if "fp8" in ql else ("int4" if ("4" in ql or "awq" in ql or "gptq" in ql) else ql),
+            "act_dtype": "fp8" if "fp8" in ql else "bf16",
+            "block_size": (model_q or {}).get("block_size"),
+            "source": "flag",
+        }
+        if model_q and "fp8" in (model_q.get("weight_dtype") or "") and "fp8" not in ql:
+            notes.append(f"flag quantization='{q_flag}' but model config says fp8 — verify which wins online.")
+    elif model_q:
+        quant = {
+            "method": ("fp8_blockscale" if model_q.get("block_size") and "fp8" in (model_q.get("weight_dtype") or "")
+                       else model_q.get("method", "")),
+            "weight_dtype": model_q.get("weight_dtype", ""),
+            "act_dtype": "fp8" if "fp8" in (model_q.get("weight_dtype") or "") else "bf16",
+            "block_size": model_q.get("block_size"),
+            "source": "model_config",
+        }
+
+    # ---- KV cache dtype ----
+    kv = flags.get("kv-cache-dtype") or flags.get("kv_cache_dtype") or "auto"
+    if isinstance(kv, str):
+        kv = kv.lower()
+    if kv in ("auto", True, None):
+        kv = "auto"
+        notes.append("kv-cache-dtype=auto -> follows model compute dtype (usually bf16); confirm if fp8 desired.")
+
+    # ---- compile / fusion state (the baseline-relevant axis) ----
+    compile_on = bool(flags.get("enable-torch-compile") or flags.get("enable_torch_compile")
+                      or flags.get("torch-compile"))
+    compile_state = "torch_compile" if compile_on else "eager"
+
+    # ---- cuda graph (decode is graph-captured unless disabled) ----
+    cuda_graph = not bool(flags.get("disable-cuda-graph") or flags.get("disable_cuda_graph"))
+
+    attn = flags.get("attention-backend") or flags.get("attention_backend") or ""
+    if attn is True:
+        attn = ""
+
+    return {
+        "quant": quant,
+        "kv_cache_dtype": kv,
+        "compile": compile_state,
+        "cuda_graph": cuda_graph,
+        "attention_backend": attn,
+        "notes": " ".join(notes),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--server-args", default="",
+                    help="the server launch flag string (e.g. EXTRA_SERVER_ARGS / the recipe flags)")
+    ap.add_argument("--model-config", default="",
+                    help="path to the model's config.json (for a pre-quantized checkpoint)")
+    ap.add_argument("--out", default="", help="write regime json here (also printed to stdout)")
+    args = ap.parse_args()
+    regime = parse_regime(args.server_args, args.model_config)
+    js = json.dumps(regime, indent=2)
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(js)
+        sys.stderr.write(f"wrote {args.out}\n")
+    print(js)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e_workflow/scripts/tests/test_workload_alignment.py
+++ b/e2e_workflow/scripts/tests/test_workload_alignment.py
@@ -274,5 +274,98 @@ class TestBuildWorkload(unittest.TestCase):
         self.assertEqual(wl["kernels"][0]["name"], "foo_kernel")
 
 
+# --------------------------------------------------------------------------- #
+# op_kind-aware attribution beyond GEMM (attn / moe / recurrent) — the unified engine
+# --------------------------------------------------------------------------- #
+class TestAttributeAttn(unittest.TestCase):
+    """Attention: the regime is discriminated by the KERNEL NAME (prefill FMHA vs paged decode), and
+    the extractor tags each meta case with its regime. Decode usually hides its shape behind a graph,
+    so its time must still be attributed from the kernel total, not dropped."""
+    def _meta(self):
+        return {"op_kind": "attn", "short_name": "attn",
+                "cases": [{"sig": "prefill_q2048", "dims": [[2048, 24, 128]], "dtypes": ["bf16"],
+                           "regime": "prefill"},
+                          {"sig": "decode_q1", "dims": [[64, 24, 128]], "dtypes": ["bf16"],
+                           "regime": "decode"}]}
+
+    def test_name_based_regime_split_when_shapes_hidden(self):
+        # both launches are graph-hidden (dims=[]); only the NAME says which regime.
+        entries = [
+            {"name": "fmha_prefill_kernel", "short_name": "attn",
+             "cases": [{"dims": [], "weight": 800.0}]},
+            {"name": "paged_attention_decode_kernel", "short_name": "attn",
+             "cases": [{"dims": [], "weight": 200.0}]},
+        ]
+        notes = []
+        cases = attribute_weights.attribute_attn(self._meta(), entries, notes)
+        by = {c["name"]: c for c in cases}
+        self.assertEqual(by["prefill_q2048"]["regime"], "prefill")
+        self.assertEqual(by["decode_q1"]["regime"], "decode")
+        # prefill got the 800us, decode the 200us — NOT collapsed to 0 prior
+        self.assertAlmostEqual(by["prefill_q2048"]["weight"], 800.0, places=1)
+        self.assertAlmostEqual(by["decode_q1"]["weight"], 200.0, places=1)
+        self.assertTrue(all(c["weight_source"] == "regime" for c in cases))
+
+    def test_shape_matched_decode_uses_trace(self):
+        # profile exposed the decode shape -> trace weight; prefill stays name-classified.
+        entries = [
+            {"name": "fmha_prefill_kernel", "short_name": "attn",
+             "cases": [{"dims": [], "weight": 500.0}]},
+            {"name": "paged_attention_decode_kernel", "short_name": "attn",
+             "cases": [{"dims": [[64, 24, 128]], "dtypes": ["bf16"], "weight": 300.0, "count": 9}]},
+        ]
+        notes = []
+        cases = attribute_weights.attribute_attn(self._meta(), entries, notes)
+        by = {c["name"]: c for c in cases}
+        self.assertEqual(by["decode_q1"]["weight_source"], "trace")
+        self.assertAlmostEqual(by["decode_q1"]["weight"], 300.0, places=1)
+
+
+class TestAttributeRecurrent(unittest.TestCase):
+    """A pure-decode recurrent kernel runs only under a HIP/CUDA graph: shapes hidden, one regime.
+    Its total time must be distributed across the meta cases by the size prior (larger batch dominates),
+    NOT dropped to weight-0 prior (which would collapse the weighted metric to a geomean)."""
+    def test_size_prior_batch_dominates(self):
+        meta = {"op_kind": "linear_attn_recurrent", "short_name": "gdn_decode",
+                "cases": [{"sig": "decode_B64", "dims": [[64, 10240], [64, 48]], "regime": "decode"},
+                          {"sig": "decode_B1", "dims": [[1, 10240], [1, 48]], "regime": "decode"}]}
+        entries = [{"name": "gdn_decode_kernel", "short_name": "gdn_decode",
+                    "cases": [{"dims": [], "weight": 200000.0, "count": 1824}]}]
+        notes = []
+        cases = attribute_weights.attribute_generic(meta, entries, notes)
+        by = {c["name"]: c for c in cases}
+        self.assertEqual(by["decode_B64"]["weight_source"], "regime_prior")
+        total = sum(c["weight"] for c in cases)
+        # B64 element count 64*10240 >> B1 1*10240 -> ~0.985 share
+        self.assertGreater(by["decode_B64"]["weight"] / total, 0.95)
+        self.assertGreater(by["decode_B1"]["weight"], 0.0)   # tail is present, not zero
+
+    def test_no_total_no_shape_stays_prior_zero(self):
+        # no profiled time at all -> honest weight-0 prior (nothing to distribute)
+        meta = {"op_kind": "editable", "short_name": "k",
+                "cases": [{"sig": "c0", "dims": [[8, 8]], "regime": ""}]}
+        cases = attribute_weights.attribute_generic(meta, [], [])
+        self.assertEqual(cases[0]["weight"], 0.0)
+        self.assertEqual(cases[0]["weight_source"], "prior")
+
+
+class TestAttributeMoe(unittest.TestCase):
+    """MoE grouped-GEMM reuses the precise bucket/grid GEMM engine (effective-M from routing) and adds
+    a low-confidence note."""
+    def test_moe_delegates_to_gemm_engine(self):
+        meta = {"op_kind": "moe", "short_name": "fused_moe",
+                "a_shape": ["M", 512], "b_shape": [1024, 512], "dtype": "fp8_e4m3",
+                "decode_m_buckets": [8], "prefill_m_buckets": [2048]}
+        entries = [{"name": "fused_moe GRID_MN_8 BLOCK_SIZE_N_128", "short_name": "fused_moe",
+                    "cases": [{"dims": [], "weight": 1000.0}]},
+                   {"name": "fused_moe GRID_MN_512 BLOCK_SIZE_N_128", "short_name": "fused_moe",
+                    "cases": [{"dims": [], "weight": 5000.0}]}]
+        notes = []
+        cases = attribute_weights.attribute_moe(meta, entries, notes)
+        regimes = {c["regime"] for c in cases}
+        self.assertEqual(regimes, {"decode", "prefill"})
+        self.assertTrue(any("routing-dependent" in n for n in notes))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/e2e_workflow/scripts/tests/test_workload_alignment.py
+++ b/e2e_workflow/scripts/tests/test_workload_alignment.py
@@ -236,7 +236,8 @@ class TestAttributeWeightsEndToEnd(unittest.TestCase):
             self.assertGreaterEqual(dshare, 0.29)
         finally:
             for p in (meta_p, prof_p, out_p):
-                os.path.exists(p) and os.unlink(p)
+                if os.path.exists(p):
+                    os.unlink(p)
 
 
 # --------------------------------------------------------------------------- #
@@ -347,6 +348,87 @@ class TestAttributeRecurrent(unittest.TestCase):
         cases = attribute_weights.attribute_generic(meta, [], [])
         self.assertEqual(cases[0]["weight"], 0.0)
         self.assertEqual(cases[0]["weight_source"], "prior")
+
+
+class TestPassthrough(unittest.TestCase):
+    """When meta has no explicit cases, _passthrough emits the profile's own per-(shape,dtype)
+    weights verbatim — the fallback for kernels the extractor didn't tag with cases."""
+    def test_passthrough_emits_profile_shapes(self):
+        entries = [{"name": "k", "short_name": "k", "cases": [
+            {"dims": [[8, 128]], "dtypes": ["bf16"], "weight": 100.0, "count": 3},
+            {"dims": [[16, 128]], "dtypes": ["bf16"], "weight": 200.0, "count": 7},
+        ]}]
+        notes = []
+        cases = attribute_weights._passthrough(entries, notes)
+        self.assertEqual(len(cases), 2)
+        self.assertTrue(all(c["weight_source"] == "trace" for c in cases))
+        self.assertAlmostEqual(cases[0]["weight"], 100.0)
+        self.assertAlmostEqual(cases[1]["weight"], 200.0)
+
+    def test_passthrough_empty_profile(self):
+        notes = []
+        cases = attribute_weights._passthrough([], notes)
+        self.assertEqual(cases, [])
+        self.assertTrue(any("nothing to weight" in n for n in notes))
+
+
+class TestRegimeFloorEdgeCases(unittest.TestCase):
+    """Edge cases in _apply_regime_floor: overflow guard, and non-GEMM (no per-case M) even split."""
+    def test_floor_overflow_skips(self):
+        cases = [
+            {"regime": "decode", "weight": 0.0, "weight_source": "prior"},
+            {"regime": "prefill", "weight": 0.0, "weight_source": "prior"},
+            {"regime": "other", "weight": 100.0, "weight_source": "regime"},
+        ]
+        notes = []
+        attribute_weights._apply_regime_floor(cases, 0.6, notes)
+        self.assertTrue(any("skipped" in n for n in notes))
+
+    def test_non_gemm_even_split(self):
+        cases = [
+            {"name": "d1", "regime": "decode", "weight": 0.0, "weight_source": "prior"},
+            {"name": "d2", "regime": "decode", "weight": 0.0, "weight_source": "prior"},
+            {"name": "p1", "regime": "prefill", "weight": 100.0, "weight_source": "regime"},
+        ]
+        notes = []
+        attribute_weights._apply_regime_floor(cases, 0.3, notes)
+        decode_cases = [c for c in cases if c["regime"] == "decode"]
+        self.assertTrue(all(c["weight_source"] == "regime_floor" for c in decode_cases))
+        self.assertAlmostEqual(decode_cases[0]["weight"], decode_cases[1]["weight"])
+        total = sum(c["weight"] for c in cases)
+        decode_share = sum(c["weight"] for c in decode_cases) / total
+        self.assertAlmostEqual(decode_share, 0.3, places=2)
+
+
+class TestAttnUnnamedSpreading(unittest.TestCase):
+    """When attention launches can't be name-classified (no decode/prefill/paged keywords), the
+    unnamed time is spread across meta regimes by size."""
+    def test_unnamed_spread_by_size(self):
+        meta = {"op_kind": "attn", "short_name": "attn",
+                "cases": [{"sig": "prefill_q2048", "dims": [[2048, 24, 128]], "dtypes": ["bf16"],
+                           "regime": "prefill"},
+                          {"sig": "decode_q1", "dims": [[64, 24, 128]], "dtypes": ["bf16"],
+                           "regime": "decode"}]}
+        entries = [{"name": "some_unknown_attn_op", "short_name": "attn",
+                    "cases": [{"dims": [], "weight": 1000.0}]}]
+        notes = []
+        cases = attribute_weights.attribute_attn(meta, entries, notes)
+        self.assertTrue(any("unnamed launches" in n for n in notes))
+        by = {c["name"]: c for c in cases}
+        self.assertGreater(by["prefill_q2048"]["weight"], by["decode_q1"]["weight"])
+        self.assertGreater(by["decode_q1"]["weight"], 0.0)
+
+
+class TestBaseToken(unittest.TestCase):
+    """_base_token should keep embedded digits (a8w8) and only strip trailing _NNN suffixes."""
+    def test_keeps_embedded_digits(self):
+        self.assertEqual(attribute_weights._base_token("_gemm_a8w8"), "_gemm_a8w8")
+
+    def test_strips_trailing_numeric_suffix(self):
+        self.assertEqual(attribute_weights._base_token("_gemm_a8w8_128"), "_gemm_a8w8")
+
+    def test_drops_whitespace_params(self):
+        self.assertEqual(attribute_weights._base_token("_gemm_a8w8 GRID_MN_8"), "_gemm_a8w8")
 
 
 class TestAttributeMoe(unittest.TestCase):

--- a/e2e_workflow/scripts/tests/test_workload_alignment.py
+++ b/e2e_workflow/scripts/tests/test_workload_alignment.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Unit tests for the workload-alignment scripts (stdlib only; no pytest needed).
+
+Run:  python3 -m unittest discover -s e2e_workflow/scripts/tests -v
+  or: python3 e2e_workflow/scripts/tests/test_workload_alignment.py
+
+Covers the three deterministic, pure-stdlib pieces the workload-aligned harness relies on:
+  - parse_regime.py        : launch-flag/model-config -> regime descriptor
+  - attribute_weights.py   : meta shapes JOIN profile weight signal (op_kind-aware) + regime guards
+  - parse_profile.build_workload : trace agg -> per-(shape,dtype) weighted workload model
+"""
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+
+SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _load(mod_name, filename):
+    path = os.path.join(SCRIPTS_DIR, filename)
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+parse_regime = _load("parse_regime", "parse_regime.py")
+attribute_weights = _load("attribute_weights", "attribute_weights.py")
+parse_profile = _load("parse_profile", "parse_profile.py")
+
+
+def _write_json(obj):
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w") as fh:
+        json.dump(obj, fh)
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# parse_regime.py
+# --------------------------------------------------------------------------- #
+class TestParseRegime(unittest.TestCase):
+    def test_empty_defaults(self):
+        r = parse_regime.parse_regime("")
+        self.assertEqual(r["quant"]["method"], "none")
+        self.assertEqual(r["quant"]["source"], "none")
+        self.assertEqual(r["kv_cache_dtype"], "auto")
+        self.assertEqual(r["compile"], "eager")
+        self.assertTrue(r["cuda_graph"])
+
+    def test_fp8_quant_flag(self):
+        r = parse_regime.parse_regime("--quantization fp8")
+        self.assertEqual(r["quant"]["method"], "fp8")
+        self.assertEqual(r["quant"]["act_dtype"], "fp8")
+        self.assertEqual(r["quant"]["weight_dtype"], "fp8_e4m3")
+        self.assertEqual(r["quant"]["source"], "flag")
+
+    def test_equals_form_and_full_serving_flags(self):
+        r = parse_regime.parse_regime(
+            "--quantization=fp8 --kv-cache-dtype=fp8 --enable-torch-compile --disable-cuda-graph")
+        self.assertEqual(r["quant"]["method"], "fp8")
+        self.assertEqual(r["kv_cache_dtype"], "fp8")
+        self.assertEqual(r["compile"], "torch_compile")
+        self.assertFalse(r["cuda_graph"])
+
+    def test_awq_int4(self):
+        r = parse_regime.parse_regime("--quantization awq")
+        self.assertEqual(r["quant"]["weight_dtype"], "int4")
+        self.assertEqual(r["quant"]["act_dtype"], "bf16")
+
+    def test_model_config_fp8_blockscale(self):
+        cfg = _write_json({"quantization_config": {"quant_method": "fp8",
+                                                   "weight_block_size": [128, 128]}})
+        try:
+            r = parse_regime.parse_regime("", cfg)   # no flag -> model config wins
+            self.assertEqual(r["quant"]["source"], "model_config")
+            self.assertEqual(r["quant"]["method"], "fp8_blockscale")
+            self.assertEqual(r["quant"]["block_size"], [128, 128])
+            self.assertEqual(r["quant"]["act_dtype"], "fp8")
+        finally:
+            os.unlink(cfg)
+
+    def test_flag_overrides_but_notes_model_mismatch(self):
+        cfg = _write_json({"quantization_config": {"quant_method": "fp8"}})
+        try:
+            r = parse_regime.parse_regime("--quantization none", cfg)
+            self.assertEqual(r["quant"]["source"], "flag")
+            self.assertIn("model config says fp8", r["notes"])
+        finally:
+            os.unlink(cfg)
+
+
+# --------------------------------------------------------------------------- #
+# attribute_weights.py
+# --------------------------------------------------------------------------- #
+class TestAttributeGemm(unittest.TestCase):
+    def _meta(self, **kw):
+        m = {
+            "op_kind": "gemm", "short_name": "_gemm_a8w8",
+            "a_shape": ["M", 512], "b_shape": [1024, 512], "dtype": "fp8_e4m3",
+            "decode_m_buckets": [1, 128], "prefill_m_buckets": [2048],
+        }
+        m.update(kw)
+        return m
+
+    def _entries(self, decode_us, prefill_us):
+        # GRID_MN small -> decode (M_blocks<=1.5); large -> prefill. N=1024, BLOCK_SIZE_N=128 -> nblk=8.
+        return [
+            {"name": "_gemm_a8w8 GRID_MN_8 BLOCK_SIZE_N_128", "short_name": "_gemm_a8w8",
+             "pct_gpu_time": 5.0, "cases": [{"dims": [], "weight": decode_us}]},
+            {"name": "_gemm_a8w8 GRID_MN_512 BLOCK_SIZE_N_128", "short_name": "_gemm_a8w8",
+             "pct_gpu_time": 20.0, "cases": [{"dims": [], "weight": prefill_us}]},
+        ]
+
+    def test_gemm_regime_split_and_shapes(self):
+        notes = []
+        cases = attribute_weights.attribute_gemm(self._meta(), self._entries(1000.0, 5000.0), notes)
+        regimes = {c["regime"] for c in cases}
+        self.assertEqual(regimes, {"decode", "prefill"})
+        # shapes always come from meta: [[M,K],[N,K]] with K=512, N=1024
+        for c in cases:
+            self.assertEqual(c["dims"][0][1], 512)
+            self.assertEqual(c["dims"][1], [1024, 512])
+            self.assertEqual(c["dtypes"], ["fp8_e4m3", "fp8_e4m3"])
+            self.assertEqual(c["weight_source"], "regime")
+        # decode within-regime prior: 80% on the largest decode bucket (128)
+        decode = {c["m"]: c["weight"] for c in cases if c["regime"] == "decode"}
+        self.assertAlmostEqual(decode[128], 1000.0 * 0.8, places=3)
+        self.assertAlmostEqual(decode[1], 1000.0 * 0.2, places=3)
+
+    def test_gemm_trace_weight_when_profile_exposes_shape(self):
+        notes = []
+        entries = [{"name": "_gemm_a8w8 GRID_MN_8 BLOCK_SIZE_N_128", "short_name": "_gemm_a8w8",
+                    "pct_gpu_time": 5.0,
+                    "cases": [{"dims": [[128, 512], [1024, 512]], "weight": 777.0}]}]
+        cases = attribute_weights.attribute_gemm(self._meta(), entries, notes)
+        traced = [c for c in cases if c["weight_source"] == "trace"]
+        self.assertTrue(traced)
+        self.assertAlmostEqual(traced[0]["weight"], 777.0, places=3)
+
+    def test_zero_decode_time_warns(self):
+        notes = []
+        cases = attribute_weights.attribute_gemm(self._meta(), self._entries(0.0, 5000.0), notes)
+        decode = [c for c in cases if c["regime"] == "decode"]
+        self.assertTrue(all(c["weight"] == 0.0 for c in decode))
+        self.assertTrue(all(c["weight_source"] == "prior" for c in decode))
+        self.assertTrue(any("ZERO profiled" in n for n in notes))
+
+    def test_regime_floor_protects_decode(self):
+        cases = attribute_weights.attribute_gemm(self._meta(), self._entries(0.0, 5000.0), [])
+        notes = []
+        attribute_weights._apply_regime_floor(cases, 0.3, notes)
+        total = sum(c["weight"] for c in cases)
+        decode_share = sum(c["weight"] for c in cases if c["regime"] == "decode") / total
+        self.assertAlmostEqual(decode_share, 0.3, places=2)
+        self.assertTrue(any(c["weight_source"] == "regime_floor"
+                            for c in cases if c["regime"] == "decode"))
+
+
+class TestAttributeGeneric(unittest.TestCase):
+    def test_shape_match_trace_vs_prior(self):
+        # q1 trailing dims [8,128] match the profiled shape (exact/fuzzy -> trace); q3 has DIFFERENT
+        # trailing dims [16,128] so the fuzzy matcher can't attribute it -> prior (weight 0).
+        meta = {"op_kind": "attn", "short_name": "_attn_fwd",
+                "cases": [{"sig": "q1", "input_shapes": [[1, 8, 128]], "input_dtypes": ["bf16"]},
+                          {"sig": "q2", "input_shapes": [[2048, 16, 128]], "input_dtypes": ["bf16"]}]}
+        entries = [{"name": "_attn_fwd_kernel", "short_name": "_attn_fwd", "pct_gpu_time": 10.0,
+                    "cases": [{"dims": [[1, 8, 128]], "dtypes": ["bf16"], "weight": 100.0, "count": 5}]}]
+        notes = []
+        cases = attribute_weights.attribute_generic(meta, entries, notes)
+        by = {c["name"]: c for c in cases}
+        self.assertEqual(by["q1"]["weight_source"], "trace")
+        self.assertAlmostEqual(by["q1"]["weight"], 100.0, places=3)
+        self.assertEqual(by["q2"]["weight_source"], "prior")
+        self.assertEqual(by["q2"]["weight"], 0.0)
+
+
+class TestQuantStamping(unittest.TestCase):
+    """The regime's job that REMAINS: stamp per-operand dtype/quant so the harness builds in-regime
+    operands (fp8 + scales, not bf16). The old _regime_warnings gate was removed by design."""
+    def test_quant_block_fp8_blockscale(self):
+        meta = {"dtype": "fp8_e4m3", "out_dtype": "bf16", "weight_block_size": [128, 128]}
+        regime = {"quant": {"method": "fp8", "act_dtype": "fp8", "block_size": [128, 128]},
+                  "kv_cache_dtype": "fp8"}
+        q = attribute_weights._quant_block(meta, regime)
+        self.assertEqual(q["act_dtype"], "fp8")
+        self.assertEqual(q["weight_dtype"], "fp8_e4m3")
+        self.assertEqual(q["out_dtype"], "bf16")
+        self.assertEqual(q["weight_block_size"], [128, 128])
+        self.assertEqual(q["scale_dtype"], "float32")
+        self.assertEqual(q["kv_cache_dtype"], "fp8")
+
+    def test_no_regime_warnings_attr(self):
+        # the gate machinery must be gone
+        self.assertFalse(hasattr(attribute_weights, "_regime_warnings"))
+
+
+class TestAttributeWeightsEndToEnd(unittest.TestCase):
+    """Drive main() through the filesystem like the extractor does."""
+    def test_main_stamps_quant_and_normalizes(self):
+        meta = {"op_kind": "gemm", "short_name": "_gemm_a8w8",
+                "a_shape": ["M", 512], "b_shape": [1024, 512], "dtype": "fp8_e4m3",
+                "decode_m_buckets": [1, 128], "prefill_m_buckets": [2048],
+                "weight_block_size": [128, 128],
+                "regime": {"quant": {"method": "fp8", "act_dtype": "fp8", "block_size": [128, 128]},
+                           "kv_cache_dtype": "auto", "compile": "eager"}}
+        prof = {"schema": "workload-v1", "kernels": [
+            {"name": "_gemm_a8w8 GRID_MN_8 BLOCK_SIZE_N_128", "short_name": "_gemm_a8w8",
+             "pct_gpu_time": 5.0, "cases": [{"dims": [], "weight": 1000.0}]},
+            {"name": "_gemm_a8w8 GRID_MN_512 BLOCK_SIZE_N_128", "short_name": "_gemm_a8w8",
+             "pct_gpu_time": 20.0, "cases": [{"dims": [], "weight": 5000.0}]}]}
+        meta_p, prof_p = _write_json(meta), _write_json(prof)
+        out_p = tempfile.mkstemp(suffix=".json")[1]
+        try:
+            import sys
+            argv = sys.argv
+            sys.argv = ["attribute_weights.py", "--meta", meta_p, "--profile-weights", prof_p,
+                        "--name-match", "_gemm_a8w8", "--min-regime-share", "0.3", "--out", out_p]
+            try:
+                attribute_weights.main()
+            finally:
+                sys.argv = argv
+            with open(out_p) as fh:
+                out = json.load(fh)
+            self.assertEqual(out["schema"], "workload-v1")
+            self.assertEqual(out["op_kind"], "gemm")
+            self.assertTrue(out["cases"])
+            self.assertAlmostEqual(sum(c["weight_norm"] for c in out["cases"]), 1.0, places=4)
+            for c in out["cases"]:                       # quant stamped from meta/regime
+                self.assertEqual(c["quant"]["act_dtype"], "fp8")
+                self.assertEqual(c["quant"]["weight_block_size"], [128, 128])
+            # decode floor honored end-to-end
+            dshare = sum(c["weight_norm"] for c in out["cases"] if c["regime"] == "decode")
+            self.assertGreaterEqual(dshare, 0.29)
+        finally:
+            for p in (meta_p, prof_p, out_p):
+                os.path.exists(p) and os.unlink(p)
+
+
+# --------------------------------------------------------------------------- #
+# parse_profile.build_workload
+# --------------------------------------------------------------------------- #
+class TestBuildWorkload(unittest.TestCase):
+    def test_per_case_weights_and_provenance(self):
+        agg = {"some_gemm_kernel": {
+            "calls": 15, "total_us": 1500.0, "shapes": set(), "dtypes": set(),
+            "by_case": {
+                ('[[1, 512]]', '["c10::BFloat16"]'): {"count": 10, "total_us": 1000.0},
+                ('', ''): {"count": 5, "total_us": 500.0},     # shape hidden (graph replay)
+            }}}
+        wl = parse_profile.build_workload(agg, 1500.0, top_n=25)
+        self.assertEqual(wl["schema"], "workload-v1")
+        self.assertEqual(wl["num_kernels"], 1)
+        k = wl["kernels"][0]
+        self.assertEqual(k["pct_gpu_time"], 100.0)
+        self.assertEqual(len(k["cases"]), 2)
+        # sorted by weight desc -> the traced (1000us) case first
+        self.assertEqual(k["cases"][0]["weight_source"], "trace")
+        self.assertEqual(k["cases"][0]["dims"], [[1, 512]])
+        self.assertAlmostEqual(k["cases"][0]["baseline_latency_ms"], 0.1, places=6)
+        self.assertEqual(k["cases"][1]["weight_source"], "regime_prior")
+        self.assertEqual(k["cases"][1]["dims"], [])
+        self.assertAlmostEqual(sum(c["weight_norm"] for c in k["cases"]), 1.0, places=4)
+
+    def test_target_filter(self):
+        agg = {"foo_kernel": {"calls": 1, "total_us": 10.0, "shapes": set(), "dtypes": set(),
+                              "by_case": {('', ''): {"count": 1, "total_us": 10.0}}},
+               "bar_kernel": {"calls": 1, "total_us": 20.0, "shapes": set(), "dtypes": set(),
+                              "by_case": {('', ''): {"count": 1, "total_us": 20.0}}}}
+        wl = parse_profile.build_workload(agg, 30.0, top_n=25, target="foo")
+        self.assertEqual(wl["num_kernels"], 1)
+        self.assertEqual(wl["kernels"][0]["name"], "foo_kernel")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/kernel_workflow/README.md
+++ b/kernel_workflow/README.md
@@ -77,10 +77,30 @@ Workflow({
     mode: "optimize",          // optional: "optimize" (default, edit an existing kernel) | "author"
     target_language: "triton", // author mode: triton (always) | flydsl | hip | ck — the language to write
     op_spec: {},               // author mode: {op_kind, shapes, dtype, math_contract, regime} for the op
-    perf_knowledge_dir: ""   // optional: AMD authoring knowledge base the author_engineer reads
+    perf_knowledge_dir: "",  // optional: AMD authoring knowledge base the author_engineer reads
+    // --- workload alignment (optional; aligns the PERF harness with the real workload) ---
+    workload_spec_path: "",    // optional: path to a workload-v1 json (parse_profile.py --workload-out).
+                               //   The benchmark harness then times the EXACT (shape,dtype) cases the
+                               //   workload hits, weighted by each case's total-time contribution, and
+                               //   the PRIMARY metric becomes the time-weighted ratio-of-sums (the
+                               //   unweighted geomean is kept as a secondary diagnostic). Correctness is
+                               //   unaffected (it stays on the frozen reference_io.pt oracle).
+                               //   Also accepted as op_spec.workload_path, or op_spec.workload (inline).
   }
 })
 ```
+
+### Workload alignment (NEW)
+By default the harness benchmarks small/medium/large cases unweighted. Pass a **workload spec** to
+instead benchmark the shapes/dtypes the kernel actually sees in production, weighted by how much
+wall-clock each contributes (`weight = call_count × baseline_latency`). Generate one from a profiler
+trace with `python3 e2e_workflow/scripts/parse_profile.py --torch-trace <trace> --workload-out
+workload.json [--target <kernel_name>]`, then pass `workload_spec_path: ".../workload.json"`. The
+optimization target becomes the **time-weighted ratio-of-sums**
+`Σ count·baseline / Σ count·optimized` (true wall-clock speedup of the kernel's total workload
+contribution); the unweighted geomean is still reported. The perf **baseline is the original/extracted
+implementation**, never an LLM naive reimplementation. When invoked from the e2e layer this is wired
+automatically (profiler → extractor → `op_spec.workload_path`).
 
 ### Author mode (NEW)
 `mode="author"` is for when there is **no existing source to optimize** — a hot op (e.g. a library

--- a/kernel_workflow/kernel_workflow.js
+++ b/kernel_workflow/kernel_workflow.js
@@ -75,6 +75,31 @@ const OP_SPEC = A.op_spec || {};
 // This turns on an OPTIONAL capture+replay smoke in the verify step so that failure is caught at the cheap
 // isolated stage. Unset (standalone single-kernel runs / non-graph ops) => byte-identical to before.
 const REQUIRE_GRAPH_CAPTURE = !!(OP_SPEC && OP_SPEC.cuda_graph_safe === true);
+// WORKLOAD ALIGNMENT (optional). When the caller supplies the real-workload shape/dtype case
+// distribution, the benchmark harness benchmarks EXACTLY those (shape, dtype) cases, weights each
+// by its total time contribution in the workload (weight = count * baseline_latency), and the
+// optimization target becomes the time-weighted ratio-of-sums instead of an unweighted geomean.
+//   workload_spec_path : path to a workload-v1 json (produced by parse_profile.py --workload-out,
+//                        or hand-written). The benchmark_engineer reads it (JS can't touch FS).
+//   op_spec.workload   : inline cases, same shape as a workload-v1 "kernels[].cases" list (or the
+//                        full object). Takes precedence; weight_source becomes "caller".
+// Both unset => unweighted behavior, byte-identical to before. Correctness ALWAYS stays on the
+// frozen reference_io.pt oracle; this only shapes the PERFORMANCE measurement.
+const WORKLOAD_SPEC_PATH = String(A.workload_spec_path || (OP_SPEC && OP_SPEC.workload_path) || '').trim();
+const WORKLOAD_SPEC = (OP_SPEC && OP_SPEC.workload) || A.workload || null;
+const HAS_WORKLOAD = !!(WORKLOAD_SPEC_PATH ||
+  (Array.isArray(WORKLOAD_SPEC) && WORKLOAD_SPEC.length) ||
+  (WORKLOAD_SPEC && Array.isArray(WORKLOAD_SPEC.kernels) && WORKLOAD_SPEC.kernels.length));
+// PRIMARY-metric selector: prefer the time-weighted number when a workload spec is in play and the
+// agent reported one; otherwise fall back to the geomean (unweighted runs => unchanged behavior).
+const primSpeedup = (o) => {
+  if (!o) return 0;
+  const w = o.verified_weighted != null ? o.verified_weighted
+          : (o.speedup_weighted != null ? o.speedup_weighted : null);
+  if (HAS_WORKLOAD && Number.isFinite(w)) return w;
+  const g = o.verified_geomean != null ? o.verified_geomean : o.speedup_geomean;
+  return Number.isFinite(g) ? g : 0;
+};
 const KERNEL_KNOWLEDGE_DIR = String(A.perf_knowledge_dir ||
   (WORKFLOW_DIR ? WORKFLOW_DIR.replace(/\/[^/]*$/, '') + '/perf_knowledge' : '')).replace(/\/+$/, '');
 // Expert skills = human-authored, validated kernel recipes (perf_knowledge/expert_skills/). ADVISORY
@@ -143,6 +168,14 @@ const perCase = {
       baseline_ms: { type: 'number' },
       optimized_ms: { type: 'number' },
       speedup: { type: 'number' },
+      // Workload-alignment fields (present only when a WORKLOAD_SPEC drives the harness; absent
+      // on a normal unweighted run). weight = this case's total time contribution in the real
+      // workload (count * baseline_latency); it is the coefficient the time-weighted metric uses.
+      weight: { type: 'number' },
+      count: { type: 'number' },
+      dims: { type: 'array', items: { type: 'array', items: { type: 'number' } } },
+      dtypes: { type: 'array', items: { type: 'string' } },
+      weight_source: { type: 'string' }, // trace | tracelens | regime_prior | caller
     },
     required: ['name', 'speedup'],
   },
@@ -186,6 +219,12 @@ const BENCH_SCHEMA = obj({
   benchmark_cmd: { type: 'string' }, profile_cmd: { type: 'string' }, parse_hint: { type: 'string' },
   baseline_per_case: { type: 'array', items: { type: 'object', additionalProperties: true } },
   baseline_geomean_ms: { type: 'number' }, num_test_cases: { type: 'number' },
+  // Workload-aligned outputs: present when a WORKLOAD_SPEC drove case selection + weights.
+  // baseline_weighted_total_ms = sum(weight_i * baseline_latency_i) — the denominator of the
+  // time-weighted ratio-of-sums metric. workload_aligned flags that weights are real (not 1).
+  workload_aligned: { type: 'boolean' },
+  baseline_weighted_total_ms: { type: 'number' },
+  weights_provenance: { type: 'string' }, // e.g. "trace" | "caller" | "regime_prior" | "mixed"
   reliable: { type: 'boolean' }, notes: { type: 'string' },
 }, ['commandment_path', 'baseline_per_case', 'baseline_geomean_ms']);
 
@@ -217,6 +256,9 @@ const PLAN_SCHEMA = obj({
 const ENG_SCHEMA = obj({
   engineer_id: { type: 'string' }, specialty: { type: 'string' }, task: { type: 'string' },
   strategy: { type: 'string' }, speedup_geomean: { type: 'number' }, speedup_arithmetic: { type: 'number' },
+  // Time-weighted ratio-of-sums vs the TRUE baseline (PRIMARY metric when workload_aligned).
+  // = sum(weight_i*baseline_i) / sum(weight_i*optimized_i). Omitted on unweighted runs.
+  speedup_weighted: { type: 'number' },
   per_case: perCase, status: { type: 'string' }, patch_file: { type: 'string' },
   strategies_tried: { type: 'array', items: { type: 'string' } }, notes: { type: 'string' },
 }, ['status', 'speedup_geomean']);
@@ -224,6 +266,7 @@ const ENG_SCHEMA = obj({
 const VERIFY_SCHEMA = obj({
   status: { type: 'string' }, correctness: { type: 'string' },
   verified_geomean: { type: 'number' }, verified_arithmetic: { type: 'number' },
+  verified_weighted: { type: 'number' }, // time-weighted ratio-of-sums (PRIMARY when workload_aligned)
   per_case: perCase, variance_note: { type: 'string' }, notes: { type: 'string' },
   graph_safe: { type: 'string' },
 }, ['status', 'verified_geomean']);
@@ -248,6 +291,7 @@ const COMMIT_SCHEMA = obj({
 
 const REPORT_SCHEMA = obj({
   final_speedup_geomean: { type: 'number' }, final_speedup_arithmetic: { type: 'number' },
+  final_speedup_weighted: { type: 'number' }, // time-weighted ratio-of-sums (PRIMARY when workload_aligned)
   rounds: { type: 'number' }, budget_used: { type: 'number' },
   report_path: { type: 'string' }, final_patch: { type: 'string' }, per_case: perCase,
 }, ['final_speedup_geomean', 'report_path', 'final_patch']);
@@ -256,6 +300,7 @@ const VALIDATE_SCHEMA = obj({
   kernel_name: { type: 'string' },
   director_verified_speedup_geomean: { type: 'number' },
   director_verified_speedup_arithmetic: { type: 'number' },
+  director_verified_speedup_weighted: { type: 'number' }, // PRIMARY when workload_aligned
   tech_lead_reported_speedup_geomean: { type: 'number' },
   validation_status: { type: 'string' }, correctness: { type: 'string' },
   per_case: perCase, applied_to_original: { type: 'string' },
@@ -423,6 +468,8 @@ const bench = await agentT(
     WORKSPACE: CANONICAL, EVAL_DIR, SKILL_DIR: WORKFLOW_DIR, GPU_ID: GPU_LIST[0],
     ANALYSIS: analysis,
     ...(HARNESS_ADDENDUM ? { HARNESS_ADDENDUM } : {}),
+    ...(WORKLOAD_SPEC_PATH ? { WORKLOAD_SPEC_PATH } : {}),
+    ...(WORKLOAD_SPEC ? { WORKLOAD_SPEC } : {}),
   }),
   { phase: 'Benchmark', label: 'benchmark_engineer', schema: BENCH_SCHEMA });
 if (!bench || !bench.baseline_per_case) throw new Error('Benchmark setup failed: no baseline recorded');
@@ -561,7 +608,7 @@ Return ONLY the worker_result.json structure as StructuredOutput.`,
     (prev) => {
       const { d, eng } = prev;
       const patch = `${d.out_dir}/best_patch.diff`;
-      if (!eng || eng.status === 'failed' || !(eng.speedup_geomean > 1.0)) {
+      if (!eng || eng.status === 'failed' || !(primSpeedup(eng) > 1.0)) {
         return { d, eng, ver: null };
       }
       return agentT(
@@ -578,12 +625,17 @@ Return ONLY the worker_result.json structure as StructuredOutput.`,
 
   const clean = results.filter(Boolean);
   const verified = clean.filter(r => r.ver && r.ver.status === 'verified' &&
-    r.ver.correctness === 'pass' && r.ver.verified_geomean > 1.0);
+    r.ver.correctness === 'pass' && primSpeedup(r.ver) > 1.0);
 
   // --- (d) Build candidate list; integrate if >=2 verified --------------
+  // `geomean` here is the PRIMARY metric used for sorting/gating/cumulative: the time-weighted
+  // ratio-of-sums when a workload spec is active, else the unweighted geomean (unchanged behavior).
+  // The raw unweighted geomean is retained separately for the report.
   let candidates = verified.map(r => ({
     source: `engineer ${r.d.id}`, id: r.d.id, title: r.d.title, specialty: r.d.specialty,
-    geomean: r.ver.verified_geomean, arithmetic: r.ver.verified_arithmetic || r.ver.verified_geomean,
+    geomean: primSpeedup(r.ver), geomean_unweighted: r.ver.verified_geomean,
+    weighted: r.ver.verified_weighted != null ? r.ver.verified_weighted : null,
+    arithmetic: r.ver.verified_arithmetic || r.ver.verified_geomean,
     per_case: r.ver.per_case || [], patch: r.patch,
   }));
 
@@ -601,11 +653,16 @@ Return ONLY the worker_result.json structure as StructuredOutput.`,
         INSIGHTS: history.insights,
       }),
       { phase: 'Merge', label: `integrate r${round}`, schema: INTEGRATE_SCHEMA });
+    const integPrim = integrate && integrate.best ? primSpeedup({
+      verified_weighted: integrate.best.weighted, verified_geomean: integrate.best.geomean,
+    }) : 0;
     if (integrate && integrate.conclusion === 'improved' && integrate.best &&
-      integrate.best.geomean > Math.max(...candidates.map(c => c.geomean))) {
+      integPrim > Math.max(...candidates.map(c => c.geomean))) {
       candidates.push({
         source: 'integrated', id: `r${round}_integrated`, title: 'integrated', specialty: 'integrate',
-        geomean: integrate.best.geomean, arithmetic: integrate.best.arithmetic || integrate.best.geomean,
+        geomean: integPrim, geomean_unweighted: integrate.best.geomean,
+        weighted: integrate.best.weighted != null ? integrate.best.weighted : null,
+        arithmetic: integrate.best.arithmetic || integrate.best.geomean,
         per_case: integrate.best.per_case || [], patch: integrate.best.patch_file,
       });
     }
@@ -709,12 +766,20 @@ const validation = await agentT(
     APPLY_TO_ORIGINAL, COMMANDMENT,
     FINAL_PATCH: report ? report.final_patch : `${EVAL_DIR}/final_patch.diff`,
     TECH_LEAD_REPORTED_GEOMEAN: report ? report.final_speedup_geomean : cumulative,
+    ...(HAS_WORKLOAD && report && report.final_speedup_weighted != null
+        ? { TECH_LEAD_REPORTED_WEIGHTED: report.final_speedup_weighted } : {}),
     BASELINE_TIMING: BASELINE_PER_CASE,
   }),
   { phase: 'Validate', label: 'director:validate', schema: VALIDATE_SCHEMA });
 
 const finalGeomean = validation ? validation.director_verified_speedup_geomean : cumulative;
-log(`COMPLETE. ${KERNEL_NAME}: verified geomean ${finalGeomean ? finalGeomean.toFixed(2) : '?'}x (status ${validation ? validation.validation_status : '?'}). Results in ${EVAL_DIR}`);
+// PRIMARY headline: the time-weighted speedup when workload-aligned, else the geomean (unchanged).
+const finalWeighted = validation && validation.director_verified_speedup_weighted != null
+  ? validation.director_verified_speedup_weighted : null;
+const finalPrimary = HAS_WORKLOAD && Number.isFinite(finalWeighted) ? finalWeighted : finalGeomean;
+log(`COMPLETE. ${KERNEL_NAME}: verified ${HAS_WORKLOAD ? 'time-weighted' : 'geomean'} ${finalPrimary ? finalPrimary.toFixed(2) : '?'}x` +
+    `${HAS_WORKLOAD && Number.isFinite(finalGeomean) ? ` (unweighted geomean ${finalGeomean.toFixed(2)}x)` : ''}` +
+    ` (status ${validation ? validation.validation_status : '?'}). Results in ${EVAL_DIR}`);
 
 return {
   mode: MODE,
@@ -722,6 +787,9 @@ return {
   authored: MODE === 'author' ? true : undefined,
   eval_dir: EVAL_DIR,
   kernel_name: KERNEL_NAME,
+  workload_aligned: HAS_WORKLOAD,
+  final_speedup: finalPrimary,                 // PRIMARY metric (weighted when workload-aligned)
+  final_weighted: finalWeighted,
   final_geomean: finalGeomean,
   final_arithmetic: validation ? validation.director_verified_speedup_arithmetic : null,
   tech_lead_reported_geomean: report ? report.final_speedup_geomean : cumulative,

--- a/kernel_workflow/kernel_workflow.js
+++ b/kernel_workflow/kernel_workflow.js
@@ -169,13 +169,14 @@ const perCase = {
       optimized_ms: { type: 'number' },
       speedup: { type: 'number' },
       // Workload-alignment fields (present only when a WORKLOAD_SPEC drives the harness; absent
-      // on a normal unweighted run). weight = this case's total time contribution in the real
-      // workload (count * baseline_latency); it is the coefficient the time-weighted metric uses.
+      // on a normal unweighted run). weight = this case's baseline time SHARE in the real workload;
+      // it is the coefficient of the time-weighted metric Σweight / Σ(weight/speedup). count is
+      // optional/informational (regime-attributed cases have no per-call count).
       weight: { type: 'number' },
       count: { type: 'number' },
       dims: { type: 'array', items: { type: 'array', items: { type: 'number' } } },
       dtypes: { type: 'array', items: { type: 'string' } },
-      weight_source: { type: 'string' }, // trace | tracelens | regime_prior | caller
+      weight_source: { type: 'string' }, // trace | regime | regime_floor | prior | caller
     },
     required: ['name', 'speedup'],
   },
@@ -220,11 +221,11 @@ const BENCH_SCHEMA = obj({
   baseline_per_case: { type: 'array', items: { type: 'object', additionalProperties: true } },
   baseline_geomean_ms: { type: 'number' }, num_test_cases: { type: 'number' },
   // Workload-aligned outputs: present when a WORKLOAD_SPEC drove case selection + weights.
-  // baseline_weighted_total_ms = sum(weight_i * baseline_latency_i) — the denominator of the
-  // time-weighted ratio-of-sums metric. workload_aligned flags that weights are real (not 1).
+  // baseline_weighted_total_ms = the baseline time the weights represent (Σ weight_i in time units).
+  // The metric is Σ weight_i / Σ (weight_i/speedup_i). workload_aligned flags weights are real (not 1).
   workload_aligned: { type: 'boolean' },
   baseline_weighted_total_ms: { type: 'number' },
-  weights_provenance: { type: 'string' }, // e.g. "trace" | "caller" | "regime_prior" | "mixed"
+  weights_provenance: { type: 'string' }, // e.g. "trace" | "regime" | "regime_floor" | "prior" | "caller" | "mixed"
   reliable: { type: 'boolean' }, notes: { type: 'string' },
 }, ['commandment_path', 'baseline_per_case', 'baseline_geomean_ms']);
 
@@ -257,7 +258,7 @@ const ENG_SCHEMA = obj({
   engineer_id: { type: 'string' }, specialty: { type: 'string' }, task: { type: 'string' },
   strategy: { type: 'string' }, speedup_geomean: { type: 'number' }, speedup_arithmetic: { type: 'number' },
   // Time-weighted ratio-of-sums vs the TRUE baseline (PRIMARY metric when workload_aligned).
-  // = sum(weight_i*baseline_i) / sum(weight_i*optimized_i). Omitted on unweighted runs.
+  // = Σ weight_i / Σ (weight_i / speedup_i). Omitted on unweighted runs.
   speedup_weighted: { type: 'number' },
   per_case: perCase, status: { type: 'string' }, patch_file: { type: 'string' },
   strategies_tried: { type: 'array', items: { type: 'string' } }, notes: { type: 'string' },

--- a/kernel_workflow/roles/benchmark_engineer.md
+++ b/kernel_workflow/roles/benchmark_engineer.md
@@ -32,6 +32,18 @@ one kernel is present, use it). Then:
   = caller-supplied. All cases still carry concrete `dims`+`dtypes` (from the spec/meta) — build inputs
   from those. A case with empty `dims` cannot be benchmarked: exclude it and say so in `notes`; never
   invent a shape.
+- **MATCH THE ONLINE REGIME (`spec.regime` + `spec.quant`) — this is what prevents "isolated win, e2e
+  loss".** The spec carries the regime resolved from the server launch flags:
+  - **Quant** (`spec.quant`): build operands in the quantized form the live kernel receives — e.g. a8w8
+    fp8: activations + weights `fp8_e4m3`, scales `fp32`, output `bf16`, per `weight_block_size`. Do NOT
+    benchmark an unquantized bf16 GEMM when the server runs fp8 (that seam is barely live online).
+  - **KV dtype** (`spec.regime.kv_cache_dtype`): if `fp8`, attention inputs/KV use the fp8 layout/stride.
+  - **Baseline must be IN-REGIME**: the speedup denominator is the live in-regime path — the quantized
+    library GEMM (hipBLASLt/Fp8LinearMethod), the fp8-KV attention, or the `torch.compile`-fused norm
+    when `spec.regime.compile == torch_compile`. NEVER an unquantized or unfused eager strawman.
+- **HEED `spec.regime_warning`.** If non-empty (seam <~2% live GPU, fp8-KV, or compiled-baseline), the
+  extraction is regime-mismatched — record it in `notes`, do NOT report a confident speedup, and prefer
+  failing loud over benchmarking a dead regime.
 - **CORRECTNESS IS DECOUPLED AND UNCHANGED.** Workload alignment shapes the PERFORMANCE measurement
   only. Correctness still runs against the IMMUTABLE frozen oracle (`unittest.py`/`reference_io.pt`) on
   its own recorded shapes — never re-weight, replace, or relax it. Random-valued workload-shape inputs

--- a/kernel_workflow/roles/benchmark_engineer.md
+++ b/kernel_workflow/roles/benchmark_engineer.md
@@ -6,48 +6,35 @@ the whole workflow depends on this being correct and stable. Operate on the cano
 ## Inputs
 `WORKSPACE`, `EVAL_DIR`, `SKILL_DIR`, `GPU_ID`, and `ANALYSIS` (kernel type, files, existing tests).
 
-**WORKLOAD ALIGNMENT (act ONLY if `WORKLOAD_SPEC_PATH` or `WORKLOAD_SPEC` is in your inputs; a normal
-run passes neither — then ignore this and benchmark the harness's own default cases unweighted).**
-When present, this is the real-workload shape/dtype distribution this kernel actually sees, so the
-benchmark measures what production runs — not arbitrary small/medium/large guesses. Read it (the JSON
-is the `workload-v1` schema from `parse_profile.py --workload-out`: `kernels[].cases[]`, each case =
-`{dims:[[…per-tensor shape…]], dtypes:[…per-tensor…], count, baseline_latency_ms, weight,
-weight_source}`). `WORKLOAD_SPEC` inline overrides `WORKLOAD_SPEC_PATH` (treat its `weight_source`
-as `caller`). Pick the case list for THIS kernel (match by `ANALYSIS` kernel name / `name`; if exactly
-one kernel is present, use it). Then:
-- **Benchmark EXACTLY these (dims, dtypes) cases** — one harness case per spec case, building each input
-  tensor with its own per-tensor shape AND dtype (do not collapse to a single dtype). Apply any scalar
-  params the kernel needs (eps/scale/causal/…) from `ANALYSIS`/source; random values are fine (perf is
-  value-independent — see CORRECTNESS note below).
-- **Weight each case by its `weight`** field (= that case's baseline time SHARE in the workload). The
-  PRIMARY metric is the time-weighted ratio-of-sums, expressed purely via `weight`:
-  `speedup = Σ_i weight_i / Σ_i (weight_i / speedup_i)`, where `speedup_i = baseline_i/optimized_i` is
-  the measured per-case speedup. This equals total_baseline_time / total_optimized_time — the true
-  wall-clock speedup of the kernel's total workload contribution. (Do NOT use `count` as the
-  coefficient — many cases are regime-attributed and have no per-call count; `weight` already folds in
-  both frequency and per-call cost.)
-- **`weight_source` tells you the fidelity**: `trace` = weight from a real per-call shape (precise);
-  `regime` = profiled decode/prefill total split across buckets; `regime_floor` = a serving floor was
-  applied so decode isn't ignored; `prior` = no profile signal (even weight, low confidence); `caller`
-  = caller-supplied. All cases still carry concrete `dims`+`dtypes` (from the spec/meta) — build inputs
-  from those. A case with empty `dims` cannot be benchmarked: exclude it and say so in `notes`; never
-  invent a shape.
-- **MATCH THE ONLINE REGIME (`spec.regime` + `spec.quant`) — this is what prevents "isolated win, e2e
-  loss".** The spec carries the regime resolved from the server launch flags:
-  - **Quant** (`spec.quant`): build operands in the quantized form the live kernel receives — e.g. a8w8
-    fp8: activations + weights `fp8_e4m3`, scales `fp32`, output `bf16`, per `weight_block_size`. Do NOT
-    benchmark an unquantized bf16 GEMM when the server runs fp8 (that seam is barely live online).
-  - **KV dtype** (`spec.regime.kv_cache_dtype`): if `fp8`, attention inputs/KV use the fp8 layout/stride.
-  - **Baseline must be IN-REGIME**: the speedup denominator is the live in-regime path — the quantized
-    library GEMM (hipBLASLt/Fp8LinearMethod), the fp8-KV attention, or the `torch.compile`-fused norm
-    when `spec.regime.compile == torch_compile`. NEVER an unquantized or unfused eager strawman.
-- **HEED `spec.regime_warning`.** If non-empty (seam <~2% live GPU, fp8-KV, or compiled-baseline), the
-  extraction is regime-mismatched — record it in `notes`, do NOT report a confident speedup, and prefer
-  failing loud over benchmarking a dead regime.
-- **CORRECTNESS IS DECOUPLED AND UNCHANGED.** Workload alignment shapes the PERFORMANCE measurement
-  only. Correctness still runs against the IMMUTABLE frozen oracle (`unittest.py`/`reference_io.pt`) on
-  its own recorded shapes — never re-weight, replace, or relax it. Random-valued workload-shape inputs
-  are for timing, not for judging correctness.
+**WORKLOAD ALIGNMENT.** The real-workload shape/dtype distribution is handled by the immutable
+`unittest.py` oracle itself — the Kernel Extractor bakes the weighted cases (`meta.workload.cases[]`)
+and the time-weighted metric into it. So in the common (e2e-fed) path you do NOTHING special:
+
+- **If the task dir's `unittest.py` is ALREADY workload-weighted** (it prints `GEAK_WEIGHTED_SPEEDUP`
+  / `meta.json` has a `workload` key), it is the SINGLE harness for BOTH correctness and the weighted
+  perf metric. **REUSE it verbatim, do NOT author a separate performance harness.** Point the
+  COMMANDMENT's CORRECTNESS/BENCHMARK/FULL_BENCHMARK/PROFILE at `python3 unittest.py`, and record the
+  PRIMARY metric as its `GEAK_WEIGHTED_SPEEDUP = Σ_i weight_i / Σ_i (weight_i / speedup_i)` (the
+  unweighted geomean is a secondary diagnostic). Operands/regime are already in-regime in the oracle —
+  you do not rebuild them.
+- **Only if NO weighted oracle exists but a caller passes `WORKLOAD_SPEC_PATH`/`WORKLOAD_SPEC` inline**
+  (a standalone single-kernel run, not an e2e extraction) do you build the weighted perf harness
+  yourself (Step 2). Read it (the `workload-v1` schema: `cases[]` each
+  `{dims:[[…per-tensor shape…]], dtypes:[…], weight, weight_source, quant}`; `WORKLOAD_SPEC` inline
+  overrides the path, `weight_source` becomes `caller`). Then:
+  - Benchmark EXACTLY these (dims, dtypes) cases (one harness case each, each tensor with its own shape
+    AND dtype + the case's `quant` operands — fp8+scales etc., NOT collapsed to bf16); random values
+    (perf is value-independent). A case with empty `dims` cannot be benchmarked — exclude it, say so in
+    `notes`, never invent a shape.
+  - PRIMARY metric = the time-weighted ratio-of-sums `Σ_i weight_i / Σ_i (weight_i / speedup_i)` using
+    each case's `weight` (do NOT use `count`; `weight` already folds frequency × per-call cost).
+  - Baseline must be IN-REGIME (the live quantized GEMM / fp8-KV attention / torch.compile-fused path),
+    never an unquantized or unfused-eager strawman.
+- **If neither** → benchmark the harness's own default cases unweighted (normal run, unchanged).
+
+**CORRECTNESS IS DECOUPLED AND UNCHANGED** in all cases: it runs against the IMMUTABLE frozen oracle
+(`unittest.py`/`reference_io.pt`) on its own recorded golden shapes — never re-weighted, replaced, or
+relaxed. Random-valued workload-shape inputs are for timing only.
 
 **DEEP-MODE harness refinement (act ONLY if `HARNESS_ADDENDUM` is in your inputs; otherwise ignore —
 a normal run never passes it).** The IMMUTABLE oracle (`unittest.py`/`meta.json`/`reference_io.pt`:
@@ -78,22 +65,22 @@ If a runner with compile/correctness/performance exists, USE IT — do not inven
 it to learn the exact commands and the per-case output format it prints (e.g. lines like
 `Perf: <ms> ms (<case_id>)`, or `GEAK_RESULT_LATENCY_MS=<ms>`, or a JSON performance report).
 
-**Exception — WORKLOAD_SPEC present**: keep reusing the existing runner / oracle for CORRECTNESS, but
-its timing cases are the captured/authored shapes, NOT the workload distribution. So ALSO author a
-dedicated PERFORMANCE harness (Step 2) that times the spec's (shape, dtype) cases, and point the
-COMMANDMENT's BENCHMARK/FULL_BENCHMARK/PROFILE at it while CORRECTNESS stays on the oracle.
+**Workload-weighted oracle present (the e2e-fed path)**: if `unittest.py` already prints
+`GEAK_WEIGHTED_SPEEDUP` (extractor baked `meta.workload`), it IS the perf harness too — reuse it for
+correctness AND the weighted metric; do NOT author `test_harness.py`. Skip Step 2.
 
-### 2. Create the (performance) harness
+### 2. Create the (performance) harness — only when NOT already covered by a weighted oracle
 Write `WORKSPACE/test_harness.py` when there is no usable runner, OR (even if a runner exists) when a
-WORKLOAD_SPEC is in your inputs — in the latter case it is the PERFORMANCE harness only; correctness
-stays on the oracle. Support `--correctness`, `--profile` (minimal allocations for profiler attach),
-`--benchmark` (30 iters/10 warmup), `--full-benchmark` (100 iters/10 warmup). Use CUDA events for
-timing. Print one line per case: `GEAK_RESULT_LATENCY_MS=<float>` plus a case id.
+`WORKLOAD_SPEC` is supplied inline AND the oracle `unittest.py` is NOT already workload-weighted — in
+that latter case it is the PERFORMANCE harness only; correctness stays on the oracle. Support
+`--correctness`, `--profile` (minimal allocations for profiler attach), `--benchmark` (30 iters/10
+warmup), `--full-benchmark` (100 iters/10 warmup). Use CUDA events for timing. Print one line per case:
+`GEAK_RESULT_LATENCY_MS=<float>` plus a case id.
 
 **Cases:**
 - WORKLOAD_SPEC present → one case per spec case, inputs built with each tensor's own `dims`+`dtype`
-  (+ scalar params), random values. Emit the per-case `count` (and `weight_source`) so the parser can
-  compute the time-weighted metric. Map/exclude `regime_prior` (empty-`dims`) cases as described above.
+  (+ scalar params + `quant` operands), random values. Emit the per-case `weight` (and `weight_source`)
+  so the parser can compute the time-weighted metric. Exclude empty-`dims` cases (say so in `notes`).
 - No WORKLOAD_SPEC → cover small/medium/large + parameter variations (unweighted, as before).
 
 **Baseline (perf reference) — use the ORIGINAL implementation, never an LLM naive reimplementation.**

--- a/kernel_workflow/roles/benchmark_engineer.md
+++ b/kernel_workflow/roles/benchmark_engineer.md
@@ -6,6 +6,33 @@ the whole workflow depends on this being correct and stable. Operate on the cano
 ## Inputs
 `WORKSPACE`, `EVAL_DIR`, `SKILL_DIR`, `GPU_ID`, and `ANALYSIS` (kernel type, files, existing tests).
 
+**WORKLOAD ALIGNMENT (act ONLY if `WORKLOAD_SPEC_PATH` or `WORKLOAD_SPEC` is in your inputs; a normal
+run passes neither — then ignore this and benchmark the harness's own default cases unweighted).**
+When present, this is the real-workload shape/dtype distribution this kernel actually sees, so the
+benchmark measures what production runs — not arbitrary small/medium/large guesses. Read it (the JSON
+is the `workload-v1` schema from `parse_profile.py --workload-out`: `kernels[].cases[]`, each case =
+`{dims:[[…per-tensor shape…]], dtypes:[…per-tensor…], count, baseline_latency_ms, weight,
+weight_source}`). `WORKLOAD_SPEC` inline overrides `WORKLOAD_SPEC_PATH` (treat its `weight_source`
+as `caller`). Pick the case list for THIS kernel (match by `ANALYSIS` kernel name / `name`; if exactly
+one kernel is present, use it). Then:
+- **Benchmark EXACTLY these (dims, dtypes) cases** — one harness case per spec case, building each input
+  tensor with its own per-tensor shape AND dtype (do not collapse to a single dtype). Apply any scalar
+  params the kernel needs (eps/scale/causal/…) from `ANALYSIS`/source; random values are fine (perf is
+  value-independent — see CORRECTNESS note below).
+- **Weight each case by `count`** (NOT by `weight`). The PRIMARY metric is the time-weighted
+  ratio-of-sums: `speedup = Σ_i count_i·baseline_i / Σ_i count_i·optimized_i`, where `baseline_i`/
+  `optimized_i` are the measured per-call latencies. This equals the true wall-clock speedup of the
+  kernel's total workload contribution. (`weight = count·baseline_latency` is the time-SHARE of each
+  case — use it only to rank/report which cases dominate, never as the metric coefficient.)
+- **`weight_source: regime_prior` cases have `dims: []`** (shape hidden behind a graph-replay launch —
+  count is real, shape is not). You cannot build inputs for an unknown shape: map such a case to the
+  decode-regime shape implied by `ANALYSIS` (keep its `count`), or exclude it and say so in `notes`.
+  Never invent a shape silently.
+- **CORRECTNESS IS DECOUPLED AND UNCHANGED.** Workload alignment shapes the PERFORMANCE measurement
+  only. Correctness still runs against the IMMUTABLE frozen oracle (`unittest.py`/`reference_io.pt`) on
+  its own recorded shapes — never re-weight, replace, or relax it. Random-valued workload-shape inputs
+  are for timing, not for judging correctness.
+
 **DEEP-MODE harness refinement (act ONLY if `HARNESS_ADDENDUM` is in your inputs; otherwise ignore —
 a normal run never passes it).** The IMMUTABLE oracle (`unittest.py`/`meta.json`/`reference_io.pt`:
 correctness, golden output, tolerance, frozen baseline) is **NEVER modified or re-weighted** — it stays
@@ -35,12 +62,34 @@ If a runner with compile/correctness/performance exists, USE IT — do not inven
 it to learn the exact commands and the per-case output format it prints (e.g. lines like
 `Perf: <ms> ms (<case_id>)`, or `GEAK_RESULT_LATENCY_MS=<ms>`, or a JSON performance report).
 
-### 2. Create a harness only if none exists
-If there is no usable runner, write `WORKSPACE/test_harness.py` supporting `--correctness`,
-`--profile` (minimal allocations for profiler attach), `--benchmark` (30 iters/10 warmup),
-`--full-benchmark` (100 iters/10 warmup). Use CUDA events for timing. Print one line per case:
-`GEAK_RESULT_LATENCY_MS=<float>` plus a case id. Correctness must compare to a trusted reference
-(PyTorch/naive) with appropriate tolerance. Cover small/medium/large + parameter variations.
+**Exception — WORKLOAD_SPEC present**: keep reusing the existing runner / oracle for CORRECTNESS, but
+its timing cases are the captured/authored shapes, NOT the workload distribution. So ALSO author a
+dedicated PERFORMANCE harness (Step 2) that times the spec's (shape, dtype) cases, and point the
+COMMANDMENT's BENCHMARK/FULL_BENCHMARK/PROFILE at it while CORRECTNESS stays on the oracle.
+
+### 2. Create the (performance) harness
+Write `WORKSPACE/test_harness.py` when there is no usable runner, OR (even if a runner exists) when a
+WORKLOAD_SPEC is in your inputs — in the latter case it is the PERFORMANCE harness only; correctness
+stays on the oracle. Support `--correctness`, `--profile` (minimal allocations for profiler attach),
+`--benchmark` (30 iters/10 warmup), `--full-benchmark` (100 iters/10 warmup). Use CUDA events for
+timing. Print one line per case: `GEAK_RESULT_LATENCY_MS=<float>` plus a case id.
+
+**Cases:**
+- WORKLOAD_SPEC present → one case per spec case, inputs built with each tensor's own `dims`+`dtype`
+  (+ scalar params), random values. Emit the per-case `count` (and `weight_source`) so the parser can
+  compute the time-weighted metric. Map/exclude `regime_prior` (empty-`dims`) cases as described above.
+- No WORKLOAD_SPEC → cover small/medium/large + parameter variations (unweighted, as before).
+
+**Baseline (perf reference) — use the ORIGINAL implementation, never an LLM naive reimplementation.**
+The speedup denominator must be the real workload code, otherwise "2× over naive torch" can be slower
+than production. In order of preference: (a) the pristine original in `EVAL_DIR/baseline` / the
+workspace's initial commit (optimize mode always has this); (b) for a library op with no editable
+source, the actual default backend the workload uses (e.g. the default GEMM/attention call), as the
+extractor's GEMM oracle already does. Only if NEITHER exists, fall back to a naive PyTorch reference
+and FLAG it in `notes` + the COMMANDMENT as a non-representative baseline.
+
+For `--correctness` in the no-runner case (no oracle at all), compare to a trusted reference
+(PyTorch/naive) with appropriate tolerance. When the oracle exists, `--correctness` just defers to it.
 
 ### 3. Validate every mode actually runs
 Run compile (if any), correctness, benchmark, profile once each (correctness/benchmark via
@@ -72,6 +121,13 @@ The COMMANDMENT MUST contain, with concrete commands (not placeholders):
   `knowledge/profiling_guide.md` (override the named env var with the corrected flag, or degrade and say so).
 - `PARSE` — a one-paragraph description of how to extract per-case latency from the output (the
   exact token/regex and the case-id mapping), so verify/profile engineers parse identically.
+- `METRIC` — define the PRIMARY speedup the optimize loop is judged on:
+  - **No WORKLOAD_SPEC**: unweighted geomean of per-case speedups (unchanged default).
+  - **WORKLOAD_SPEC present**: the **time-weighted ratio-of-sums**
+    `speedup = Σ_i count_i·baseline_i / Σ_i count_i·optimized_i` (PRIMARY), and ALSO report the
+    unweighted geomean as a secondary diagnostic. List each case's `count` and `weight_source` so
+    every downstream agent computes the SAME number. State that this primary number is what the round
+    winner gate and the final result use. If the baseline is the flagged naive fallback, say so here.
 - `MODIFIABLE FILES` and the rules (never modify harness/COMMANDMENT/files outside the workspace;
   always run correctness before benchmark; always invoke via gpu_lock from the workspace; benchmark
   output is the source of truth).
@@ -79,11 +135,15 @@ The COMMANDMENT MUST contain, with concrete commands (not placeholders):
 ### 5. Record baseline + check reliability
 Run the FULL benchmark **3 times** via gpu_lock. Confirm per-case results are within ~5% across
 runs. If variance is high, investigate (GPU busy? clocks? other procs on this GPU?) and re-run.
-Save `EVAL_DIR/baseline_timing.json`:
+Save `EVAL_DIR/baseline_timing.json` (the `count`/`dims`/`dtypes`/`weight_source` fields appear only
+when a WORKLOAD_SPEC drove the cases; `baseline_weighted_total_ms = Σ count_i·latency_i`):
 ```json
 {
-  "test_cases": [{"name": "<case_id>", "latency_ms": 0.0, "params": "..."}],
+  "test_cases": [{"name": "<case_id>", "latency_ms": 0.0, "params": "...",
+                  "dims": [[...]], "dtypes": ["..."], "count": 0, "weight_source": "trace"}],
   "geomean_ms": 0.0,
+  "workload_aligned": false,
+  "baseline_weighted_total_ms": 0.0,
   "num_test_cases": 0,
   "reliable": true,
   "runs_ms": [[...run1...],[...run2...],[...run3...]]
@@ -97,11 +157,19 @@ Save `EVAL_DIR/baseline_timing.json`:
   "correctness_cmd": "<exact>",
   "benchmark_cmd": "<exact full-benchmark cmd, WITHOUT the gpu_lock wrapper>",
   "profile_cmd": "<exact profile inner cmd>",
-  "parse_hint": "how to extract per-case latency + case ids",
-  "baseline_per_case": [{"name": "...", "latency_ms": 0.0}],
+  "parse_hint": "how to extract per-case latency + case ids (and count, when workload-aligned)",
+  "baseline_per_case": [{"name": "...", "latency_ms": 0.0,
+                         "dims": [[1,512],[512,512]], "dtypes": ["bf16","bf16"],
+                         "count": 0, "weight": 0.0, "weight_source": "trace"}],
   "baseline_geomean_ms": 0.0,
+  "workload_aligned": false,
+  "baseline_weighted_total_ms": 0.0,
+  "weights_provenance": "trace|caller|regime_prior|mixed",
   "num_test_cases": 0,
   "reliable": true,
-  "notes": "anything downstream agents must know"
+  "notes": "anything downstream agents must know (incl. any naive-baseline / regime_prior caveats)"
 }
 ```
+When `workload_aligned` is true, `baseline_per_case[].count` is the coefficient the time-weighted
+metric uses, and `weight = count·latency_ms` is the case's time share. On an unweighted run omit the
+workload fields entirely (output is identical to before).

--- a/kernel_workflow/roles/benchmark_engineer.md
+++ b/kernel_workflow/roles/benchmark_engineer.md
@@ -19,15 +19,19 @@ one kernel is present, use it). Then:
   tensor with its own per-tensor shape AND dtype (do not collapse to a single dtype). Apply any scalar
   params the kernel needs (eps/scale/causal/…) from `ANALYSIS`/source; random values are fine (perf is
   value-independent — see CORRECTNESS note below).
-- **Weight each case by `count`** (NOT by `weight`). The PRIMARY metric is the time-weighted
-  ratio-of-sums: `speedup = Σ_i count_i·baseline_i / Σ_i count_i·optimized_i`, where `baseline_i`/
-  `optimized_i` are the measured per-call latencies. This equals the true wall-clock speedup of the
-  kernel's total workload contribution. (`weight = count·baseline_latency` is the time-SHARE of each
-  case — use it only to rank/report which cases dominate, never as the metric coefficient.)
-- **`weight_source: regime_prior` cases have `dims: []`** (shape hidden behind a graph-replay launch —
-  count is real, shape is not). You cannot build inputs for an unknown shape: map such a case to the
-  decode-regime shape implied by `ANALYSIS` (keep its `count`), or exclude it and say so in `notes`.
-  Never invent a shape silently.
+- **Weight each case by its `weight`** field (= that case's baseline time SHARE in the workload). The
+  PRIMARY metric is the time-weighted ratio-of-sums, expressed purely via `weight`:
+  `speedup = Σ_i weight_i / Σ_i (weight_i / speedup_i)`, where `speedup_i = baseline_i/optimized_i` is
+  the measured per-case speedup. This equals total_baseline_time / total_optimized_time — the true
+  wall-clock speedup of the kernel's total workload contribution. (Do NOT use `count` as the
+  coefficient — many cases are regime-attributed and have no per-call count; `weight` already folds in
+  both frequency and per-call cost.)
+- **`weight_source` tells you the fidelity**: `trace` = weight from a real per-call shape (precise);
+  `regime` = profiled decode/prefill total split across buckets; `regime_floor` = a serving floor was
+  applied so decode isn't ignored; `prior` = no profile signal (even weight, low confidence); `caller`
+  = caller-supplied. All cases still carry concrete `dims`+`dtypes` (from the spec/meta) — build inputs
+  from those. A case with empty `dims` cannot be benchmarked: exclude it and say so in `notes`; never
+  invent a shape.
 - **CORRECTNESS IS DECOUPLED AND UNCHANGED.** Workload alignment shapes the PERFORMANCE measurement
   only. Correctness still runs against the IMMUTABLE frozen oracle (`unittest.py`/`reference_io.pt`) on
   its own recorded shapes — never re-weight, replace, or relax it. Random-valued workload-shape inputs
@@ -124,10 +128,10 @@ The COMMANDMENT MUST contain, with concrete commands (not placeholders):
 - `METRIC` — define the PRIMARY speedup the optimize loop is judged on:
   - **No WORKLOAD_SPEC**: unweighted geomean of per-case speedups (unchanged default).
   - **WORKLOAD_SPEC present**: the **time-weighted ratio-of-sums**
-    `speedup = Σ_i count_i·baseline_i / Σ_i count_i·optimized_i` (PRIMARY), and ALSO report the
-    unweighted geomean as a secondary diagnostic. List each case's `count` and `weight_source` so
-    every downstream agent computes the SAME number. State that this primary number is what the round
-    winner gate and the final result use. If the baseline is the flagged naive fallback, say so here.
+    `speedup = Σ_i weight_i / Σ_i (weight_i / speedup_i)` (PRIMARY), and ALSO report the unweighted
+    geomean as a secondary diagnostic. List each case's `weight` and `weight_source` so every
+    downstream agent computes the SAME number. State that this primary number is what the round winner
+    gate and the final result use. If the baseline is the flagged naive fallback, say so here.
 - `MODIFIABLE FILES` and the rules (never modify harness/COMMANDMENT/files outside the workspace;
   always run correctness before benchmark; always invoke via gpu_lock from the workspace; benchmark
   output is the source of truth).

--- a/kernel_workflow/roles/director.md
+++ b/kernel_workflow/roles/director.md
@@ -175,8 +175,11 @@ baseline latencies recorded at benchmark setup).
 4. Run FULL_BENCHMARK with `bash $SKILL_DIR/scripts/gpu_lock.sh $GPU_ID <full bench cmd>`. Parse the
    per-case latencies.
 5. Compute per-case speedup = `baseline_ms / optimized_ms` using `BASELINE_TIMING`. Compute geomean
-   = `exp(mean(log(speedups)))` and arithmetic mean.
-6. Arbitration vs the TechLead's claim:
+   = `exp(mean(log(speedups)))` and arithmetic mean. **If `BASELINE_TIMING` is workload-aligned
+   (`workload_aligned:true`, per-case `count` present), ALSO compute the time-weighted ratio-of-sums
+   `Σ count_i·baseline_i / Σ count_i·optimized_i` and report it as `director_verified_speedup_weighted`
+   — that is the PRIMARY number arbitration uses below.**
+6. Arbitration vs the TechLead's claim (on the PRIMARY metric — weighted when workload-aligned, else geomean):
    - Within 10%, or Director higher → `accepted`.
    - Director LOWER than claim by >10% → `flagged` (use Director's measured numbers as official).
    - Correctness fail / patch fails to apply → `flagged`.
@@ -200,6 +203,7 @@ Return JSON:
   "kernel_name": "<name>",
   "director_verified_speedup_geomean": 0.0,
   "director_verified_speedup_arithmetic": 0.0,
+  "director_verified_speedup_weighted": 0.0,
   "tech_lead_reported_speedup_geomean": 0.0,
   "validation_status": "accepted|flagged",
   "correctness": "pass|fail",

--- a/kernel_workflow/roles/director.md
+++ b/kernel_workflow/roles/director.md
@@ -176,8 +176,8 @@ baseline latencies recorded at benchmark setup).
    per-case latencies.
 5. Compute per-case speedup = `baseline_ms / optimized_ms` using `BASELINE_TIMING`. Compute geomean
    = `exp(mean(log(speedups)))` and arithmetic mean. **If `BASELINE_TIMING` is workload-aligned
-   (`workload_aligned:true`, per-case `count` present), ALSO compute the time-weighted ratio-of-sums
-   `Σ count_i·baseline_i / Σ count_i·optimized_i` and report it as `director_verified_speedup_weighted`
+   (`workload_aligned:true`, per-case `weight` present), ALSO compute the time-weighted ratio-of-sums
+   `Σ weight_i / Σ (weight_i / speedup_i)` and report it as `director_verified_speedup_weighted`
    — that is the PRIMARY number arbitration uses below.**
 6. Arbitration vs the TechLead's claim (on the PRIMARY metric — weighted when workload-aligned, else geomean):
    - Within 10%, or Director higher → `accepted`.

--- a/kernel_workflow/roles/engineer.md
+++ b/kernel_workflow/roles/engineer.md
@@ -74,7 +74,10 @@ Read, as reference (focused — start with the paths handed to you, don't crawl 
 2. **Implement** your direction (focused edits aligned with `SPECIALTY` and the knowledge patterns).
 3. **Correctness**: clear cache, run the correctness command. Debug until it passes.
 4. **Benchmark**: clear cache, run benchmark via gpu_lock. Parse per-case latency. Compute per-case
-   speedup vs `baseline_per_case` and geomean = `exp(mean(log(speedups)))`.
+   speedup vs `baseline_per_case` and geomean = `exp(mean(log(speedups)))`. **If the COMMANDMENT's
+   METRIC is the time-weighted ratio-of-sums (workload-aligned), ALSO compute and report
+   `speedup_weighted = Σ_i count_i·baseline_i / Σ_i count_i·optimized_i` using each case's `count`
+   from `baseline_per_case` — that is the PRIMARY number you optimize toward; the geomean is secondary.
 5. **Save patch** when geomean > 1.0: `cd $KERNEL_PATH && git diff > $OUTPUT_DIR/best_patch.diff`.
 6. **Iterate** a few variations (params/tiling/unroll/specialization), keeping the best. Obey
    self-monitoring: switch approach after ~8 stalled steps, force-submit after ~12, stop tuning when
@@ -91,7 +94,8 @@ Read, as reference (focused — start with the paths handed to you, don't crawl 
   "strategy": "what you actually implemented (specific)",
   "speedup_geomean": 0.0,
   "speedup_arithmetic": 0.0,
-  "per_case": [{"name": "...", "baseline_ms": 0.0, "optimized_ms": 0.0, "speedup": 0.0}],
+  "speedup_weighted": 0.0,
+  "per_case": [{"name": "...", "baseline_ms": 0.0, "optimized_ms": 0.0, "speedup": 0.0, "count": 0}],
   "status": "success|partial|failed",
   "patch_file": "best_patch.diff",
   "strategies_tried": ["..."],

--- a/kernel_workflow/roles/engineer.md
+++ b/kernel_workflow/roles/engineer.md
@@ -76,8 +76,8 @@ Read, as reference (focused — start with the paths handed to you, don't crawl 
 4. **Benchmark**: clear cache, run benchmark via gpu_lock. Parse per-case latency. Compute per-case
    speedup vs `baseline_per_case` and geomean = `exp(mean(log(speedups)))`. **If the COMMANDMENT's
    METRIC is the time-weighted ratio-of-sums (workload-aligned), ALSO compute and report
-   `speedup_weighted = Σ_i count_i·baseline_i / Σ_i count_i·optimized_i` using each case's `count`
-   from `baseline_per_case` — that is the PRIMARY number you optimize toward; the geomean is secondary.
+   `speedup_weighted = Σ_i weight_i / Σ_i (weight_i / speedup_i)` using each case's `weight` from
+   `baseline_per_case` — that is the PRIMARY number you optimize toward; the geomean is secondary.
 5. **Save patch** when geomean > 1.0: `cd $KERNEL_PATH && git diff > $OUTPUT_DIR/best_patch.diff`.
 6. **Iterate** a few variations (params/tiling/unroll/specialization), keeping the best. Obey
    self-monitoring: switch approach after ~8 stalled steps, force-submit after ~12, stop tuning when
@@ -95,7 +95,7 @@ Read, as reference (focused — start with the paths handed to you, don't crawl 
   "speedup_geomean": 0.0,
   "speedup_arithmetic": 0.0,
   "speedup_weighted": 0.0,
-  "per_case": [{"name": "...", "baseline_ms": 0.0, "optimized_ms": 0.0, "speedup": 0.0, "count": 0}],
+  "per_case": [{"name": "...", "baseline_ms": 0.0, "optimized_ms": 0.0, "speedup": 0.0, "weight": 0.0}],
   "status": "success|partial|failed",
   "patch_file": "best_patch.diff",
   "strategies_tried": ["..."],

--- a/kernel_workflow/roles/integrator.md
+++ b/kernel_workflow/roles/integrator.md
@@ -37,7 +37,7 @@ do not invent new optimizations; you compose and reconcile existing ones.
 5. Always clear cache before benchmarking; always correctness before benchmark; gpu_lock for all
    benchmarks. Compute per-case speedup vs `BASELINE_PER_CASE`, geomean = `exp(mean(log(...)))`.
    **If the COMMANDMENT's METRIC is the time-weighted ratio-of-sums (workload-aligned), ALSO report
-   `weighted = Σ count_i·baseline_i / Σ count_i·optimized_i`; that is the number compared to
+   `weighted = Σ weight_i / Σ (weight_i / speedup_i)`; that is the number compared to
    `BEST_INDIVIDUAL` (which is already the primary metric).**
 
 ## Output
@@ -56,7 +56,7 @@ cd "$WS" && git diff > "$INTEGRATE_DIR/integrated_patch.diff"   # $WS = the uniq
   ],
   "best": {"patches": ["..."], "geomean": 0.0, "arithmetic": 0.0, "weighted": 0.0,
             "patch_file": "<INTEGRATE_DIR>/integrated_patch.diff",
-            "per_case": [{"name":"...","baseline_ms":0.0,"optimized_ms":0.0,"speedup":0.0,"count":0}]},
+            "per_case": [{"name":"...","baseline_ms":0.0,"optimized_ms":0.0,"speedup":0.0,"weight":0.0}]},
   "improved_over_best_individual": true,
   "conclusion": "improved|no_improvement|all_failed",
   "notes": "what combined well / what conflicted"

--- a/kernel_workflow/roles/integrator.md
+++ b/kernel_workflow/roles/integrator.md
@@ -36,6 +36,9 @@ do not invent new optimizations; you compose and reconcile existing ones.
    diff stack. Respect hipify safety (template dispatch, no `<<<>>>` in macro if/else).
 5. Always clear cache before benchmarking; always correctness before benchmark; gpu_lock for all
    benchmarks. Compute per-case speedup vs `BASELINE_PER_CASE`, geomean = `exp(mean(log(...)))`.
+   **If the COMMANDMENT's METRIC is the time-weighted ratio-of-sums (workload-aligned), ALSO report
+   `weighted = Σ count_i·baseline_i / Σ count_i·optimized_i`; that is the number compared to
+   `BEST_INDIVIDUAL` (which is already the primary metric).**
 
 ## Output
 If the best combination beats `BEST_INDIVIDUAL`, save it:
@@ -51,9 +54,9 @@ cd "$WS" && git diff > "$INTEGRATE_DIR/integrated_patch.diff"   # $WS = the uniq
     {"patches": ["r1_d0","r1_d2"], "method": "incremental|hand_merge",
      "correctness": "pass|fail", "geomean": 0.0}
   ],
-  "best": {"patches": ["..."], "geomean": 0.0, "arithmetic": 0.0,
+  "best": {"patches": ["..."], "geomean": 0.0, "arithmetic": 0.0, "weighted": 0.0,
             "patch_file": "<INTEGRATE_DIR>/integrated_patch.diff",
-            "per_case": [{"name":"...","baseline_ms":0.0,"optimized_ms":0.0,"speedup":0.0}]},
+            "per_case": [{"name":"...","baseline_ms":0.0,"optimized_ms":0.0,"speedup":0.0,"count":0}]},
   "improved_over_best_individual": true,
   "conclusion": "improved|no_improvement|all_failed",
   "notes": "what combined well / what conflicted"

--- a/kernel_workflow/roles/tech_lead.md
+++ b/kernel_workflow/roles/tech_lead.md
@@ -133,6 +133,12 @@ passes them):**
 - `HARNESS_ADDENDUM` — path to an e2e-refined harness addendum (which cases to weight, a cudagraph-capture
   wrapper, hard constraint gates). Plan toward the addendum's weighted target.
 
+**Workload-aligned runs (COMMANDMENT METRIC = time-weighted ratio-of-sums):** `CUMULATIVE_SPEEDUP` is
+then the time-weighted speedup, and the per-case table carries each case's `count` / time-share. Steer
+toward the cases that DOMINATE that weighted metric (high `count·latency` share) — a big win on a
+rare-but-cheap case barely moves it, while a modest win on the dominant case (often the decode bucket)
+moves it a lot. Do NOT let a high-variance speedup on a low-weight case decide the round.
+
 Your job: decide this round's directions (or stop). Re-read `geomean_levers.md` and the relevant
 optimization knowledge first.
 
@@ -296,11 +302,15 @@ table, `BASELINE_TIMING`, and `BASELINE_GEOMEAN_MS`.
    mkdir -p "$EVAL_DIR/optimized" && cp <kernel + wrapper + binding files> "$EVAL_DIR/optimized/" 2>/dev/null || true
    ```
 2. Write `EVAL_DIR/tech_lead_report.md`. Keep it concise but COMPLETE. Required sections:
-   - **Summary**: kernel, type, final geomean & arithmetic speedup, rounds, budget used / total.
+   - **Summary**: kernel, type, final speedup, rounds, budget used / total. When the run is
+     workload-aligned (COMMANDMENT METRIC = time-weighted ratio-of-sums), report the **time-weighted
+     speedup as the headline** with the unweighted geomean & arithmetic alongside; otherwise the
+     geomean is the headline (unchanged).
    - **Round-by-round**: for EACH round list EVERY engineer individually (id, specialty, strategy,
      verified speedup, success/fail + one-line reason), the integrate result, the round winner, and
      the bottleneck shift. This is the "round 1 optimized a, b, c — what were the results, what after merging; round 2 …" narrative.
-   - **Final per-test-case table** (baseline ms / optimized ms / speedup) + geomean + arithmetic.
+   - **Final per-test-case table** (baseline ms / optimized ms / speedup; + `count` & weight-share
+     when workload-aligned) + geomean + arithmetic + the time-weighted speedup.
    - **Key optimizations applied** (what + impact).
    - **What didn't work** (dead-ends from the ledger).
 
@@ -309,6 +319,7 @@ Return JSON:
 {
   "final_speedup_geomean": 0.0,
   "final_speedup_arithmetic": 0.0,
+  "final_speedup_weighted": 0.0,
   "rounds": 0,
   "budget_used": 0,
   "report_path": "<EVAL_DIR>/tech_lead_report.md",

--- a/kernel_workflow/roles/verify_engineer.md
+++ b/kernel_workflow/roles/verify_engineer.md
@@ -55,9 +55,12 @@ absolute per-case latencies. The script trusts only your numbers.
    Do NOT relax or skip this when the flag is set — it is the isolated-stage catch for the
    cuda_graph_capture_unsafe / NO_BINARY_FOR_GPU class that otherwise only surfaces at the costly e2e gate.
 5. Reject if a patch modified the harness/COMMANDMENT/files outside the workspace, or the benchmark
-   shows a regression (geomean ≤ 1.0). Report it as `status:"regression"` with the numbers anyway.
+   shows a regression (the PRIMARY metric ≤ 1.0). Report it as `status:"regression"` with the numbers anyway.
 6. Compute per-case speedup = `BASELINE_PER_CASE.latency / your_optimized_ms`; geomean =
-   `exp(mean(log(speedups)))`; arithmetic mean.
+   `exp(mean(log(speedups)))`; arithmetic mean. **If the COMMANDMENT's METRIC is the time-weighted
+   ratio-of-sums (workload-aligned), ALSO compute `verified_weighted = Σ count_i·baseline_i /
+   Σ count_i·optimized_i` using each case's `count` — this is the PRIMARY number; regression is judged
+   on it, not the geomean.**
 
 ## Return JSON
 ```json
@@ -66,7 +69,8 @@ absolute per-case latencies. The script trusts only your numbers.
   "correctness": "pass|fail",
   "verified_geomean": 0.0,
   "verified_arithmetic": 0.0,
-  "per_case": [{"name": "...", "baseline_ms": 0.0, "optimized_ms": 0.0, "speedup": 0.0}],
+  "verified_weighted": 0.0,
+  "per_case": [{"name": "...", "baseline_ms": 0.0, "optimized_ms": 0.0, "speedup": 0.0, "count": 0}],
   "variance_note": "e.g. run-to-run within 3%",
   "graph_safe": "pass|fail|n/a (only when REQUIRE_GRAPH_CAPTURE was set; omit otherwise)",
   "notes": "anything suspicious (overfit special-casing, narrow correctness, graph-capture host-sync, etc.)"

--- a/kernel_workflow/roles/verify_engineer.md
+++ b/kernel_workflow/roles/verify_engineer.md
@@ -58,9 +58,9 @@ absolute per-case latencies. The script trusts only your numbers.
    shows a regression (the PRIMARY metric ≤ 1.0). Report it as `status:"regression"` with the numbers anyway.
 6. Compute per-case speedup = `BASELINE_PER_CASE.latency / your_optimized_ms`; geomean =
    `exp(mean(log(speedups)))`; arithmetic mean. **If the COMMANDMENT's METRIC is the time-weighted
-   ratio-of-sums (workload-aligned), ALSO compute `verified_weighted = Σ count_i·baseline_i /
-   Σ count_i·optimized_i` using each case's `count` — this is the PRIMARY number; regression is judged
-   on it, not the geomean.**
+   ratio-of-sums (workload-aligned), ALSO compute `verified_weighted = Σ weight_i /
+   Σ (weight_i / speedup_i)` using each case's `weight` — this is the PRIMARY number; regression is
+   judged on it, not the geomean.**
 
 ## Return JSON
 ```json
@@ -70,7 +70,7 @@ absolute per-case latencies. The script trusts only your numbers.
   "verified_geomean": 0.0,
   "verified_arithmetic": 0.0,
   "verified_weighted": 0.0,
-  "per_case": [{"name": "...", "baseline_ms": 0.0, "optimized_ms": 0.0, "speedup": 0.0, "count": 0}],
+  "per_case": [{"name": "...", "baseline_ms": 0.0, "optimized_ms": 0.0, "speedup": 0.0, "weight": 0.0}],
   "variance_note": "e.g. run-to-run within 3%",
   "graph_safe": "pass|fail|n/a (only when REQUIRE_GRAPH_CAPTURE was set; omit otherwise)",
   "notes": "anything suspicious (overfit special-casing, narrow correctness, graph-capture host-sync, etc.)"


### PR DESCRIPTION
Fix part of #332 
## Summary
- **Unified extraction of shape / dtype / regime / count in the extractor**: parse_regime.py infers the serving regime (quant, kv_cache_dtype, compile) from server launch flags + model config; attribute_weights.py joins meta.json shape cases with per-kernel profiled time from parse_profile.py via an op_kind-aware engine — profile trace weight first, falling back to regime split → prior.
- **unittest.py as the single harness**: correctness (frozen golden cases) + time-weighted speedup (GEAK_WEIGHTED_SPEEDUP = Σw / Σ(w/s)) in one file; the baseline is always the original/in-regime kernel from the workload, never an LLM-generated naive PyTorch implementation.
- **Steady-state profiling**: bench_e2e.sh now captures the trace in a mid-load window on a warm server (not a cold-start burst), ensuring decode kernels are not missed.

## Key files
| File | Role |
|------|------|
| `e2e_workflow/scripts/parse_regime.py` | server flags + model config → regime descriptor |
| `e2e_workflow/scripts/attribute_weights.py` | meta shapes ⊕ profile weights → workload-v1 spec |
| `e2e_workflow/scripts/parse_profile.py` | torch trace → per-(shape,dtype) weight signal |
| `e2e_workflow/roles/kernel_extractor.md` | orchestrates extraction, bakes workload into meta.json |
| `kernel_workflow/kernel_workflow.js` | primSpeedup() selects weighted metric when present |
| `e2e_workflow/scripts/bench_e2e.sh` | steady-state profile window capture |

## Test plan
- [x] 29 unit tests pass (`python3 -m unittest discover -s e2e_workflow/scripts/tests -v`)
- [ ] E2E validation on a real MI300X sglang run (fp8 blockscale GEMM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)