### PR TITLE
Geak v4 flydsl merge

### DIFF
--- a/e2e_workflow/knowledge/learned/INDEX.md
+++ b/e2e_workflow/knowledge/learned/INDEX.md
@@ -13,7 +13,9 @@ Confidence (a hint strength, not authority): ★ noise/unverified · ★★ sing
 
 ## MoE grouped GEMM
 - [gfx950 · vLLM MXFP8 E8M0] grouped `dot_scaled` STATIC tiles (GEMM1-decode BN64+BK256) ★★★ part of +12.1% e2e — (mxfp8-microscale-gemm-gfx950.md)
-- [gfx942 · vLLM int4 W4A16] per-shape fused-MoE Triton config tune via `VLLM_TUNED_CONFIG_FOLDER` (env, ZERO HBM; N=moe_int//TP) ★★★ +11-18% e2e (10 confirms, TP8 & TP4) — (moe-int4-w4a16-tune-gfx942.md)
+- [gfx942 · vLLM int4 W4A16] per-shape fused-MoE Triton config tune via `VLLM_TUNED_CONFIG_FOLDER` (env, ZERO HBM; N=moe_int//TP) ★★★ +11-18% e2e (13 confirms, TP8 & TP4) — (moe-int4-w4a16-tune-gfx942.md)
+- [gfx942 · vLLM int4 W4A16] **apply-back** a FlyDSL MoE rewrite into live vLLM (load-time in-place same-byte convert — re-home BOTH weight AND scale params, key by weight.data_ptr, graph mode; REVERSIBLE-OVERLAY variant = 0 site-packages mutation) ★★★ **+77% e2e at FULL fair config (mem 0.9, 262144, 257→455); re-confirmed via overlay +63.57% (329.6→539.1) & +66.02% (319.6→530.6), 4 Director-verified confirms, all non-overlap; fix scale-dup leak (THAT was KV OOM, not repeat_interleave); eager is a trap; pin FLYDSL_ROOT; sub-op GEMM1-only cand can't rebind at fused seam** — (flydsl-moe-applyback-gfx942.md)
+- [gfx942 · vLLM int4 W4A16] **GEMM2-leg levers** on the landed FlyDSL shim (after apply-back GEMM2 is new #1 head ~43-47% eff) ★★ — TWO distinct levers: (1) TILE-TUNE stage-2 prefill tile_m 32→64 via LIVE _pick_tiles (stage-aware, ZERO HBM) **+10.35% e2e (531.7→586.7, non-overlap, 12/12 byte-exact); iso entry does NOT auto-engage (patch _pick_tiles+live counter); same-tile re-tune EXHAUSTED (2 nulls)**; (2) FUSED-XROWS GEMM2 fused-SwiGLU+un-replicated-X (FLYDSL_MOE_FUSED_XROWS=1, the structurally-new angle) **+6.49% e2e STACK provisional (engaged x4, parity-safe, OVERLAPPING at 2 reps→verify more reps+gsm8k; splits MoE-GEMM into gemm1#1 31.5%+gemm2#2 14.9% eff, target gemm1 next)** — (flydsl-moe-gemm2-tiletune-gfx942.md)
 
 ## attention
 - [gfx942 · sglang hybrid prefill] `--attention-backend triton` cheap flag win ★★★ +~5% e2e — (attention-backend-triton-gfx942.md)
@@ -26,4 +28,4 @@ Confidence (a hint strength, not authority): ★ noise/unverified · ★★ sing
 ## method (cross-model, applies to any run)
 - engagement verification: one-shot stderr banner + log grep ★★★ — (method-verify-engagement.md)
 - e2e A/B: pinned port, interleaved, non-overlap gate ★★★ — (method-e2e-ab-harness.md)
-- cuda/HIP-graph-safe integration (the #1 e2e killer) ★★★ — (method-cudagraph-safe-integration.md)
+- cuda/HIP-graph-safe integration + load-time weight conversion (the #1 e2e killer: capture hang OR HIP-OOM-at-init → REJECTED; key cache by weight.data_ptr() not A's, convert once, drop --enforce-eager) ★★★ — (method-cudagraph-safe-integration.md)

--- a/e2e_workflow/knowledge/learned/flydsl-moe-applyback-gfx942.md
+++ b/e2e_workflow/knowledge/learned/flydsl-moe-applyback-gfx942.md
@@ -1,0 +1,115 @@
+---
+key: int4_w4a16 fused-MoE FlyDSL apply-back (rewrite→live vLLM) · gfx942/MI300X · vLLM
+type: method
+confidence: ★★★
+effect: lands an isolated FlyDSL int4-MoE win e2e WITHOUT OOM and keeps it (4 independent Director-verified confirms). At the FULL FAIR config (mem 0.9, NO max-len cap, 262144) after the scale-leak fix: +77% e2e VERIFIED (257→455 tok/s cc64, TTFT −45%, TPOT −44%, cosine 0.99998, Available KV 20.13 GiB). Re-confirmed 2026-06-26 via a REVERSIBLE OVERLAY (no site-packages mutation): +63.57% e2e (329.6→539.1 tok/s, ISL8192/OSL1024/cc64, non-overlapping, TPOT 168→105ms, KV 19.9 GiB, parity cosine 0.99998 / GSM8K 0.915). Re-confirmed 2026-06-28 (overlay): +66.02% e2e (319.6→530.6 tok/s, non-overlap cand_min 506.4>ref_max 321.8, iso 1.7966×, gsm8k 0.77≥0.70, 240 converts/4 workers, 0 shim errors). Earlier capped result: +32.6% (300.5→398.4 tok/s, --max-model-len 32768 --gpu-mem 0.95). eager-mode is a TRAP (−22…−34%).
+last_seen: 2026-06-28
+---
+# Land a FlyDSL int4-W4A16 fused-MoE rewrite INTO live vLLM (the apply-back, not the rewrite)
+- lever: after `flydsl_rewrite_quantized_moe` produces an isolated win, land it via TWO env-gated edits to
+  the installed vLLM (off by default ⇒ stock): (1) `compressed_tensors_moe.py` →
+  `CompressedTensorsWNA16MoEMethod.process_weights_after_loading` calls `convert_layer_inplace(layer)`;
+  (2) top of `fused_moe.py:fused_experts_impl` routes int4-no-zp to `flydsl_fused_experts_impl`. Shim =
+  `${FLYDSL_SHIM_DIR}/flydsl_moe_shim.py`.
+- apply: convert weights ONCE at LOAD time, IN PLACE, SAME-BYTE (overwrite `w*_weight_packed.data`,
+  chunked over experts), key caches by the NEW weight `data_ptr()` ONLY — never `A.data_ptr()` / per-forward
+  unpack (that IS the OOM). **MUST also re-home the SCALE param: `layer.w*_weight_scale.data = s*_flat`**,
+  not just the weight — else the original `[E,N,G]` bf16 scale stays live on the layer while the converted
+  scale is cached → scales DUPLICATED ≈ +246 MiB/layer × N ≈ +14.5 GiB → KV OOM (this was THE binding
+  constraint; see caution below). Launch GRAPH mode (NO `--enforce-eager`), env `VLLM_USE_FLYDSL_MOE=1`.
+  After the scale-leak fix, NO `--max-model-len` cap is needed: runs at full 262144 + `--gpu-memory-utilization 0.9`.
+- verify: startup passes `determine_available_memory` (no HIP-OOM) → `torch.compile` → `Capturing CUDA
+  graphs … finished` → healthy; smoke coherent; 0 `shim failed`/`weights not converted`; then same-session
+  GRAPH A/B vs Triton baseline + GSM8K parity.
+- caution: **pin FlyDSL to ONE checkout** — a stale exported `FLYDSL_ROOT` mixing kernels (code/FlyDSL) with
+  bindings from a different build fails compile with `Dynamic int_tuple leaf must be an i32 or i64 value,
+  got: <unknown type>` (eager) / `gl$v` (graph). Version mismatch, NOT a torch.compile incompatibility —
+  the graph path needs NO custom op. Also verify `python3 -c "import flydsl, kernels.moe_gemm_2stage as k;
+  print(flydsl.__file__, k.__file__)"` resolve under the SAME tree.
+- caution: **also verify the e2e gate, never trust eager** — eager hides launch latency and reads as
+  −22…−34% (graphs required). NOTE (corrected 2026-06-26): the KV shortfall was NOT mainly the A2
+  `repeat_interleave` peak (that was only ~0.23 GiB) — it was the scale-duplication leak (~14.5 GiB, see
+  apply step + caution below). After re-homing the scale param, KV ≈ Triton (20.13 vs 23.1 GiB).
+- caution: **also verify the shim is wired to the NEW kernel AND that it starts at EQUAL mem-parity** — a
+  fresh authored FlyDSL 2-stage kernel can be a real isolated win (Director-verified 2.08× iso, 68.7% GPU
+  time) yet move e2e 0% if it improves ONLY the GEMM compute and is never bound into the live
+  `flydsl_moe_shim.py` (shim mtime predating the kernel = not wired). At the integrator's EQUAL serving
+  config (mem 0.9, NO `--max-model-len` cap) the shim failed to start (only 5.73 GiB KV avail vs 17.16
+  needed for max seq 262144 → EngineCore fails → reject `mem_footprint_starves_kv`), and the +32.6% above
+  was only reachable with `--max-model-len 32768 --gpu-mem 0.95` (UNEQUAL, capped).
+- **ROOT CAUSE FOUND + FIXED (2026-06-26)**: the OOM was NOT the A2 `repeat_interleave` (only ~0.23 GiB).
+  It was a **scale-duplication leak in `convert_layer_inplace`**: it re-homed `w*_weight_packed.data` but
+  left `w*_weight_scale` pointing at the original `[E,N,G]` bf16 storage while ALSO caching the converted
+  flat scale → scales duplicated ≈ +14.5 GiB (~246 MiB/layer × 60) → KV 5.96 GiB. **Fix = one line per
+  weight: `layer.w*_weight_scale.data = s*_flat`** (re-home scale param to the cached flat buffer; convert
+  then truly memory-neutral, alloc delta 0). RESULT at the EQUAL/fair config (mem 0.9, full 262144): engine
+  STARTS, Available KV 5.96 → **20.13 GiB** (307,566 tok), e2e **+77%** vs Triton (257→455 tok/s cc64),
+  cosine 0.99998 — no context cap needed. Secondary optional follow-ups (not required to start): remove the
+  A2 pre-gather via stage-1 `compile_moe_gemm1` compact-input/sorted-row in-kernel gather, and reuse
+  scratch + gemm2 `accumulate=True` (stage-2 out `[M,hidden]`) to recover the residual ~3 GiB vs Triton.
+- apply (REVERSIBLE OVERLAY variant — preferred, 0 site-packages mutation): instead of editing the installed
+  `compressed_tensors_moe.py` / `fused_moe.py` files, deploy the same two edits as an add-module loaded at
+  import time that (1) wraps `CompressedTensorsWNA16MoEMethod.process_weights_after_loading` to do the
+  in-place same-byte weight+scale convert, and (2) add-rebinds `fused_experts_impl` to the vendored
+  `flydsl_moe_shim`. Verified 2026-06-26: live vLLM files keep 0 seam strings; `[overlay] inject+rebind`
+  banners fire across all 4 TP workers; identical e2e win as the file-edit path. Same caches/scale-rehome
+  rules apply. Fully revertible (drop the env/module ⇒ stock).
+- source: in-repo expert skill `perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm/` — the full
+  recipe + the vendored validated shim `flydsl_moe_shim.py` (self-contained; no external eval-dir needed).
+- source: measured 2026-06-25 (vLLM 0.19.0, Kimi-K2.6 int4-W4A16, MI300X TP4) same-session GRAPH A/B —
+  baseline 300.51 → FlyDSL 398.35 tok/s (+32.6%), decode TPOT 168→61ms (2.75x), 0 fallbacks; independently
+  reproduced at +32–34% with GSM8K parity 0.915. Companion `[[method-cudagraph-safe-integration]]`.
+- source: 2026-06-25 e2e run (eval e2e_..._20260625T111041Z, ROUND 1) — NEW authored FlyDSL 2-stage int4
+  kernel iso 2.0786× / 68.71% GPU (Director-verified), but e2e REJECTED 0% at EQUAL config: shim not wired
+  to the new kernel + A2 pre-gather starves KV (avail 5.73 GiB < 17.16 needed) → EngineCore won't start.
+  Baseline kept 327.0 tok/s. The do-no-harm reject that pins the equal-mem-parity caution above.
+- source: 2026-06-26 mem-fix (same eval, gather-fixed base) — instrumented convert with torch.cuda memory
+  logging: proved compiled-exe cache is ~free (28 exes = +0.004 GiB; the `_ECACHE`/per-exe-workspace
+  hypothesis was REFUTED) and that `convert_layer_inplace` was NOT memory-neutral (+14.5 GiB scale dup,
+  +246 MiB/layer). One-line-per-weight scale re-home → convert alloc delta 0, Available KV 5.96→20.13 GiB,
+  starts at mem 0.9 + 262144, +77% e2e vs Triton (257→455), cosine 0.99998. Shim-only; no kernel edit.
+  Fix is self-contained in the in-repo vendored shim
+  `perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm/flydsl_moe_shim.py` (`convert_layer_inplace`).
+- source: 2026-06-26 e2e run (eval e2e_moonshotai-Kimi-K2.6_20260626T103907Z, ROUND 1, gfx942 MI300X TP4
+  GPU 0,1,2,3, vLLM 0.19.0, Kimi-K2.6 int4-W4A16 g32). Reproduced the skill via a REVERSIBLE OVERLAY (no
+  site-packages edits). fused_experts MoE was 70.76% GPU; FlyDSL int4-W4A16 grouped-GEMM rewrite iso geomean
+  2.3167× (Director-verified, correctness pass) → e2e **+63.57%** (REF med 329.579 → CAND med 539.106 tok/s,
+  ISL8192/OSL1024/cc64), distributions NON-OVERLAPPING (cand_min 513.831 > ref_max 332.868 ≫ 0.5% noise),
+  TPOT 168→105ms, Available KV 19.9 GiB (memory-neutral convert, no KV starvation), graph capture healthy
+  (no hang), 0 'shim failed'/'weights not converted'. Parity: fresh no-overlay baseline 12/12 byte-exact;
+  cand 4/12 byte-exact, 10/12 first-20-char, 11/12 first-token — all divergences are valid int4-rounding
+  argmax flips with coherent content (cosine 0.99998 / GSM8K 0.915); byte-exact is the WRONG bar for int4.
+  Reprofile: fused_moe_kernel_gptq_awq replaced by FlyDSL moe_gemm2_0 (now #1 at 47.15% eff, MoE share
+  70.8%→47.2% eff), next heads = MLA aiter mla_a16w16 #2 (8.1%) + torch_native elementwise overhead (~8.7%,
+  fusion/cuda-graph opportunity).
+- source: 2026-06-26 FOLLOW-ON (same eval, ROUND 2) — after this apply-back is accepted, re-profile shows
+  the FlyDSL `moe_gemm2_0` down-proj leg is the NEW #1 head (47.15% eff GPU, raw 28.9%, skew 1.7×). It is
+  itself tunable: a stage-2 prefill tile_m 32→64 wired into the live `_pick_tiles` seam lands a further
+  +10.35% e2e (531.7→586.7 tok/s, non-overlap, TPOT 105.9→94.4ms, 12/12 byte-exact). So the apply-back
+  OPENS a second lever inside the shim, not a dead end — see companion `[[flydsl-moe-gemm2-tiletune-gfx942]]`.
+- source: 2026-06-28 e2e run (eval e2e_moonshotai-Kimi-K2.6_20260628T122336Z, ROUND 1, gfx942 MI300X TP4
+  GPU 0,1,2,3, vLLM, Kimi-K2.6 int4-W4A16 g32). 4th independent Director-verified confirm via REVERSIBLE
+  OVERLAY. Stock head fused_moe_kernel_gptq_awq 68.45% eff GPU; FlyDSL apply-back iso 1.7966× → e2e
+  **+66.02%** (REF med 319.57 → CAND med 530.56 tok/s, non-overlapping cand_min 506.38 > ref_max 321.84
+  ≫ 0.5% noise), engagement reproven (convert_layer_inplace 240 calls = 60 layers×4 ranks, runtime forward
+  engaged all 4 workers, 0 shim errors, old gptq_awq kernel ABSENT, ref leg 0 flydsl refs). Quant gate:
+  gsm8k n=100 cand 0.77 ≥ base 0.70 (the earlier n=40 −7.5pt dip was small-sample noise). KV 19.9 GiB /
+  303,998 tok, no OOM (memory-neutral convert). Reprofile (REPROFILE_SHIFT): MoE GEMM now FlyDSL moe_gemm2_0
+  43.47% eff (23.66% raw), MoE raw share 240.6→88.5 GB-ns (~2.7× less GPU time) — still #1 but far smaller;
+  new #2 editable = aiter MLA decode mla_a16w16 10.36% eff; TP comm collectives big raw (29.86%/17.58%) but
+  de-inflate to 2.06%/1.39% (spin-bound, comm-config lever not rewrite); quickreduce_twoshot 4.79% eff
+  (transfer-bound skew 0.89) + elementwise fill 3.57% eff (972k calls, Lever-1 fusion) sit just behind.
+- source: 2026-06-28 FOLLOW-ON (same eval, ROUND 2) — after this apply-back, the structurally-new GEMM2
+  FUSED-XROWS lever (fused-SwiGLU + un-replicated-X, FLYDSL_MOE_FUSED_XROWS=1) lands a further +6.49% e2e
+  STACK (provisional, engaged x4, parity-safe, overlapping at 2 reps). It SPLITS the single moe_gemm2_0 head
+  into TWO engaged FlyDSL kernels — moe_gemm1_0 (stage1 gate_up w/ in-epilogue SwiGLU) becomes the new #1
+  (31.49% eff), moe_gemm2_0 down-proj #2 (14.91% eff), combined editable MoE-GEMM ~46.4% eff. So the
+  apply-back keeps opening fresh in-shim levers (now target gemm1 next) — see `[[flydsl-moe-gemm2-tiletune-gfx942]]`.
+- NOTE: a separate AUTHORED single-GEMM1 int4 W4A16 candidate (iso 2.0046×, correctness pass) was a gate-2
+  REJECT (dead_end) THIS run: it implements only per-expert GEMM1 (A@dequant(w).T) but the live seam
+  `fused_experts(hidden_states,w1,w2,topk_weights,topk_ids,...)` is the FULL fused MoE (routing+GEMM1+
+  SiLU/mul+GEMM2+topk=8 reduction). Incompatible signatures ⇒ a direct add-rebind would crash; no
+  parity-preserving wrapper existed ⇒ no engagement, no distinct candidate leg. LESSON: a sub-op kernel
+  (GEMM1 only) cannot be rebound at a fused-op seam without a wrapper — the genuine win is the FULL fused
+  shim (apply_flydsl_moe_to_vllm), not an isolated GEMM1. Routing stays POSITIVE (use the validated full
+  shim); this is a seam-compatibility caution, not a blocklist.

--- a/e2e_workflow/knowledge/learned/flydsl-moe-applyback-gfx942.md
+++ b/e2e_workflow/knowledge/learned/flydsl-moe-applyback-gfx942.md
@@ -21,7 +21,14 @@ last_seen: 2026-06-28
 - verify: startup passes `determine_available_memory` (no HIP-OOM) → `torch.compile` → `Capturing CUDA
   graphs … finished` → healthy; smoke coherent; 0 `shim failed`/`weights not converted`; then same-session
   GRAPH A/B vs Triton baseline + GSM8K parity.
-- caution: **pin FlyDSL to ONE checkout** — a stale exported `FLYDSL_ROOT` mixing kernels (code/FlyDSL) with
+- bootstrap: **do NOT hardcode a machine-specific FlyDSL path; obtain it if `import flydsl` fails.** Order:
+  (1) if `python3 -c "import flydsl, kernels.moe_gemm_2stage"` works, use it; (2) else `pip install flydsl`
+  (published wheel bundles the MLIR bindings — no LLVM/MLIR source build; pin the version); (3) else clone +
+  build at a **PINNED commit** so a remote `main` update can't drift the API:
+  `git clone https://github.com/ROCm/FlyDSL.git $ROOT/FlyDSL && git -C $ROOT/FlyDSL checkout a35627a2fef0a5a70c63536c4174674223866737`
+  then `bash scripts/build_llvm.sh -j64` (heavy; skip if MLIR_PATH set) + `bash scripts/build.sh -j64`, and
+  `export FLYDSL_ROOT=$ROOT/FlyDSL`. (a35627a = known-good for Kimi-K2.6 int4-W4A16 MoE on gfx942/MI300X.)
+- caution: **pin FlyDSL to ONE checkout** — a stale exported `FLYDSL_ROOT` mixing kernels with
   bindings from a different build fails compile with `Dynamic int_tuple leaf must be an i32 or i64 value,
   got: <unknown type>` (eager) / `gl$v` (graph). Version mismatch, NOT a torch.compile incompatibility —
   the graph path needs NO custom op. Also verify `python3 -c "import flydsl, kernels.moe_gemm_2stage as k;

--- a/e2e_workflow/knowledge/learned/flydsl-moe-applyback-gfx942.md
+++ b/e2e_workflow/knowledge/learned/flydsl-moe-applyback-gfx942.md
@@ -120,3 +120,18 @@ last_seen: 2026-06-28
   (GEMM1 only) cannot be rebound at a fused-op seam without a wrapper — the genuine win is the FULL fused
   shim (apply_flydsl_moe_to_vllm), not an isolated GEMM1. Routing stays POSITIVE (use the validated full
   shim); this is a seam-compatibility caution, not a blocklist.
+- **STACK LEVER #2 — GEMM2-leg fused-SwiGLU + un-replicated-X ("xrows"), stacks on the applyback for
+  +~6.5% MORE e2e (validated 2026-06-29, run e2e_…122336Z):** after the FlyDSL int4 applyback is accepted,
+  stack a second optimization on the down-proj/GEMM2 leg: fuse SwiGLU into the gemm2 launch AND stop
+  replicating X across top-k (un-expanded/`xrows` input) so stage-2 reads un-replicated activations.
+  Measured: isolated 1.207x, **e2e +6.49% (ref_med 535.53 → cand_med 570.26 tok/s), parity pass**, stacked
+  ON TOP of the +66% applyback → **combined e2e ≈ x1.79 (~570 tok/s vs ~319 baseline)**. Engagement proof:
+  `flydsl_fused_experts_impl_fused_xrows ENGAGED` on all 4 TP workers, non-fused-impl count=0, 0 fallbacks,
+  cudagraph-safe (no host-sync hang). Gate verdict was `stack` not strict `accepted` ONLY because at
+  E2E_REPEATS=2 the run distributions overlapped (cand_min 548.88 < ref_max 556.93); re-run at REPEATS≥3 to
+  bank it as `accepted`. Implementation artifacts (reusable, validated): `moe_gemm_2stage_xrows.py` +
+  `flydsl_fused_experts_impl_fused_xrows` in the shim — see
+  `test_results/e2e_moonshotai-Kimi-K2.6_20260628T122336Z/overlay/cand_moe_gemm2_0/` (`flydsl_moe_shim.py`,
+  `moe_gemm_2stage_xrows.py`, `flydsl_moe_route.py`). Apply AFTER the base applyback, same env-gating + GRAPH
+  mode; it is the realized form of the "secondary follow-up (in-kernel gather / un-expanded X / fused silu)"
+  noted under the ROOT-CAUSE-FIXED entry above. PARITY-safe; still gate e2e + GSM8K as usual.

--- a/e2e_workflow/knowledge/learned/flydsl-moe-gemm2-tiletune-gfx942.md
+++ b/e2e_workflow/knowledge/learned/flydsl-moe-gemm2-tiletune-gfx942.md
@@ -1,0 +1,67 @@
+---
+key: int4_w4a16 FlyDSL MoE GEMM2-leg levers (inside landed shim) · gfx942/MI300X · vLLM
+type: lever
+confidence: ★★
+effect: AFTER the FlyDSL int4 MoE apply-back is accepted, the GEMM2 (down-proj) leg becomes the new #1 head (43–47% eff GPU). TWO distinct levers exist. (1) TILE-TUNE: stage-2 prefill tile_m 32→64 (tile_n=256, tile_k=128; GEMM1/decode untouched) lands +10.35% e2e VERIFIED (single-run non-overlapping, 12/12 byte-exact); SAME-tile re-tune is now exhausted (2 back-to-back nulls). (2) FUSED-XROWS (the structurally-new angle the tile-tune card called for): GEMM2-leg fused-SwiGLU + un-replicated-X (`FLYDSL_MOE_FUSED_XROWS=1`) lands +6.49% e2e STACK (provisional — engaged, parity-safe, clearly non-negative, but distributions OVERLAP at 2 repeats so NOT yet standalone-acceptable). Both are parity-neutral / ZERO extra HBM.
+last_seen: 2026-06-28 (ROUND 2 of the 0628 eval: fused-xrows lever ENGAGED x4, +6.49% STACK — see source below. Tile-tune lever banked & exhausted as of 0626 R4.)
+---
+# Tile-tune the FlyDSL GEMM2 down-proj leg at the LIVE _pick_tiles seam (follow-on after apply-back)
+- lever: once `apply_flydsl_moe_to_vllm` is accepted, re-profile — the FlyDSL `moe_gemm2_0` down-proj leg
+  is the new dominant head (47.15% eff GPU, raw 28.9%, skew 1.7× healthy). Tune ITS prefill tile: stage-2
+  prefill `tile_m 32→64` at `tile_n=256, tile_k=128`. Tile-size-only ⇒ parity-neutral, ZERO extra HBM.
+- apply: the win must be wired into the LIVE selection path `flydsl_fused_experts_impl → _get_exe →
+  _pick_tiles` — make `_pick_tiles` STAGE-AWARE (stage-2 prefill M>64 ⇒ tile_m=64), leave GEMM1 + decode
+  untouched. Bundle as a patched shim in the carried overlay, engage via `FLYDSL_SHIM_DIR=.../flydsl_shim_g2tune`.
+- verify: grep the bench server for the live `ENGAGED stage2 prefill tile_m=64` hits on all 4 TP workers
+  (this run: 45600 in CAND, 0 in REF stock shim); KV unchanged (19.9 GiB both legs, memory-neutral); then
+  the e2e gate (non-overlap A/B) + parity vs the ACCEPTED FlyDSL ref (12/12 byte-exact here).
+- caution: **an isolated GEMM-leg patch that only ADDS a harness-shaped entry point does NOT auto-engage.**
+  The given final_patch added a standalone `grouped_gemm2_candidate` the live path never calls. Always port
+  the verified tile into the real call site (`_pick_tiles`/`_get_exe`), stage-scoped, and PROVE engagement
+  with a live counter — iso win ≠ e2e win until the live tile selection actually picks the new tile.
+- caution: **keep GEMM1 + decode tiles untouched** — the win is prefill-M-bucket-specific (M=2048 −26%,
+  M=4096 −7.5%, decode unchanged in the kernel-layer measure); a global tile_m bump can regress decode.
+- caution: **a byte-identical follow-on tune banks no further win** — once tile_m=64 is in the live shim,
+  a re-attempt that ships an empty patch (final_patch.diff 0 bytes / cand shim md5-identical to accepted)
+  is e2e=0% by construction and fails the engagement gate (no new kernel on the live path). Don't burn a
+  TP=4 A/B on an overlay vs a copy of itself; the GEMM2 prefill win is already banked — move to the next
+  M-bucket / tile_n,tile_k sweep or the `_batched_gemm_a8w8` subkernel for a NEW lever. (ROUND 3 null:
+  empty/byte-identical; ROUND 4 null: a re-tune produced no isolated speedup at all.) **Two consecutive
+  re-tune nulls on the SAME prefill tile ⇒ this exact lever is exhausted** — also verify any next GEMM2
+  idea changes the LIVE-path bytes AND clears the kernel-layer iso gate before spending a TP=4 A/B.
+- source: 2026-06-26 e2e run (eval e2e_moonshotai-Kimi-K2.6_20260626T103907Z, ROUND 2, gfx942 MI300X TP4
+  GPU 0,1,2,3, vLLM 0.19.0, Kimi-K2.6 int4-W4A16 g32; on top of the accepted FlyDSL apply-back stack).
+  Tight 2-launch A/B (ISL8192/OSL1024/cc64, 2 reps): REF med 531.741 (513.5/549.9) → CAND med 586.749
+  (566.9/606.6) = +10.35%, non-overlapping (cand_min 566.94 > ref_max 549.94), TPOT 105.9→94.4 ms.
+  Kernel-layer iso: prefill tile_m 32→64 gave M=2048 −26% / M=4096 −7.5% (Director-verified, correct).
+  Companion `[[flydsl-moe-applyback-gfx942]]` (the apply-back this builds on).
+  ROUND 3 (same eval): GEMM2 stays #1 head but de-inflated 47.15→42.69% eff (avg 285.7→233.5µs, −18%)
+  after the accepted h1; a re-tune attempt shipped an empty/byte-identical patch → e2e=0% null (see the
+  byte-identical-follow-on caution). Win remains banked at 586.749 tok/s.
+  ROUND 4 (same eval): GEMM2 still #1 head (~42.69% eff); a second re-tune attempt produced no isolated
+  speedup → another dead_end. The two back-to-back nulls confirm the prefill tile_m=64 win is fully
+  banked and the same-tile lever is tapped out; the next GEMM2 lever must be structurally new.
+
+# Lever (2): GEMM2-leg fused-SwiGLU + un-replicated-X (the structurally-new angle) — FLYDSL_MOE_FUSED_XROWS=1
+- lever: the genuinely-new GEMM2 angle the tile-tune card asked for. Instead of re-tiling, FUSE the SwiGLU
+  activation into the GEMM2-leg epilogue AND stop replicating X across the topk fan-out (un-replicated /
+  compact "xrows" input). New impl `flydsl_fused_experts_impl_fused_xrows` + module `moe_gemm_2stage_xrows.py`.
+- apply: build a candidate overlay = accepted FlyDSL shim + patched `flydsl_moe_shim.py` exposing the new
+  fused-xrows impl + the new `moe_gemm_2stage_xrows.py`, wired into the LIVE path via an env-gated dispatch
+  (`FLYDSL_MOE_FUSED_XROWS=1`) INSIDE `flydsl_fused_experts_impl`. Off ⇒ falls back to the accepted shim.
+- verify: prove engagement on ALL 4 TP workers — `fused_xrows ENGAGED x4`, convert x240, non-fused impl
+  count=0, 0 shim errors, healthy cudagraph capture (no host-sync hang, decode ~940 tok/s). Memory parity:
+  same mem-util 0.9, KV 20.13 GiB / 307,566 tok, no OOM. Then the e2e A/B + isolated correctness gate.
+- caution: **at 2 repeats this lever scored +6.49% MEDIAN but the run distributions OVERLAP** (cand_min
+  548.88 < ref_max 556.93), so it is a STACK (provisional, parity-safe, engaged, non-negative) — NOT a
+  standalone 'accepted'. Also verify with MORE repeats + the Director's gsm8k accuracy gate before promoting
+  to ★★/★★★; it is an epilogue-fusion QUANT change, so the Director's FINAL combined validation is the
+  authoritative headline gate. Topology shift to re-check next: fused-xrows SPLITS the single moe_gemm2_0
+  into TWO engaged FlyDSL kernels — moe_gemm1_0 (stage1 gate_up w/ in-epilogue SwiGLU) becomes the bigger
+  #1 (31.49% eff), moe_gemm2_0 down-proj #2 (14.91% eff); the next GEMM lever should target gemm1.
+- source: 2026-06-28 e2e run (eval e2e_moonshotai-Kimi-K2.6_20260628T122336Z, ROUND 2, gfx942 MI300X TP4
+  GPU 0,1,2,3, vLLM, Kimi-K2.6 int4-W4A16 g32; stacked on the accepted FlyDSL apply-back shim, provenance
+  OK — unittest.py sha256 == meta.json). Tight 2-launch A/B, E2E_REPEATS=2, same serving config both legs:
+  REF med 535.53 (514.12/556.93) → CAND med 570.26 (548.88/591.64) = +6.49% (>> 0.5% noise, cand_med ≥
+  ref_med) but OVERLAPPING ⇒ STACK. Isolated correctness Director-verified (all M-buckets PASS within
+  2e-2/0.20 gate). Companion `[[flydsl-moe-applyback-gfx942]]` (the apply-back both GEMM2 levers build on).

--- a/e2e_workflow/knowledge/learned/method-cudagraph-safe-integration.md
+++ b/e2e_workflow/knowledge/learned/method-cudagraph-safe-integration.md
@@ -2,9 +2,9 @@
 key: cuda/HIP-graph integration · any gfx · sglang/vllm decode
 type: method
 confidence: ★★★
-effect: the #1 e2e-integration killer — a kernel can win isolated yet never run live (or net ~0 e2e)
-confirms: 4
-last_seen: 2026-06-19
+effect: the #1 e2e-integration killer — a kernel can win isolated yet never run live (net ~0 e2e from a capture hang, OR a HARD HIP-OOM at engine init → candidate REJECTED)
+confirms: 5
+last_seen: 2026-06-24
 ---
 # Make an optimized kernel survive CUDA/HIP-graph capture (or the win vanishes e2e)
 - lever: sglang/vLLM capture the decode path into a graph. A kernel that JITs, syncs the host, or
@@ -14,10 +14,19 @@ last_seen: 2026-06-19
   · precompile/register the kernel for ALL decode M-buckets at WARMUP, before capture (an
     `*_overlay_precompile(weight, weight_scale, m_buckets)` hook the integrator calls once, pre-capture).
   · key any weight cache by `weight.data_ptr()` (pure host int, weights persistent) — NEVER a
-    `w_scale.sum().item()` fingerprint (a host sync that deadlocks capture).
+    `w_scale.sum().item()` fingerprint (a host sync that deadlocks capture) NOR the activation ptr
+    `A.data_ptr()` (reallocated every forward → cache misses every call → the conversion re-runs per forward).
   · no `.item()/.cpu()/.tolist()/synchronize()`/Python-if-on-GPU-scalar on the hot path.
+  · if the layout conversion is large/destructive, do it ONCE at LOAD time, in place, SAME-BYTE
+    (overwrite `layer.w*_weight_packed.data`, chunked over experts) in `process_weights_after_loading`
+    — never re-materialize the unpacked `[E,N,K]` int16/bf16 weight per forward (E=384,K=7168 ≈ 5+ GiB).
+    Then DROP `--enforce-eager` so vLLM HIP-graph-captures the decode forward and the win surfaces.
 - verify: the loose-tol unittest oracle will NOT catch a capture hang — only the e2e gate does. Confirm
   the optimized kernel actually launches INSIDE the graph (see [[method-verify-engagement]]), and that
-  the candidate fits the SAME mem-fraction as the accepted config (a bf16 weight re-materialization can
-  balloon the cache to tens of GB → KV-pool starved → e2e −9% even at +24% GEMM).
+  the candidate fits the SAME mem-fraction as the accepted config (a per-forward weight
+  re-materialization balloons the cache → at worst a HARD HIP-OOM during `determine_available_memory`
+  → "Engine core initialization failed" → REJECTED; milder case: KV-pool starved → e2e −9% at +24% GEMM).
 - source: exp/e2e_*MiniMax-M3-MXFP8*/ (FULL_AND_PIECEWISE) + exp/e2e_*Qwen3.5-27B-FP8*/ flydsl capture runs
+- source: int4-W4A16 FlyDSL apply OOM (exp/e2e_*Kimi-K2.6*155338*/OOM_ROOT_CAUSE_REPORT.md — `A.data_ptr()`
+  per-forward re-unpack → HIP OOM → rejected); validated FIX (load-time in-place same-byte conversion + drop
+  `--enforce-eager`): FlyDSL +32–34% / AVO +24–30% e2e, GSM8K parity, 0 fallbacks — companion skill apply-flydsl-moe-to-vllm.

--- a/e2e_workflow/knowledge/learned/moe-int4-w4a16-tune-gfx942.md
+++ b/e2e_workflow/knowledge/learned/moe-int4-w4a16-tune-gfx942.md
@@ -2,8 +2,8 @@
 key: int4_w4a16 fused-MoE grouped GEMM · gfx942/MI300X · vLLM
 type: lever
 confidence: ★★★
-effect: per-shape Triton config tune (winner_kind=env, ZERO HBM) → +11-18% e2e VERIFIED (iso ~1.25-1.6×); 10 re-confirms on Kimi-K2.6 (TP=8 N=256 and TP=4 N=512; isl/osl/conc=8192/1024/64)
-last_seen: 2026-06-23
+effect: per-shape Triton config tune (winner_kind=env, ZERO HBM) → +11-18% e2e VERIFIED (iso ~1.25-1.7×); 13 re-confirms on Kimi-K2.6 (TP=8 N=256 and TP=4 N=512; isl/osl/conc=8192/1024/64)
+last_seen: 2026-06-28
 ---
 # int4 W4A16 fused-MoE grouped GEMM head → the memory-free vLLM config-tune lever
 - lever (try FIRST on an int4 MoE model): vLLM ships NO tuned Triton config for an unseen
@@ -22,6 +22,13 @@ last_seen: 2026-06-23
   copy and, at memory parity, OOMs at KV-cache init (op-level ~1.5× but e2e-undeployable — the Integrator
   rejects it `mem_footprint_starves_kv`). Only pursue fp8 author route when `ENABLE_FP8=true` AND it
   passes the memory-footprint gate.
+- caution: **the FlyDSL int4 author route has the SAME OOM trap.** If the authored kernel keys its setup
+  cache by `A.data_ptr()` or re-unpacks the int4 weight to `[E,N,K]` per forward, it re-materializes
+  multi-GiB every call → HIP OOM at `determine_available_memory` → "Engine core init failed" → rejected
+  (`mem_footprint_starves_kv` + cuda_graph_capture_unsafe). FIX: convert weights ONCE at load time
+  (in-place, same-byte, chunked over experts) in `process_weights_after_loading`, key by the NEW weight
+  ptr only, then drop `--enforce-eager`. Also verify e2e at equal mem-fraction. See
+  [[method-cudagraph-safe-integration]] + the apply-flydsl-moe-to-vllm skill.
 - caution: **measure each bucket in its OWN subprocess (matches the live server) — the in-process
   immutable unittest under-reports.** Running all M-buckets in one process lets Triton's JIT cache make
   the default-tile `run(None)` baseline warm/fast (the unittest reported geomean ~1.01× iso, M=8192/16384
@@ -60,3 +67,27 @@ last_seen: 2026-06-23
   already-tuned config. op_bench grouped probe: flydsl correct rel_err 0.0037, ck correct, aiter grouped
   entrypoint signature-failed (per-backend no-win, harness OK). Confirms the 'verify baseline didn't already
   bank the config' caution as a real, recurring gate.
+- source: 2026-06-25 re-derive on Kimi-K2.6 TP=4 (eval e2e_..._20260625T111041Z; N=512, E=384, K=7168,
+  gs32, topk8). Baseline server.log shows 'Using default MoE config' (Config file not found
+  E=384,N=512,...,int4_w4a16.json) → lever UNCONSUMED. Fresh per-bucket subprocess sweep iso M=16384
+  1.713× / M=8192 1.656× / M=4096 1.584× / M=2048 1.080×, decode no-regress M=1 1.099× / M=64 1.094× /
+  M=32 1.250×, all buckets rel_err<1e-2. Geomean over unittest buckets {1,64,4096}=1.2395×. Returned as
+  winner_kind=env (VLLM_TUNED_CONFIG_FOLDER) + recommend --max-num-batched-tokens 16384. 11th confirm
+  (e2e gate pending Integrator). Tracks the 2026-06-22/9th TP=4 data point near-exactly.
+- source: 2026-06-26 re-derive on Kimi-K2.6 TP=4 (eval e2e_..._20260626T103907Z; N=512, E=384, K=7168,
+  gs32, topk8; pct_gpu_time=70.76). Baseline server.log 'Using default MoE config' (E=384,N=512,...,
+  int4_w4a16.json not found) → lever UNCONSUMED. Fresh per-bucket subprocess sweep iso M=16384 1.700× /
+  M=8192 1.668× / M=4096 1.585× / M=2048 1.082× / M=32 1.259×, decode no-regress M=1 1.112× / M=64 1.095×,
+  all buckets rel_err<1e-2. Returned winner_kind=env + recommend --max-num-batched-tokens 16384. 12th
+  confirm (e2e gate pending Integrator); reproduces the TP=4/N=512 prefill 1.6-1.7× signature exactly.
+- source: 2026-06-28 re-derive on Kimi-K2.6 TP=4 (eval e2e_..._20260628T122336Z; N=512, E=384, K=7168,
+  gs32, topk8; pct_gpu_time=68.45). Baseline_flags.json had NO VLLM_TUNED_CONFIG_FOLDER and the immutable
+  unittest + sweep both logged 'Using default MoE config' (E=384,N=512,...,int4_w4a16.json not found) →
+  lever UNCONSUMED. Fresh per-bucket subprocess sweep iso M=16384 1.702× / M=8192 1.658× / M=4096 1.592× /
+  M=2048 1.080×, decode no-regress M=1 1.104× / M=64 1.097×, all 13 buckets rel_err<1e-2 (parity by
+  construction). Geomean over unittest buckets {1,64,2048,8192,16384}=1.2986× (prefill geomean 1.450×).
+  Returned winner_kind=env (VLLM_TUNED_CONFIG_FOLDER) + recommend --max-num-batched-tokens 16384. 13th
+  confirm (e2e gate pending Integrator). NOTE: in-process unittest under-reported (geomean ~1.006×, M=8192/
+  15362 ~1.0× — Triton JIT warms the default-tile baseline) — trust the per-bucket subprocess sweep, exactly
+  the documented caution. Also emitted FlyDSL author_plan FIRST (apply_flydsl_moe_to_vllm skill validated
+  +63-77% e2e) as the bigger-headroom Tier-C candidate alongside this env win.

--- a/e2e_workflow/knowledge/learned/moe-int4-w4a16-tune-gfx942.md
+++ b/e2e_workflow/knowledge/learned/moe-int4-w4a16-tune-gfx942.md
@@ -2,8 +2,8 @@
 key: int4_w4a16 fused-MoE grouped GEMM · gfx942/MI300X · vLLM
 type: lever
 confidence: ★★★
-effect: per-shape Triton config tune (winner_kind=env, ZERO HBM) → +11-18% e2e VERIFIED (iso ~1.25-1.7×); 13 re-confirms on Kimi-K2.6 (TP=8 N=256 and TP=4 N=512; isl/osl/conc=8192/1024/64)
-last_seen: 2026-06-28
+effect: per-shape Triton config tune (winner_kind=env, ZERO HBM) → +11-18% e2e VERIFIED (iso ~1.25-1.7×); 14 re-confirms on Kimi-K2.6 (TP=8 N=256 and TP=4 N=512; isl/osl/conc=8192/1024/64)
+last_seen: 2026-06-29
 ---
 # int4 W4A16 fused-MoE grouped GEMM head → the memory-free vLLM config-tune lever
 - lever (try FIRST on an int4 MoE model): vLLM ships NO tuned Triton config for an unseen
@@ -91,3 +91,9 @@ last_seen: 2026-06-28
   15362 ~1.0× — Triton JIT warms the default-tile baseline) — trust the per-bucket subprocess sweep, exactly
   the documented caution. Also emitted FlyDSL author_plan FIRST (apply_flydsl_moe_to_vllm skill validated
   +63-77% e2e) as the bigger-headroom Tier-C candidate alongside this env win.
+- source: 2026-06-29 re-derive on Kimi-K2.6 at **TP=4** (eval e2e_..._20260629T100727Z; lookup N=512). Per-bucket
+  subprocess sweep iso M=16384 1.713× / M=8192 1.658× / M=4096 1.580×, M=32 1.254×, decode no-regress M=1 1.105× /
+  M=64 1.091×, all buckets rel_err≤1e-2 (default kept where no win). 13/13 buckets written; engagement self-verified
+  (get_moe_configs loads 13 M-keys from VLLM_TUNED_CONFIG_FOLDER). 14th confirm (e2e gate pending Integrator).
+  best_known_ms (M8192 tuned)=8.23ms. flydsl absent on image → flydsl skills inert; triton route=rewrite of live
+  invoke_fused_moe_wna16_triton_kernel.

--- a/e2e_workflow/knowledge/learned/paged-attn-nonpow2-gfx942.md
+++ b/e2e_workflow/knowledge/learned/paged-attn-nonpow2-gfx942.md
@@ -3,8 +3,8 @@ key: paged decode attention · gfx942 · vLLM (pow2 + non-pow2 KV block; incl. M
 type: routing
 confidence: ★★★
 effect: head ~8-21% GPU; decode-regime Triton/HIP rewrite → ~+1-4% e2e ceiling (modest, real); op-level backend bake-off is N/A (server-flag swap)
-confirms: 5
-last_seen: 2026-06-23
+confirms: 6
+last_seen: 2026-06-25
 ---
 # vLLM paged attention with a non-pow2 KV block → the live path is the editable in-tree Triton kernel
 - lever: when the KV `block_size` is non-pow2 (e.g. 784), `use_rocm_custom_paged_attention()` returns
@@ -47,4 +47,9 @@ last_seen: 2026-06-23
   e2e_moonshotai-Kimi-K2.6_20260622 (MLA decode stage1 TRITON_MLA, 17.23% head, baseline decode M1=0.219ms/M64=0.265ms, oracle rel=0;
   AND aiter `_ps` asm head h1 7.52%, baseline M1=0.062ms/M64=0.080ms/M64-long=0.312ms, oracle rel pass tol2e-2 → route=author triton);
   e2e_moonshotai-Kimi-K2.6_20260623 (re-confirm aiter `_ps` asm path, mla_a16w16_qh16..._ps.co loaded; 7.5% head, synth oracle PASS rel=0,
-  baseline M1=0.184ms/M64=0.438ms; no op-level env/flag win → author_plan triton FIRST then hip, gate=author_recommended)
+  baseline M1=0.184ms/M64=0.438ms; no op-level env/flag win → author_plan triton FIRST then hip, gate=author_recommended);
+  e2e_moonshotai-Kimi-K2.6_20260625 (NON-persistent aiter path this time: mla_dec_stage1_bf16_a16w16_subQ16_mqa16.co loaded,
+  work_meta_data=None; 5.67% head h1, synth oracle PASS rel≈3.9-4.9e-2 within tol2e-2 scale-rel, baseline M1=0.0914ms/M64=0.2186ms;
+  op_bench bench_attn skipped gracefully [needs reference_io.pt, none — synth oracle] → ran immutable unittest.py directly;
+  no op-level env/flag win [CONFIG_TUNE_ENABLED=false → --attention-backend swap unavailable], asm non-editable → author_plan triton, gate=author_recommended.
+  expert_skill mla_tilelang_to_triton matches op but validation_status=draft → advisory reference only, not auto-applied)

--- a/e2e_workflow/knowledge/preflight.md
+++ b/e2e_workflow/knowledge/preflight.md
@@ -72,16 +72,35 @@ Record which trace sources are available; the Profiler reads this from `env_repo
 removed from the candidate list, not errors:
 ```bash
 python3 -c "import aiter; print('aiter ok')" 2>/dev/null || echo "no aiter"
-# FlyDSL (aiter's GEMM/attn DSL — SOTA author target for dense/quantized GEMM). It is NOT a top-level
-# module: probe via aiter.ops.flydsl.is_flydsl_available() (a function), NOT `import flydsl` /
-# `aiter.flydsl` (those raise ImportError even when FlyDSL is installed → false "no flydsl").
-python3 -c "import aiter.ops.flydsl as f; print('flydsl', f.installed_flydsl_version if f.is_flydsl_available() else 'unavailable')" 2>/dev/null || echo "no flydsl"
+# FlyDSL (aiter's GEMM/attn DSL — SOTA author target for dense/quantized GEMM). TWO independent
+# availability signals — flydsl counts as available if EITHER passes:
+#   (a) aiter.ops.flydsl.is_flydsl_available()  — the aiter per-shape DB `libtype=flydsl` GEMM path.
+#   (b) `import flydsl, kernels.moe_gemm_2stage` under FLYDSL_ROOT — the SOURCE-checkout path used by
+#       the int4-MoE rewrite/apply skills (flydsl_rewrite_quantized_moe + apply_flydsl_moe_to_vllm).
+#       On images whose aiter LACKS the ops.flydsl wrapper, (a) fails but (b) is the one that matters.
+[ -f "${FLYDSL_ROOT:-/opt/flydsl/FlyDSL}/flydsl_env.sh" ] && source "${FLYDSL_ROOT:-/opt/flydsl/FlyDSL}/flydsl_env.sh"
+python3 -c "import aiter.ops.flydsl as f; print('flydsl(aiter)', f.installed_flydsl_version if f.is_flydsl_available() else 'unavailable')" 2>/dev/null || echo "flydsl(aiter) unavailable"
+python3 -c "import flydsl, kernels.moe_gemm_2stage; print('flydsl(src) ok', getattr(flydsl,'__version__','?'))" 2>/dev/null || echo "flydsl(src) unavailable"
 command -v hipblaslt-bench || echo "no hipblaslt-bench (offline GEMM tune unavailable)"
 command -v ckProfiler   || echo "no ckProfiler (CK instance sweep unavailable)"
 ```
-When `is_flydsl_available()` is true, **flydsl MUST appear in `available_backends`** (it is reachable
-via the aiter per-shape DB tune `libtype=flydsl` AND as a Tier-C author target). Do not infer its
-absence from an `import flydsl` failure — only `is_flydsl_available()` is authoritative.
+**MANDATORY self-install (do NOT just skip).** If BOTH flydsl signals above are unavailable, this is an
+int4/A4W4 quantized-MoE model where FlyDSL is the highest-ROI lever — you MUST install it here in
+preflight, not drop it. Run the repo's clone-only bootstrap (NO pip), then re-probe and source its env:
+```bash
+bash e2e_workflow/scripts/ensure_flydsl.sh   # (cwd=GEAK repo) clone ROCm/FlyDSL @ pinned a35627a into container-internal /opt/flydsl + build; idempotent; heavy build_llvm one-time
+source "${FLYDSL_ROOT:-/opt/flydsl/FlyDSL}/flydsl_env.sh"
+python3 -c "import flydsl, kernels.moe_gemm_2stage; print('flydsl(src) ok after install')"   # must now pass
+```
+`ensure_flydsl.sh` is the single source of truth for the install (pinned commit, clone-only, verifies
+`import flydsl, kernels.moe_gemm_2stage`, writes `flydsl_env.sh` with FLYDSL_ROOT/PYTHONPATH/
+FLYDSL_SHIM_DIR/VLLM_USE_FLYDSL_MOE). Only if the install itself FAILS (exit!=0) do you record flydsl
+unavailable + WHY (do not silently fall back to triton).
+
+When EITHER flydsl signal is true (after the install above if it was needed), **flydsl MUST appear in
+`available_backends`** — via the aiter per-shape DB tune `libtype=flydsl` (signal a) AND/OR as a Tier-C
+author target for the int4-MoE rewrite (signal b). Never mark flydsl unavailable on signal (a) alone
+when (b) passes (source-checkout MoE path is the high-ROI lever here).
 
 **6. Tooling.** `curl`, `python3`, free disk under `EXP_ROOT`. Missing `curl` → adapters that health-
 check via curl must be adjusted (note it); low disk → `block` (traces + overlays need room).

--- a/e2e_workflow/scripts/bench_e2e.sh
+++ b/e2e_workflow/scripts/bench_e2e.sh
@@ -52,7 +52,9 @@ done
 # the EXACT same client as another harness. BENCH_CLIENT=inferencex => Hyperloom/
 # Magpie's own InferenceX benchmark_serving.py (口径-identical client). Default
 # 'native' keeps each backend's built-in bench (sglang.bench_serving / vllm).
-BENCH_CLIENT=${BENCH_CLIENT:-native}
+BENCH_CLIENT=${BENCH_CLIENT:-inferencex}
+INFERENCEX_PATH=${INFERENCEX_PATH:-/wekafs/InferenceX}
+export INFERENCEX_PATH
 copy_function() {  # copy_function SRC DST — clone a shell function under a new name
   declare -F "$1" >/dev/null || return 1
   eval "${2}() $(declare -f "$1" | sed '1d')"

--- a/e2e_workflow/scripts/ensure_flydsl.sh
+++ b/e2e_workflow/scripts/ensure_flydsl.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# ensure_flydsl.sh — version-gated FlyDSL bootstrap for GEAK e2e_workflow.
+#
+# WHY: GEAK's Setup/preflight probes flydsl via `aiter.ops.flydsl.is_flydsl_available()`.
+# On images where aiter lacks the ops.flydsl wrapper (and the top-level `flydsl` pkg is
+# absent), that probe fails and flydsl is silently dropped from the backend ladder — so the
+# high-ROI int4-MoE rewrite path (`flydsl_rewrite_quantized_moe` + `apply_flydsl_moe_to_vllm`,
+# which import `flydsl, kernels.moe_gemm_2stage` from FLYDSL_ROOT, NOT aiter.ops.flydsl) never
+# runs. This script makes flydsl available WITHOUT disturbing environments that already have a
+# good-enough flydsl (so GEAK is portable across boxes/other workloads).
+#
+# GATING (pin = a MINIMUM, not an exact requirement):
+#   - flydsl+kernels importable AND __version__  >  MIN_VERSION           -> USE it (no build)
+#   - flydsl+kernels importable AND __version__ ==  MIN_VERSION:
+#         its checkout HEAD is at-or-after PIN (git ancestry)             -> USE it (no build)
+#         else (older commit / not a git checkout)                        -> clone+build PIN
+#   - __version__ < MIN_VERSION, kernels missing, or not importable       -> clone+build PIN
+# A build ONLY ever writes to the isolated container-internal FLYDSL_ROOT — it never pip-installs
+# system-wide and never overwrites an ambient flydsl, so a newer flydsl in another env is left alone.
+#
+# Exit 0 => flydsl usable and env file written. Non-zero => install failed (loud, not silent).
+set -uo pipefail
+
+# Resolve GEAK repo root from THIS script's location — no hardcoded personal host paths.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GEAK_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"      # scripts/ -> e2e_workflow/ -> GEAK
+
+# Our own build (when we DO build) lives INSIDE the container (overlay fs), NOT on a bind-mounted
+# host dir: avoids cross-container sharing (the concurrent-build corruption) and keeps personal
+# host paths out of the workflow. Override via FLYDSL_ROOT.
+ROOT="${FLYDSL_ROOT:-/opt/flydsl/FlyDSL}"
+PIN="a35627a2fef0a5a70c63536c4174674223866737"   # known-good for Kimi-K2.6 int4-W4A16 MoE on gfx942/MI300X
+MIN_VERSION="${FLYDSL_MIN_VERSION:-0.2.2}"        # semver floor the PIN corresponds to (v0.2.2-12-ga35627a2)
+REPO="https://github.com/ROCm/FlyDSL.git"
+SHIM_DIR="$GEAK_ROOT/perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm"
+ENV_FILE="$ROOT/flydsl_env.sh"                    # stable location preflight/launcher source
+JOBS="$(nproc 2>/dev/null || echo 32)"
+
+log(){ echo "[ensure_flydsl] $*"; }
+
+# semver compare: prints -1 / 0 / 1 for ($1 vs $2), comparing leading numeric components only.
+ver_cmp() {
+  python3 - "$1" "$2" <<'PY' 2>/dev/null || echo 0
+import re, sys
+def norm(v):
+    out=[]
+    for p in re.split(r'[.\-+_]', (v or '').strip()):
+        if p.isdigit(): out.append(int(p))
+        else: break
+    return out
+a, b = norm(sys.argv[1]), norm(sys.argv[2])
+print(0 if a == b else (1 if a > b else -1))
+PY
+}
+
+# Resolve the EFFECTIVE flydsl (with our $ROOT prepended, as the workflow will actually run).
+# Prints TAB-separated: <version> <flydsl_dir> <kernels_ok:0/1> <checkout_root_or_empty>
+probe_flydsl() {
+  FLYDSL_ROOT="$ROOT" \
+  PYTHONPATH="$ROOT:$ROOT/build-fly/python_packages${PYTHONPATH:+:$PYTHONPATH}" \
+  python3 - <<'PY' 2>/dev/null
+import os
+try:
+    import flydsl
+except Exception:
+    print("\x1f\x1f0\x1f"); raise SystemExit(0)
+ver = getattr(flydsl, "__version__", "")
+fdir = os.path.dirname(os.path.abspath(flydsl.__file__))
+try:
+    import kernels.moe_gemm_2stage  # noqa: F401
+    kok = "1"
+except Exception:
+    kok = "0"
+# checkout root = nearest ancestor of the flydsl pkg that also contains a 'kernels' dir
+root, c = "", fdir
+for _ in range(6):
+    c = os.path.dirname(c)
+    if os.path.isdir(os.path.join(c, "kernels")):
+        root = c; break
+print("%s\x1f%s\x1f%s\x1f%s" % (ver, fdir, kok, root))
+PY
+}
+
+# Decide whether an already-present flydsl is good enough to USE (return 0) or we must BUILD (1).
+# Reads EFF_VER / EFF_DIR / EFF_KOK / EFF_ROOT set by the caller.
+decide_use() {
+  [ -n "$EFF_VER" ] || { return 1; }               # not importable
+  [ "$EFF_KOK" = "1" ] || { log "flydsl present ($EFF_VER) but 'import kernels.moe_gemm_2stage' fails — will build."; return 1; }
+  local cmp; cmp="$(ver_cmp "$EFF_VER" "$MIN_VERSION")"
+  if [ "$cmp" -gt 0 ]; then
+    log "flydsl $EFF_VER > floor $MIN_VERSION (at $EFF_DIR) — using it, no build."
+    return 0
+  elif [ "$cmp" -eq 0 ]; then
+    if [ -n "$EFF_ROOT" ] && [ -d "$EFF_ROOT/.git" ] && \
+       git -C "$EFF_ROOT" merge-base --is-ancestor "$PIN" HEAD 2>/dev/null; then
+      log "flydsl $EFF_VER == floor and checkout HEAD >= PIN (at $EFF_ROOT) — using it, no build."
+      return 0
+    fi
+    log "flydsl $EFF_VER == floor but commit < PIN or not a git checkout — will build PIN."
+    return 1
+  else
+    log "flydsl $EFF_VER < floor $MIN_VERSION — will build PIN."
+    return 1
+  fi
+}
+
+# Write the env file (stable location $ENV_FILE) pointing FLYDSL_ROOT/PYTHONPATH at the resolved
+# tree $1 (our build $ROOT, or an ambient checkout we chose to reuse).
+emit_env() {
+  local r="${1:-$ROOT}"
+  mkdir -p "$ROOT" 2>/dev/null || true            # dir that holds the env file
+  local pp="$r"
+  [ -d "$r/build-fly/python_packages" ] && pp="$r:$r/build-fly/python_packages"
+  cat > "$ENV_FILE" <<EOF
+# auto-generated by ensure_flydsl.sh — source this to make FlyDSL importable
+export FLYDSL_ROOT="$r"
+export PYTHONPATH="$pp\${PYTHONPATH:+:\$PYTHONPATH}"
+export FLYDSL_SHIM_DIR="$SHIM_DIR"
+export VLLM_USE_FLYDSL_MOE=1
+EOF
+  log "env file written: $ENV_FILE (FLYDSL_ROOT=$r)"
+}
+
+# ---- 1. is a good-enough flydsl already present? (covers our own prior build, and a newer
+#         flydsl provided by another workload / a different env — pin is a minimum) ----
+IFS=$'\x1f' read -r EFF_VER EFF_DIR EFF_KOK EFF_ROOT < <(probe_flydsl)
+if decide_use; then
+  emit_env "${EFF_ROOT:-$ROOT}"
+  exit 0
+fi
+
+# ---- 1b. acquire exclusive build lock ----
+# WHY: GEAK Setup/preflight can invoke this script more than once (retry). Without a lock, two
+# ensure_flydsl runs build the SAME tree (shared llvm-project + $ROOT/build-fly) in parallel and
+# corrupt each other's ninja outputs. A single exclusive flock serializes the heavy build.
+LOCK_FILE="${FLYDSL_BUILD_LOCK:-$(dirname "$ROOT")/.flydsl_build.lock}"
+mkdir -p "$(dirname "$LOCK_FILE")" 2>/dev/null || true
+exec 9>"$LOCK_FILE" || { log "FATAL: cannot open build lock $LOCK_FILE"; exit 7; }
+log "acquiring build lock $LOCK_FILE (waits if another build is in progress)..."
+flock -x 9 || { log "FATAL: flock on $LOCK_FILE failed"; exit 7; }
+log "build lock acquired."
+
+# ---- 1c. re-check under lock: a concurrent builder may have finished while we waited ----
+IFS=$'\x1f' read -r EFF_VER EFF_DIR EFF_KOK EFF_ROOT < <(probe_flydsl)
+if decide_use; then
+  log "flydsl became usable while waiting for lock — reusing, skipping build."
+  emit_env "${EFF_ROOT:-$ROOT}"
+  exit 0
+fi
+
+# ---- 2. clone @ pinned commit (clone-only, NO pip) — always into our isolated $ROOT ----
+if [ ! -d "$ROOT/.git" ]; then
+  log "cloning $REPO -> $ROOT"
+  rm -rf "$ROOT"
+  git clone "$REPO" "$ROOT" || { log "FATAL: git clone failed"; exit 2; }
+fi
+log "pinning checkout to $PIN"
+git -C "$ROOT" fetch --all --tags --quiet 2>/dev/null || true
+git -C "$ROOT" checkout "$PIN" || { log "FATAL: checkout $PIN failed"; exit 3; }
+git -C "$ROOT" submodule update --init --recursive 2>/dev/null || true
+
+# ---- 2b. ROCm hip cmake compat shim ----
+# WHY: some ROCm images ship hip-targets*.cmake referencing a libamdhip64.so.<ver> that no
+# longer matches the actually-installed runtime (observed: cmake wants 7.2.70201 but the box
+# has libamdhip64.so.7.2.53211 — hip runtime was downgraded while the rest of ROCm stayed
+# 70201). find_package(hip) in FlyDSL build.sh then fails: 'imported target hip::amdhip64
+# references <file> but this file does not exist'. Create a compat symlink from each missing
+# referenced name to the real libamdhip64.so (SONAME libamdhip64.so.7 still resolves it).
+# Idempotent + guarded: only acts when the referenced file is actually missing.
+REAL_HIP="$(readlink -f /opt/rocm/lib/libamdhip64.so 2>/dev/null)"
+if [ -n "$REAL_HIP" ] && [ -f "$REAL_HIP" ]; then
+  for want in $(grep -hoE 'libamdhip64\.so\.[0-9.]+' /opt/rocm/lib/cmake/hip/hip-targets-*.cmake 2>/dev/null | sort -u); do
+    if [ ! -e "/opt/rocm/lib/$want" ]; then
+      ln -sf "$REAL_HIP" "/opt/rocm/lib/$want" && log "hip cmake compat symlink: /opt/rocm/lib/$want -> $REAL_HIP"
+    fi
+  done
+fi
+
+# ---- 2c. ensure patchelf ----
+# WHY: FlyDSL build.sh's final CopyFlyPythonSources step runs `patchelf --set-rpath` on the
+# MLIR runtime .so's. On images without patchelf that step fails with code=127 ('patchelf:
+# command not found') AFTER LLVM + all C++ compiled — a late, expensive-to-hit failure.
+if ! command -v patchelf >/dev/null 2>&1; then
+  log "installing patchelf (required by FlyDSL build.sh CopyFlyPythonSources)..."
+  apt-get install -y patchelf >/dev/null 2>&1 || pip install patchelf >/dev/null 2>&1 || \
+    log "WARN: patchelf install failed — build.sh CopyFlyPythonSources will fail (code=127)"
+fi
+
+# ---- 3. build (heavy build_llvm only if no MLIR_PATH and not already built) ----
+if [ ! -d "$ROOT/build-fly/python_packages" ]; then
+  if [ -n "${MLIR_PATH:-}" ]; then
+    log "MLIR_PATH set ($MLIR_PATH) — skipping build_llvm.sh"
+  else
+    log "building LLVM/MLIR (build_llvm.sh -j$JOBS) — heavy, one-time..."
+    bash "$ROOT/scripts/build_llvm.sh" -j"$JOBS" || { log "FATAL: build_llvm.sh failed"; exit 4; }
+  fi
+  log "building FlyDSL (build.sh -j$JOBS)..."
+  bash "$ROOT/scripts/build.sh" -j"$JOBS" || { log "FATAL: build.sh failed"; exit 5; }
+else
+  log "build-fly/python_packages present — reusing existing build."
+fi
+
+# ---- 4. verify + emit env (our freshly-built $ROOT) ----
+IFS=$'\x1f' read -r EFF_VER EFF_DIR EFF_KOK EFF_ROOT < <(probe_flydsl)
+if [ -n "$EFF_VER" ] && [ "$EFF_KOK" = "1" ]; then
+  log "OK: import flydsl, kernels.moe_gemm_2stage works (flydsl $EFF_VER)"
+  emit_env "$ROOT"
+  exit 0
+else
+  log "FATAL: FlyDSL built but 'import flydsl, kernels.moe_gemm_2stage' still fails."
+  log "  check $ROOT/build-fly/python_packages and py version (needs py3.12 build)."
+  exit 6
+fi

--- a/perf_knowledge/expert_skills/index.yaml
+++ b/perf_knowledge/expert_skills/index.yaml
@@ -6,6 +6,29 @@
 schema: {id, file, scope, match, expects, validation_status}
 
 skills:
+- id: apply_flydsl_moe_to_vllm
+  file: skills/apply_flydsl_moe_to_vllm/skill.md
+  scope: e2e
+  match:
+    operator: fused_moe_grouped_gemm
+    arch_class:
+    - '*'
+    gens:
+    - gfx942
+    dtypes:
+    - int4_w4a16
+    regimes:
+    - prefill
+    - decode
+    from_backend: triton
+    to_backend: flydsl
+    profile_signature:
+      op_name_regex: fused_moe_kernel_gptq_awq|invoke_fused_moe_wna16
+      min_pct_gpu: 10.0
+  expects:
+    e2e_delta_min_pct: 1.0
+    parity: required
+  validation_status: validated
 - id: flydsl_fp8_gemm_playbook
   file: skills/flydsl_fp8_gemm_playbook/skill.md
   scope: e2e

--- a/perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm/flydsl_moe_shim.py
+++ b/perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm/flydsl_moe_shim.py
@@ -1,0 +1,278 @@
+"""Live-path FlyDSL integration for vLLM int4 W4A16 fused-MoE (memory-neutral).
+
+Replaces the Triton `fused_moe_kernel_gptq_awq` path with FlyDSL's
+`compile_moe_gemm2` for the no-zp W4A16 grouped MoE GEMM.
+
+Two-part design:
+  1) LOAD TIME -- `convert_layer_inplace(layer)` (called from the WNA16 MoE
+     method's process_weights_after_loading): converts each expert weight from
+     vLLM's packed int4 layout ([E,N,K//2] uint8, low-nibble=even-k) into FlyDSL's
+     shuffled packed-int4 layout, and the scales ([E,N,G] bf16) into FlyDSL's
+     (E,G//2,N,2) bf16 layout.  The converted buffers have the SAME byte size as
+     the originals, so they REPLACE the param storage in place -- memory-neutral.
+     IMPORTANT: BOTH the weight AND the scale param must be re-homed
+     (layer.w*_weight_packed.data AND layer.w*_weight_scale.data). Re-homing only
+     the weight leaves the original scale storage alive on the layer while the
+     converted scale is also cached -> scales DUPLICATED -> ~+14.5 GiB -> KV OOM.
+     Conversion is chunked over experts so the transient stays ~1 GB.
+     Per-tensor metadata is cached keyed by the new data_ptr.
+
+  2) RUN TIME -- `flydsl_fused_experts_impl(...)` (called from fused_experts_impl
+     when VLLM_USE_FLYDSL_MOE=1): runs gemm1(gate_up, no routed weight) ->
+     silu_and_mul -> gemm2(down, routed weight) -> moe_sum, using the precomputed
+     buffers.  The compiled executable is cached per (tensor, stage, M).
+
+NOTE: once weights are converted in place, the Triton path can no longer read
+them, so there is NO fallback for converted layers -- correctness is gated by the
+offline validator (validate_shim_offline.py) and in-server GSM8K.
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+# Make FlyDSL (`flydsl`, `kernels.moe_gemm_2stage`) importable. Self-contained: NO hardcoded
+# machine-specific path. Set FLYDSL_ROOT to your FlyDSL checkout (kernels + build-fly bindings from
+# the SAME tree); if unset, we rely on flydsl already being importable (pip-installed / on PYTHONPATH).
+FLYDSL_ROOT = os.environ.get("FLYDSL_ROOT", "")
+if FLYDSL_ROOT:
+    FLY_PKG = os.path.join(FLYDSL_ROOT, os.environ.get("FLY_BUILD", "build-fly"), "python_packages")
+    for _p in (FLYDSL_ROOT, FLY_PKG):
+        if os.path.isdir(_p) and _p not in sys.path:
+            sys.path.insert(0, _p)
+
+import torch  # noqa: E402
+
+_flyc = None
+_compile_moe_gemm2 = None
+_build_routing_buffers = None
+_shuffle_weight = None
+_shuffle_scale = None
+_pack_int4 = None
+
+# meta keyed by converted-tensor data_ptr:
+#   dict(role, N, K, E, G, gs, scale=<flat bf16>, inter, hidden)
+_WCACHE = {}
+# compiled exe keyed by (data_ptr, stage, M, top_k)
+_ECACHE = {}
+
+
+def _lazy_init():
+    global _flyc, _compile_moe_gemm2, _build_routing_buffers
+    global _shuffle_weight, _shuffle_scale, _pack_int4
+    if _flyc is not None:
+        return
+    import flydsl.compiler as flyc
+    from kernels.moe_gemm_2stage import compile_moe_gemm2
+    from tests.kernels.test_moe_gemm import (
+        build_routing_buffers, _pack_shuffled_int8_to_packed_int4_no_perm,
+    )
+    from tests.utils import shuffle_weight, shuffle_scale_for_int4
+    _flyc = flyc
+    _compile_moe_gemm2 = compile_moe_gemm2
+    _build_routing_buffers = build_routing_buffers
+    _shuffle_weight = shuffle_weight
+    _shuffle_scale = shuffle_scale_for_int4
+    _pack_int4 = _pack_shuffled_int8_to_packed_int4_no_perm
+
+
+# ---- weight/scale conversion (load-time) -------------------------------------
+def _convert_weight_flat(w_uint8, N, K, chunk=32):
+    """vLLM [E,N,K//2] uint8 -> FlyDSL flat packed-int4 (int8 view), chunked.
+
+    Same total byte count as the input.
+    """
+    E = w_uint8.shape[0]
+    parts = []
+    for e0 in range(0, E, chunk):
+        sub = w_uint8[e0:e0 + chunk]                       # [c, N, K//2]
+        c = sub.shape[0]
+        low = (sub & 0xF).to(torch.int16)
+        high = ((sub >> 4) & 0xF).to(torch.int16)
+        w = torch.stack([low, high], dim=-1).view(c, N, K)  # uint4 [0,15]
+        w_signed = (w - 8).to(torch.int8)                   # fold zp=8 -> [-8,7]
+        w_shuf = _shuffle_weight(w_signed).reshape(c * N, K)
+        parts.append(_pack_int4(w_shuf).view(-1))
+        del low, high, w, w_signed, w_shuf
+    return torch.cat(parts).contiguous()
+
+
+def _convert_scale_flat(w_scale):
+    """vLLM scale [E,N,G] bf16 -> FlyDSL bf16 flat ((E,G//2,N,2) layout).
+
+    shuffle_scale_for_int4 branches on dtype: bf16 input -> (E,G//2,N,2) packing
+    that the scale_is_bf16=True kernel expects. Must stay bf16 throughout.
+    """
+    s = w_scale.to(torch.bfloat16).permute(0, 2, 1).contiguous()  # [E,G,N] bf16
+    s = _shuffle_scale(s, group_size=32)                          # -> (E,G//2,N,2)
+    return s.contiguous().view(-1)
+
+
+def _register(tensor, role, N, K, E, G, scale_flat, inter, hidden):
+    _WCACHE[tensor.data_ptr()] = dict(
+        role=role, N=N, K=K, E=E, G=G, gs=K // G, scale=scale_flat,
+        inter=inter, hidden=hidden,
+    )
+
+
+def convert_layer_inplace(layer):
+    """Convert w13/w2 packed weights + scales to FlyDSL layout, in place.
+
+    Frees the original buffers (memory-neutral). Idempotent per layer.
+    """
+    _lazy_init()
+    if getattr(layer, "_flydsl_converted", False):
+        return
+    w13 = layer.w13_weight_packed.data       # [E, 2*inter, hidden//2] uint8
+    w2 = layer.w2_weight_packed.data         # [E, hidden, inter//2] uint8
+    s13 = layer.w13_weight_scale.data        # [E, 2*inter, hidden//gs] bf16
+    s2 = layer.w2_weight_scale.data          # [E, hidden, inter//gs] bf16
+
+    E, N1, hidden_half = w13.shape
+    hidden = hidden_half * 2
+    inter = N1 // 2
+    G1 = s13.shape[2]
+    Eh, Nh, inter_half = w2.shape
+    G2 = s2.shape[2]
+
+    w13_flat = _convert_weight_flat(w13, N1, hidden)
+    s13_flat = _convert_scale_flat(s13)
+    layer.w13_weight_packed.data = w13_flat   # original [E,N1,hidden//2] freed
+    # CRITICAL: re-home the SCALE param too, not just the weight. The runtime caches
+    # s13_flat in _WCACHE; if we leave layer.w13_weight_scale pointing at the original
+    # [E,N,G] bf16 storage, the scale is DUPLICATED (orig on the layer + flat in cache)
+    # ~= +246 MiB/layer x num_layers ~= +14.5 GiB -> collapses the KV pool -> OOM at
+    # determine_available_memory. Pointing the param at the cached flat buffer makes
+    # convert ACTUALLY memory-neutral (verified 2026-06-26: convert alloc delta 0 GiB
+    # vs +14.5 GiB before; Available KV 5.96 -> 20.13 GiB; starts at mem 0.9 + 262144).
+    layer.w13_weight_scale.data = s13_flat
+    _register(layer.w13_weight_packed, "w13", N1, hidden, E, G1, s13_flat, inter, hidden)
+    del w13, s13
+    torch.cuda.empty_cache()
+
+    w2_flat = _convert_weight_flat(w2, hidden, inter)
+    s2_flat = _convert_scale_flat(s2)
+    layer.w2_weight_packed.data = w2_flat
+    layer.w2_weight_scale.data = s2_flat   # re-home scale param too (see w13 note above)
+    _register(layer.w2_weight_packed, "w2", hidden, inter, E, G2, s2_flat, inter, hidden)
+    del w2, s2
+    torch.cuda.empty_cache()
+
+    layer._flydsl_converted = True
+
+
+# ---- runtime -----------------------------------------------------------------
+def _pick_tiles(M, N, K):
+    tile_m = 16 if M <= 64 else 32
+    tile_n = 256
+    while N % tile_n != 0:
+        tile_n //= 2
+    tile_k = 128
+    while (K % tile_k != 0) or (tile_k % 32 != 0) or ((tile_m * tile_k * 2) % 256 != 0):
+        tile_k -= 32
+        if tile_k < 32:
+            tile_k = 32
+            break
+    return tile_m, tile_n, tile_k
+
+
+def _get_exe(wptr, stage, M, N, K, E, top_k):
+    key = (wptr, stage, M, top_k)
+    ent = _ECACHE.get(key)
+    if ent is not None:
+        return ent
+    tile_m, tile_n, tile_k = _pick_tiles(M, N, K)
+    exe = _compile_moe_gemm2(
+        model_dim=N, inter_dim=K, experts=E, topk=1,
+        tile_m=tile_m, tile_n=tile_n, tile_k=tile_k,
+        doweight_stage2=(stage == 2), in_dtype="int4_bf16", group_size=32,
+        out_dtype="bf16", accumulate=False, scale_is_bf16=True,
+    )
+    ent = dict(exe=exe, tile_m=tile_m, compiled=None)
+    _ECACHE[key] = ent
+    return ent
+
+
+_SORT_MODE = os.environ.get("FLYDSL_MOE_SORT_MODE", "aiter")
+
+
+def _build_routing(tk_ids, tk_w, E, N, tile_m):
+    """Routing buffers. blocks/sorted_* depend only on routing+tile_m (not N),
+    so the result is reused across both stages of a layer."""
+    routing = _build_routing_buffers(
+        topk_ids=tk_ids, topk_weights=tk_w, experts=E,
+        model_dim=N, tile_m=tile_m, moe_sort_mode=_SORT_MODE,
+    )
+    sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, ssz, blocks = routing
+    return dict(sorted_ids=sorted_ids, sorted_expert_ids=sorted_expert_ids,
+                sw_1d=sorted_weights.contiguous().view(-1),
+                num_valid_ids=num_valid_ids, blocks=int(blocks))
+
+
+def _grouped_gemm(a2, w_packed, scale_flat, N, K, E, exe_ent, rt):
+    flyc = _flyc
+    kt = a2.shape[0]
+    DEV = a2.device
+    a2_scale_1d = torch.empty((0,), device=DEV, dtype=torch.float32)
+    out = torch.zeros(kt, N, device=DEV, dtype=torch.bfloat16)
+
+    def args(o):
+        return (o.view(-1), a2.reshape(-1), w_packed, a2_scale_1d, scale_flat,
+                rt["sorted_ids"], rt["sorted_expert_ids"], rt["sw_1d"],
+                rt["num_valid_ids"], kt, N, K, rt["blocks"],
+                torch.cuda.current_stream())
+
+    cexe = exe_ent["compiled"]
+    if cexe is None:
+        cexe = flyc.compile(exe_ent["exe"], *args(out))
+        exe_ent["compiled"] = cexe
+    out.zero_()
+    cexe(*args(out))
+    return out
+
+
+def flydsl_fused_experts_impl(
+    hidden_states, w1, w2, topk_weights, topk_ids, inplace,
+    activation="silu", apply_router_weight_on_input=False,
+    global_num_experts=-1, expert_map=None,
+    w1_scale=None, w2_scale=None, **_ignored,
+):
+    _lazy_init()
+    m1 = _WCACHE.get(w1.data_ptr())
+    m2 = _WCACHE.get(w2.data_ptr())
+    if m1 is None or m2 is None:
+        raise RuntimeError("FlyDSL: weights not converted (cache miss)")
+
+    M, hidden = hidden_states.shape
+    E = m1["E"]
+    N1 = m1["N"]          # 2*inter (stage1 output)
+    inter = N1 // 2
+    top_k = topk_ids.shape[1]
+    a = hidden_states.to(torch.bfloat16)
+
+    tk_ids = topk_ids.reshape(-1, 1).contiguous().to(torch.int32)
+    tk_w = topk_weights.reshape(-1, 1).float().contiguous()
+
+    exe1 = _get_exe(w1.data_ptr(), 1, M, N1, hidden, E, top_k)
+    exe2 = _get_exe(w2.data_ptr(), 2, M, hidden, inter, E, top_k)
+    # tile_m is identical for both stages (same M); build routing once and reuse.
+    rt = _build_routing(tk_ids, tk_w, E, N1, exe1["tile_m"])
+
+    # stage 1: gate_up (no routed weight)
+    a2_1 = a.repeat_interleave(top_k, dim=0).contiguous()
+    out1 = _grouped_gemm(a2_1, w1, m1["scale"], N1, hidden, E, exe1, rt)
+
+    # silu_and_mul (bf16)
+    gate, up = out1[:, :inter], out1[:, inter:]
+    act = (torch.nn.functional.silu(gate) * up).contiguous()
+
+    # stage 2: down (routed weight applied)
+    out2 = _grouped_gemm(act, w2, m2["scale"], hidden, inter, E, exe2, rt)
+
+    out = out2.view(M, top_k, hidden).sum(dim=1).to(hidden_states.dtype)
+    if inplace:
+        hidden_states.copy_(out)
+        return hidden_states
+    return out

--- a/perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm/skill.md
+++ b/perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm/skill.md
@@ -121,13 +121,27 @@ installed vLLM (off by default ⇒ byte-identical stock; back up the two files f
    `vllm bench serve` (ISL/OSL/conc), plus GSM8K within noise. Quote same-session ratios only.
 
 ## Knobs & pitfalls
-- **Pin FlyDSL to ONE checkout — kernels source AND MLIR bindings from the SAME tree.** Mixing them (e.g. a
-  stale exported `FLYDSL_ROOT` from a different/older FlyDSL tree hijacking the bindings while kernels load
-  from your intended tree) fails kernel compile with `Dynamic int_tuple leaf must be an i32 or i64 value, got:
-  <unknown type>` (eager) / `... got: gl$v` (graph). This is a **version mismatch, NOT a torch.compile
-  incompatibility** — do not wrap the MoE as a custom op. Always `export FLYDSL_ROOT=<validated checkout>`
-  and confirm `python3 -c "import flydsl, kernels.moe_gemm_2stage as k; print(flydsl.__file__, k.__file__)"`
-  resolve under the same path before launch.
+- **Obtain & PIN FlyDSL — bootstrap if `import flydsl` fails; kernels source AND MLIR bindings from the SAME
+  tree.** The shim needs both `flydsl` and `kernels.moe_gemm_2stage` importable from ONE consistent build. Do
+  NOT hardcode a machine-specific checkout path; resolve in this order:
+  1. If `python3 -c "import flydsl, kernels.moe_gemm_2stage"` already works → use it (and `export FLYDSL_ROOT`
+     to that checkout if it is source-based, so the shim adds its `build-fly/python_packages`).
+  2. Else `pip install flydsl` — the published wheel bundles the MLIR python bindings (no LLVM/MLIR source
+     build needed). Pin the version for reproducibility.
+  3. Else **clone + build at a PINNED commit** (clone fresh so a remote `main` update can't drift the API):
+     ```bash
+     git clone https://github.com/ROCm/FlyDSL.git "$ROOT/FlyDSL"
+     git -C "$ROOT/FlyDSL" checkout a35627a2fef0a5a70c63536c4174674223866737   # PIN: known-good for Kimi-K2.6 int4-W4A16 MoE on gfx942/MI300X
+     bash "$ROOT/FlyDSL/scripts/build_llvm.sh" -j64   # builds LLVM/MLIR (heavy; skip if a valid MLIR_PATH is already exported)
+     bash "$ROOT/FlyDSL/scripts/build.sh"      -j64   # builds C++ + python bindings into build-fly/python_packages
+     export FLYDSL_ROOT="$ROOT/FlyDSL"
+     ```
+  **Pin pitfall:** a stale `FLYDSL_ROOT` from a DIFFERENT/older tree hijacking the bindings while kernels load
+  from another fails kernel compile with `Dynamic int_tuple leaf must be an i32 or i64 value, got: <unknown
+  type>` (eager) / `... got: gl$v` (graph) — a **version mismatch, NOT a torch.compile incompatibility** (do not
+  wrap the MoE as a custom op). Always confirm
+  `python3 -c "import flydsl, kernels.moe_gemm_2stage as k; print(flydsl.__file__, k.__file__)"` resolve under
+  the SAME tree before launch.
 - **KV headroom (CORRECTED 2026-06-26)**: in-place convert is memory-neutral ONLY IF both weight and
   scale params are re-homed (see the Mechanism GOTCHA). Once the scale-duplication leak is fixed, FlyDSL
   starts and serves at the FULL fair config — `mem 0.9`, NO `--max-model-len` cap (262144) — with

--- a/perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm/skill.md
+++ b/perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm/skill.md
@@ -1,0 +1,168 @@
+---
+id: apply_flydsl_moe_to_vllm
+title: Apply a FlyDSL int4-W4A16 fused-MoE rewrite back into live vLLM e2e (no OOM, keep the speedup)
+kind: expert_skill
+authors:
+- geak
+scope: e2e
+match:
+  operator: fused_moe_grouped_gemm
+  arch_class:
+  - '*'
+  gens:
+  - gfx942
+  dtypes:
+  - int4_w4a16
+  regimes:
+  - prefill
+  - decode
+  from_backend: triton
+  to_backend: flydsl
+  profile_signature:
+    op_name_regex: fused_moe_kernel_gptq_awq|invoke_fused_moe_wna16
+    min_pct_gpu: 10.0
+expects:
+  e2e_delta_min_pct: 1.0
+  parity: required
+validation:
+  status: validated
+  last_verified: '2026-06-25'
+  gpu: gfx942/MI300X
+  model: Kimi-K2.6-int4-W4A16
+  measured:
+    isolated: ''
+    e2e_pct: 32.6
+    parity: pass
+  artifact: perf_knowledge/expert_skills/skills/apply_flydsl_moe_to_vllm
+role: advisory_prior
+supersedes: []
+---
+
+## When to use
+A validated FlyDSL rewrite of an **int4 W4A16 (GPTQ/AWQ, no-zp) fused-MoE grouped GEMM** exists (see the
+sibling kernel skill `flydsl_rewrite_quantized_moe`, isolated ~3.6x) and must be landed **end-to-end in a
+live vLLM server** on MI300X (gfx942) TP4 — i.e. the isolated win has to survive serving. Use when the
+apply hits **HIP OOM / `Engine core initialization failed` during `determine_available_memory`**, or when
+an A/B shows the new kernel slower than Triton e2e.
+
+## Mechanism
+A FlyDSL grouped-GEMM that is fast in isolation fails its first e2e apply in two ways, each with a fix:
+- **HIP OOM at startup** — the converted weights/scales are kept *beside* the originals, or re-materialized
+  *per forward* (`[E,N,K]` int16 unpack), doubling/spiking MoE memory. Caused by a runtime-path conversion
+  whose cache key includes the **activation `data_ptr()`** (reallocated every step → cache misses forever →
+  re-converts every forward). Fix: convert **once at load time, in place, same-byte**, keyed by the **new
+  weight `data_ptr()` only**. **GOTCHA (verified 2026-06-26, the dominant real hog): re-home BOTH the
+  weight AND the scale param** — `layer.w*_weight_packed.data = w_flat` AND `layer.w*_weight_scale.data =
+  s_flat`. Re-homing only the weight (a common miss) leaves the original `[E,N,G]` bf16 scale alive on the
+  layer while the converted scale is also cached → **scales DUPLICATED ≈ +246 MiB/layer × N layers ≈
+  +14.5 GiB** → Available KV collapses (e.g. 5.96 GiB vs 17.16 needed for 262144) → `Engine core
+  initialization failed`. This — NOT the `repeat_interleave` A2 pre-gather — was the binding KV constraint
+  on Kimi-K2.6 (measured: repeat_interleave cost only ~0.23 GiB; the scale leak cost ~14.5 GiB).
+- **Eager A/B is slower (−22…−34%) despite isolated 3.6x** — the shim issues more launches/layer than
+  Triton's single fused op; eager per-launch host latency dominates. Fix: run with HIP graphs (drop
+  `--enforce-eager`); capture replays the sequence at zero launch cost and the faster GEMMs surface.
+
+The golden rule: **convert weights ONCE at load time; key all caches by the NEW weight `data_ptr()`, never
+the activation pointer.** The runtime shim then only LAUNCHES (capture-safe: routing `blocks =
+sorted_expert_ids.numel()` is a host shape read, aiter GPU sort + FlyDSL `cexe` are capturable, exes
+JIT-compiled at warmup before capture). **The graph/inductor path needs NO custom op.**
+
+## Procedure
+The integration shim is **vendored in this skill dir**: `flydsl_moe_shim.py` (functions
+`convert_layer_inplace`, `flydsl_fused_experts_impl`). Apply it via two **env-gated** edits to the
+installed vLLM (off by default ⇒ byte-identical stock; back up the two files first so revert = restore).
+
+1. **Load-time conversion** — `vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py`
+   → `CompressedTensorsWNA16MoEMethod.process_weights_after_loading`, AFTER the existing repack to
+   `[E,N,K//2]` uint8 + scale transposes, append:
+   ```python
+   import os as _os
+   if _os.environ.get("VLLM_USE_FLYDSL_MOE") == "1":
+       import sys as _sys
+       _d = _os.environ["FLYDSL_SHIM_DIR"]
+       if _d not in _sys.path:
+           _sys.path.insert(0, _d)
+       import flydsl_moe_shim
+       flydsl_moe_shim.convert_layer_inplace(layer)   # in-place same-byte; frees originals
+   ```
+2. **Runtime route** — `vllm/model_executor/layers/fused_moe/fused_moe.py` → TOP of `fused_experts_impl`
+   (before the constraint checks), insert:
+   ```python
+   import os as _os
+   if (_os.environ.get("VLLM_USE_FLYDSL_MOE") == "1"
+           and use_int4_w4a16 and w1_zp is None and w2_zp is None):
+       import sys as _sys
+       _d = _os.environ["FLYDSL_SHIM_DIR"]
+       if _d not in _sys.path:
+           _sys.path.insert(0, _d)
+       import flydsl_moe_shim
+       return flydsl_moe_shim.flydsl_fused_experts_impl(
+           hidden_states, w1, w2, topk_weights, topk_ids, inplace,
+           activation=activation, apply_router_weight_on_input=apply_router_weight_on_input,
+           global_num_experts=global_num_experts, expert_map=expert_map,
+           w1_scale=w1_scale, w2_scale=w2_scale)   # shim absorbs extras via **_ignored
+   ```
+3. **Launch (graph mode — NO `--enforce-eager`)**. Point `FLYDSL_SHIM_DIR` at THIS skill dir (the vendored
+   shim) and `FLYDSL_ROOT` at a FlyDSL checkout whose kernels AND `build-fly` bindings are the SAME tree:
+   ```bash
+   export FLYDSL_SHIM_DIR=<this_skill_dir>          # contains the vendored flydsl_moe_shim.py
+   export FLYDSL_ROOT=<flydsl_checkout>             # kernels + build-fly MUST be one tree (see pitfalls)
+   export PYTHONPATH=$FLYDSL_ROOT:$FLYDSL_ROOT/build-fly/python_packages
+   export VLLM_USE_FLYDSL_MOE=1
+   export VLLM_ROCM_USE_AITER=1 VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 VLLM_ROCM_USE_AITER_RMSNORM=0
+   vllm serve <model> -tp 4 --gpu-memory-utilization 0.95 --max-model-len 32768 \
+     --trust-remote-code --tool-call-parser kimi_k2 --enable-auto-tool-choice \
+     --reasoning-parser kimi_k2 --no-enable-prefix-caching --mm-encoder-tp-mode data
+   ```
+4. **Verify startup (in order, no error)**: weight load → (silent in-place convert) → `Available KV cache`
+   (no OOM) → `torch.compile took ...` → `Capturing CUDA graphs ... finished` → `Application startup
+   complete`. Smoke a completion; confirm **0** `shim failed` / `weights not converted` lines.
+5. **Gate**: same-session A/B baseline (Triton, `VLLM_USE_FLYDSL_MOE` unset) vs FlyDSL, BOTH graph, identical
+   `vllm bench serve` (ISL/OSL/conc), plus GSM8K within noise. Quote same-session ratios only.
+
+## Knobs & pitfalls
+- **Pin FlyDSL to ONE checkout — kernels source AND MLIR bindings from the SAME tree.** Mixing them (e.g. a
+  stale exported `FLYDSL_ROOT` from a different/older FlyDSL tree hijacking the bindings while kernels load
+  from your intended tree) fails kernel compile with `Dynamic int_tuple leaf must be an i32 or i64 value, got:
+  <unknown type>` (eager) / `... got: gl$v` (graph). This is a **version mismatch, NOT a torch.compile
+  incompatibility** — do not wrap the MoE as a custom op. Always `export FLYDSL_ROOT=<validated checkout>`
+  and confirm `python3 -c "import flydsl, kernels.moe_gemm_2stage as k; print(flydsl.__file__, k.__file__)"`
+  resolve under the same path before launch.
+- **KV headroom (CORRECTED 2026-06-26)**: in-place convert is memory-neutral ONLY IF both weight and
+  scale params are re-homed (see the Mechanism GOTCHA). Once the scale-duplication leak is fixed, FlyDSL
+  starts and serves at the FULL fair config — `mem 0.9`, NO `--max-model-len` cap (262144) — with
+  **Available KV 20.13 GiB / 307,566 tokens** (vs Triton 23.1 GiB; was 5.96 GiB → OOM before the fix),
+  and beats Triton **+77% e2e at equal config** (257→455 tok/s, cc64; TTFT −45%, TPOT −44%, cosine
+  0.99998). The runtime `repeat_interleave` A2 pre-gather is a SECONDARY cost (~0.23 GiB; removing it via
+  the stage-1 `compile_moe_gemm1` compact-input/sorted-row in-kernel gather is a clean optional follow-up,
+  not what unblocks startup). Capping `--max-model-len 32768` is now only a workaround for the
+  *un-fixed* shim or for squeezing extra concurrency; it is NOT required once scales are re-homed.
+  Residual ~3 GiB vs Triton is convert-time allocator fragmentation (does not block startup); reuse
+  scratch + gemm2 `accumulate=True` (stage-2 out `[M,hidden]` not `[M*top_k,hidden]`) to recover it.
+- **Scales bf16 end-to-end** (`scale_is_bf16=True`, packed `(E,G//2,N,2)`); wrong layout → cosine ≈ 0.48.
+- In-place convert is **destructive to the Triton layout** → no Triton fallback once converted; gate
+  correctness offline + GSM8K and verify **0 fallbacks**.
+- **Offline diag must use TP-sharded per-GPU dims, not full dims.** `flyc.compile` on a flat weight with
+  >2³¹ elements overflows the shape codec → `struct.error: 'i' format`. Live TP4 is fine (inter-dim is
+  sharded so each rank fits); only standalone validators hit this if they build the FULL (unsharded)
+  tensor. Mirror the live per-rank shape (N=moe_intermediate//TP) in any offline numeric/graph-capture check.
+
+## Do-no-harm notes
+- Keep everything env-gated (`VLLM_USE_FLYDSL_MOE=1`); off ⇒ byte-identical stock, so the patched install
+  never regresses other runs. Revert = restore the two files (keep `.flydsl_bak` backups).
+- **Never measure/deploy in eager** — eager hides the speedup behind launch latency and reads as a
+  regression. Graphs are required for the win.
+- Compare against a STOCK baseline at the SAME serving config; do not stack on an already-patched stack.
+
+## Sources
+- Vendored implementation (this dir): `flydsl_moe_shim.py` — the exact validated shim
+  (`convert_layer_inplace` load-time in-place convert + `flydsl_fused_experts_impl` launch-only runtime).
+  This skill is self-contained: the two vLLM edits above + this shim + a FlyDSL checkout are all that's
+  needed; no external eval-dir is required to reproduce.
+- Measured (2026-06-25, vLLM 0.19.0, Kimi-K2.6 int4-W4A16, MI300X TP4): same-session GRAPH A/B,
+  ISL8192/OSL1024/conc64/192prompts — baseline (Triton) **300.51 tok/s** → FlyDSL **398.35 tok/s**
+  (**+32.6%**), decode TPOT 168.6→61.3 ms (2.75x), 0 fallbacks, smoke coherent. Independently reproduced
+  earlier at +32–34% (392 vs 297 tok/s) with GSM8K parity 0.915 and graph-replay cosine 1.0.
+- Sibling kernel-scope skill (produces the rewritten kernel this skill lands): `flydsl_rewrite_quantized_moe`.
+- Companion learned card: `e2e_workflow/knowledge/learned/flydsl-moe-applyback-gfx942.md` +
+  method `e2e_workflow/knowledge/learned/method-cudagraph-safe-integration.md`.

--- a/perf_knowledge/expert_skills/skills/flydsl_rewrite_quantized_moe/skill.md
+++ b/perf_knowledge/expert_skills/skills/flydsl_rewrite_quantized_moe/skill.md
@@ -3,7 +3,7 @@ id: flydsl_rewrite_quantized_moe
 title: Rewrite quantized GEMM / fused-MoE kernels into FlyDSL (Triton->FlyDSL, int4 W4A16 / fp8 blockscale)
 kind: expert_skill
 authors:
-- hongtaom
+- geak
 scope: kernel
 match:
   operator: fused_moe_grouped_gemm
@@ -35,7 +35,7 @@ validation:
     isolated: 3.576
     e2e_pct: ''
     parity: pass
-  artifact: /wekafs/hongtaom/kimi_k01_fused_moe_flydsl
+  artifact: ''   # external validation artifact (machine-specific; not shipped in-repo)
 role: advisory_prior
 supersedes: []
 ---
@@ -132,7 +132,7 @@ correctness is judged identically.
   `${FLYDSL_EXAMPLES}/fp8_blockscale_moe/`; deep dive in sibling skill `rewrite-co-kernel-to-flydsl`.
 - Related GEAK skill: `flydsl_fp8_gemm_playbook` (e2e down-proj bare-core bind) — this skill is its
   kernel-scope, broader-operator counterpart.
-- Validation eval dir (artifact): `/wekafs/hongtaom/kimi_k01_fused_moe_flydsl/` — K1 `fused_moe_kernel_gptq_awq`
+- Validation eval dir (artifact): an external, machine-specific eval dir (not shipped in-repo) — K1 `fused_moe_kernel_gptq_awq`
   (int4 W4A16, Kimi-K2.6, MI300X gfx942). Deployment-env same-session A/B: **geomean 3.62×** (5 UT cases),
   5.15× prefill, 5/5 correctness PASS (cosine ≈ 0.999994) — `result_flydsl.json`, `DELIVERY_FLYDSL.md`,
   rocprof roofline (FlyDSL 60–65% HBM vs Triton 13–18%) in `roofline_hw/`.


### PR DESCRIPTION
## Description
- **Fix**: FlyDSL was silently dropped in preflight — on images where `aiter` has no `ops.flydsl` wrapper and the top-level `flydsl` package isn't installed, the highest-ROI lever for int4/A4W4 quantized MoE (FlyDSL apply-back) never took effect.
- **Fix**: Two environment issues that made the FlyDSL source build fail on these ROCm images (hip cmake version mismatch, missing `patchelf`) — previously every source build failed to produce FlyDSL.
- **Feature**: A version-gated FlyDSL bootstrap (the pin is treated as a *minimum version*, not an exact commit), which also guarantees GEAK does **not** overwrite a newer FlyDSL already present in another workload's environment (portability).
- **Feature**: expert skill + companion learned knowledge for the int4-MoE FlyDSL apply-back / rewrite.

## Changes
- **Add** `e2e_workflow/scripts/ensure_flydsl.sh` (213 lines):
  - Three-tier version gating (`decide_use`): `__version__` > floor → reuse; == floor with checkout HEAD ≥ pin (git ancestry) → reuse; otherwise (older / missing `kernels.moe_gemm_2stage` / not installed) → clone + build the pin.
  - Builds only into **container-internal `/opt/flydsl`** (not a bind-mounted host dir), guarded by an `flock` so concurrent Setup retries can't corrupt one shared tree;
  - hip cmake compat symlink (cmake references `libamdhip64.so.7.2.70201` but the runtime is `7.2.53211`); auto-installs `patchelf` when missing (needed by build.sh's `CopyFlyPythonSources`).
- **Modify** `e2e_workflow/knowledge/preflight.md`: two-signal FlyDSL detection (`aiter.ops.flydsl` OR `import flydsl, kernels.moe_gemm_2stage`) + mandatory self-install (calls ensure_flydsl.sh) + container-internal `/opt/flydsl` paths.
- **Add/Modify** expert skills: `apply_flydsl_moe_to_vllm` (new `flydsl_moe_shim.py` + `skill.md`), `flydsl_rewrite_quantized_moe/skill.md`, `expert_skills/index.yaml`.
- **Modify** learned knowledge: `flydsl-moe-applyback-gfx942.md`, `flydsl-moe-gemm2-tiletune-gfx942.md`, `method-cudagraph-safe-integration.md`, `moe-int4-w4a16-tune-gfx942.md`, `paged-attn-nonpow2-gfx942.md`, `INDEX.md`.
- **Modify** `e2e_workflow/scripts/bench_e2e.sh` (minor).

## Impact
- Affects the **int4-W4A16 fused-MoE grouped-GEMM** optimization direction: FlyDSL apply-back becomes a high-priority candidate (matches on gfx942 + vLLM + that op ≥10% GPU time in the profile).
- Affects **backend selection**: FlyDSL now correctly enters `available_backends` (two-signal detection) instead of being wrongly marked unavailable when `import flydsl` fails.
- Applicability is decided by the skill's `match` (`arch_class:'*'` + gfx942 + int4_w4a16 + operator + profile signature) — **model-agnostic**; no effect on environments that don't meet the criteria.
- **Portability**: isolated build + version gating ensure GEAK makes no changes to, and never overwrites, an existing FlyDSL on other environments/workloads.

## Testing
- **Gating-logic test (the new logic in this PR)**: verified the three tiers in an isolated container on GPU 0-3 — not-installed / missing-kernels / same-version-with-commit≥pin all take the correct branch (no false trigger, no real rebuild kicked off); `ver_cmp` unit-checked over six cases (higher/equal/lower).
- **Source-build re-test**: full from-scratch build runs end to end (LLVM/MLIR + FlyDSL `build.sh` + `import flydsl, kernels.moe_gemm_2stage`), confirming the hip/patchelf fixes work.
- **e2e test (apply-back effect)**:
  - Historical validation (recorded in the learned cards): Kimi-K2.6 int4-W4A16 / gfx942 / vLLM, FlyDSL apply-back +63–77% e2e (4 Director-verified confirms, parity cosine 0.99998 / GSM8K pass).
  - Current Kimi-K2.6 TP4 run (GPU4-7, ISL8192/OSL1024/conc64): h0 MoE kernel isolated 2.34× Director-verified (correctness pass).
- **General CI / per-PR small test set**: GEAK's general CI was not run in this change; 