### PR TITLE
fix(e2e): remove forced high-priority-GEMM head reordering (HEAD_PRIORITY)

### DIFF
--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -141,12 +141,6 @@ const HEAD_AUTHOR_MAX = parseInt(A.head_author_max != null ? A.head_author_max :
 // hits a harness fault / no-win / extraction failure, the orchestrator LOUDLY flags it (and still tries
 // the author route when a plan exists) instead of dropping the biggest lever on the floor. Default 30%.
 const HEAD_PROTECT_PCT = parseFloat(A.head_protect_pct != null ? A.head_protect_pct : 30);
-// FAST-MODE ONLY head priority (opt-in, default ''=OFF): a regex matched against each head candidate's
-// op_kind/short_name/name; matching heads are pulled to the FRONT of the head queue BEFORE the budget
-// slice, so e.g. head_priority="gemm" guarantees the dense/scaled-GEMM head is selected AND
-// integrated/stacked FIRST. Applied ONLY when FAST_MODE is on (see the heads[] construction below);
-// default '' leaves every mode (default/fast/deep) byte-identical.
-const HEAD_PRIORITY = String(A.head_priority != null ? A.head_priority : '').trim();
 // Corrective re-author: when a verified-isolated head winner is REJECTED at the e2e gate for a FIXABLE
 // integration reason (it ENGAGED live + beat the isolated oracle, only the integration POSTURE is wrong —
 // e.g. a JIT/DSL kernel lazily compiling in the TP>1 warmup -> NO_BINARY_FOR_GPU / cuda_graph_capture_unsafe,
@@ -880,18 +874,8 @@ const history = ST.history || { insights: [], ledger: [], milestones: [], bottle
 if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
   phase('HeadKernel');
   log(`Head-kernel track: ${headQueue.length} candidate op(s), head_budget=${HEAD_BUDGET}, threshold=${HEAD_THRESHOLD_PCT}%.`);
-  // FAST-MODE head priority: pull HEAD_PRIORITY-matching ops to the front BEFORE the budget slice, so the
-  // prioritized op (e.g. "gemm") is guaranteed selected and gated/stacked FIRST. Gated on FAST_MODE ->
-  // default/deep are byte-identical. Array.sort is stable: non-matches keep their Amdahl order, and among
-  // matches the original order is preserved (only the matched group is promoted ahead of the rest).
-  let _hq = headQueue;
-  if (FAST_MODE && HEAD_PRIORITY) {
-    const _re = new RegExp(HEAD_PRIORITY, 'i');
-    const _isPri = (c) => _re.test(`${c.op_kind || ''} ${c.short_name || ''} ${c.name || ''}`);
-    _hq = headQueue.slice().sort((a, b) => (_isPri(b) ? 1 : 0) - (_isPri(a) ? 1 : 0));
-    log(`[fast-mode] head_priority='${HEAD_PRIORITY}': ${_hq.filter(_isPri).length}/${_hq.length} head(s) match; integrate order=[${_hq.slice(0, HEAD_BUDGET).map((c) => c.short_name || c.op_kind || 'op').join(', ')}].`);
-  }
-  const heads = _hq.slice(0, HEAD_BUDGET).map((c, i) => ({
+  // Head ops are taken in the Architect's Amdahl-ranked order — no forced GEMM-first reordering.
+  const heads = headQueue.slice(0, HEAD_BUDGET).map((c, i) => ({
     ...c, idx: i, gpu_id: GPU_LIST[i % GPU_LIST.length],
     short_name: c.short_name || `${c.op_kind || 'op'}${i}`,
   }));

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -791,7 +791,17 @@ if (want('setup')) {
     { phase: 'Strategize', label: 'architect:strategize', schema: STRATEGY_SCHEMA });
   kernelQueue = (strategy && strategy.kernel_candidates) ? strategy.kernel_candidates.slice() : [];
   headQueue = (strategy && strategy.head_candidates) ? strategy.head_candidates.slice() : [];
-  log(`Strategy: ${headQueue.length} head (GEMM/attn) candidates, ${kernelQueue.length} kernel candidates, ${(strategy && strategy.config_directions || []).length} config directions.`);
+  // A fused-MoE / grouped-expert GEMM STAYS in the head-kernel sequence (if its pct earns it — same
+  // Amdahl priority/budget as any head op), but it must NOT be decomposed into a dense-GEMM optimization:
+  // its ragged per-expert M + token routing make a dense A·Bᵀ bake-off the wrong target and the wrong
+  // rebind seam. Force its op_kind to `moe` so the head track takes the grouped-GEMM branch
+  // (extract editable source + optimize as `fused_moe_grouped_gemm`) instead of `extract_op` dense synth.
+  const _isMoe = (c) => /(?:^|[^a-z])moe(?:[^a-z]|$)|grouped_gemm|group_gemm|ck_moe|expert/i
+    .test(`${(c && c.op_kind) || ''} ${(c && c.short_name) || ''} ${(c && c.name) || ''} ${(c && c.classification) || ''}`);
+  let _moeTagged = 0;
+  for (const c of headQueue) { if (_isMoe(c) && c.op_kind !== 'moe') { c.op_kind = 'moe'; _moeTagged++; } }
+  if (_moeTagged) log(`[route-guard] ${_moeTagged} fused-MoE/grouped head op(s) kept in the head track but tagged op_kind=moe (grouped-GEMM branch, never dense-GEMM).`);
+  log(`Strategy: ${headQueue.length} head candidates, ${kernelQueue.length} kernel candidates, ${(strategy && strategy.config_directions || []).length} config directions.`);
 } else {
   // Load carried state from a prior phase invocation (args.state).
   EVAL_DIR = ST.eval_dir || EVAL_DIR_OVERRIDE;

--- a/e2e_workflow/roles/kernel_extractor.md
+++ b/e2e_workflow/roles/kernel_extractor.md
@@ -99,11 +99,21 @@ If extraction fails (can't hook the callable, no cases captured, or not editable
 
 ---
 
-## PHASE=extract_op  (HEAD kernels: dense GEMM / attention — even when `edit=N`)
+## PHASE=extract_op  (HEAD kernels: dense GEMM / attention / fused-MoE — even when `edit=N`)
 
 For the **head track** the contract is different: a head kernel is usually a LIBRARY op (hipBLASLt
 GEMM, CK attention) with a clean math contract, so it does NOT need a copy of editable source — it
 needs an op task dir the **Op Benchmarker** can bake-off across backends. `edit=N` is fine here.
+
+> **`op_kind=moe` (fused-MoE / grouped-expert GEMM) — DO NOT synthesize a dense GEMM.** A MoE head op
+> stays in the head track (it earns head priority by pct), but it is a grouped/ragged GEMM with token
+> routing, NOT a dense `A·Bᵀ`. For `op_kind=moe`, do **PHASE=extract instead** (copy the EDITABLE
+> fused_moe source subtree into `kernel_src/` + capture the REAL I/O oracle via the capture overlay),
+> and write `meta.json` with `op_kind:"moe"`, `math_contract:"grouped per-expert GEMM + routing"`, the
+> real `target_callable` = the **fused_moe/grouped_gemm dispatcher** seam (NOT `tuned_gemm:gemm_a16w16`),
+> and `build` per the kernel. Return `op_kind:"moe"`. The Op Benchmarker then optimizes it as
+> `fused_moe_grouped_gemm` via kernel_workflow — it must never be dense-GEMM baked off. The GEMM-synth
+> path below applies ONLY to `op_kind=gemm`.
 
 Inputs: `EVAL_DIR`, `MODEL_PATH`, `GPU_ID`, `WORKLOAD`, `KERNEL` (Architect head candidate: short_name,
 op_kind=gemm|attn, the profiled `shapes`, dtype, regime, `target_callable` for attn, and OPTIONAL

--- a/e2e_workflow/roles/op_benchmarker.md
+++ b/e2e_workflow/roles/op_benchmarker.md
@@ -8,6 +8,14 @@ pick the fastest correct backend, tune that backend, and — only if the winner 
 op to the recursive `kernel_workflow` for code-level work. You never touch a server or measure e2e; the
 e2e Integrator turns your winner into an overlay/config and runs the Amdahl gate.
 
+> **`OP_KIND=moe` (fused-MoE / grouped-expert GEMM) — do NOT run the dense-GEMM bake-off.** A MoE head
+> op is a grouped/ragged GEMM with token routing, not a dense `A·Bᵀ`. Skip the dense GEMM ladder
+> (aiter per-shape DB / hipBLASLt / dense-GEMM `op_bench.py`). Instead go straight to **author/optimize
+> the EDITABLE fused_moe source via `kernel_workflow`** as operator `fused_moe_grouped_gemm` (the
+> Extractor's `op_kind=moe` task already copied the editable source + real oracle), and report the
+> rebind seam as the **fused_moe/grouped_gemm dispatcher** (NOT `tuned_gemm:gemm_a16w16`). Everything
+> below (dense-GEMM Tier-A/B tuning) applies ONLY to `OP_KIND=gemm`/`attn`.
+
 Read first, every time:
 - `SKILL_DIR/knowledge/gemm_attention_backends.md` — the head-kernel ladder, per-backend tuning knobs,
   parity/accuracy gate (the priors).


### PR DESCRIPTION
  ## What
                                                                                                                                                                      
  Removes the `HEAD_PRIORITY` mechanism introduced in #304, which force-reordered the
  head-kernel queue to optimize GEMM first.                                                                                                                           
                                                                                                                                                                      
  In FAST_MODE, when `head_priority` was set (e.g. `head_priority="gemm"`), matching head
  ops were pulled to the **front** of the head queue *before* the budget slice, so the
  dense/scaled-GEMM head was guaranteed to be selected and integrated/stacked first —
  overriding the Architect's Amdahl ranking.                                        
                                                                                    
  This PR drops that logic so head ops are processed strictly in the order the System
  Architect ranks them (by `pct_gpu_time × achievable_speedup`), with no hard-coded 
  GEMM-first bias.                        
                                                                                    
  ## Changes
                                                                                    
  `e2e_workflow/e2e_workflow.js` only (+2 / −18):                                   
  - Remove the `HEAD_PRIORITY` constant + its comment block.
  - Remove the FAST_MODE head-queue reordering block; head selection is now simply  
    `headQueue.slice(0, HEAD_BUDGET)` in Amdahl order.
                                          
  ## Why
                                                                                    
  Forcing GEMM to the front is a hard-coded heuristic that pre-empts the Architect's
  per-run prioritization. Different workloads/regimes don't always want GEMM optimized
  first; the queue should reflect the measured Amdahl priority, not a fixed op-kind rule.