### PR TITLE
  [GEAK v4] e2e report: reconcile headline with Director + backend-provenance timeline

### DIFF
--- a/e2e_workflow/docs/pr-report-director-reconcile.md
+++ b/e2e_workflow/docs/pr-report-director-reconcile.md
@@ -1,0 +1,71 @@
+# Report ↔ Director reconcile + backend-provenance timeline
+
+## Problem
+
+The headline numbers in `final_report.md` / `architect_report.md` did NOT match the authoritative
+`director_e2e_validation.json`. Concretely (gpt-oss-120b): the report quoted throughput `640.4 → 709.0`
+while the Director's same-session A/B was `621.365 → 698.373`. The affected fields are all of the
+headline metrics: **throughput, speedup, TTFT, TPOT** (and status/parity).
+
+Root cause is a **phase-ordering gap**, not a measurement bug:
+
+1. The orchestrator runs `Report` (System Architect) BEFORE `Validate` (Director) —
+   `Finalize → Report → Validate`.
+2. `system_architect.md` already mandates that the headline quote the Director's same-session numbers
+   (`director_e2e_validation.json` + `validation/{base,final}/bench_summary.json`). But at `report` time
+   the Director has not run yet, so those files do not exist — the Architect silently falls back to the
+   **Finalize-bundle** bench (`final/bench_final` / `final/bench_baseline_ab`). The two benches differ
+   (different session/drift), so the report and the Director disagree.
+
+Separately, the `final_report.md` timeline did not consistently record **which backend each hot kernel
+originally ran on**, nor **which backend每 optimization attempt tried** — so a reader could not see the
+backend bake-off ladder (what was tried, what won, what was skipped and why).
+
+## Fix (all generic — no model/kernel/backend hardcode)
+
+**1. Director reconciles the report after validation (keeps the existing phase order).** The `validate`
+agent now receives the two already-written report paths (`ARCHITECT_REPORT`, `FINAL_REPORT`). New
+**step 7** in `director.md`: after writing `director_e2e_validation.json`, the Director reviews both
+reports and **overwrites only the headline metrics** — throughput (median+spread), speedup (`×` and `%`),
+TTFT, TPOT, validation_status, output_parity — with its authoritative same-session numbers (sources =
+`director_e2e_validation.json` + `validation/{base,final}/bench_summary.json`). Every other line/table/tree
+is preserved. If validation produced no usable number (server crash / degenerate), it does NOT rewrite —
+the Finalize fallback stays and is annotated. A closing self-check asserts the report headline equals
+`director_e2e_validation.json`.
+
+**2. Architect writes the headline as provisional.** `system_architect.md` now states that at `report`
+time the Director file does not exist yet, so the headline throughput/speedup/TTFT/TPOT are written from
+the Finalize bench and tagged `(provisional — pending Director validation)` on clearly-identifiable lines;
+the Director drops the tag when it reconciles. This removes the contradiction where the role said "quote
+the Director" for a file that was not there.
+
+**3. Backend-provenance in the timeline (headline requirement).** The `final_report.md` Phases tree now
+MUST, for every head op, name the op's **original/stock backend + dtype** (from the baseline profile Top-N
++ `meta.json`), and show **one sub-node per backend attempted** (each Tier-A bake-off candidate and each
+Tier-C author language; in deep mode one per `(op × backend)` lane) with its best isolated `×` and the e2e
+verdict. Backends **considered but not run** appear marked `⊘` with a one-word reason (`⊘ CK — ckProfiler
+absent`, `⊘ flydsl — seam mismatch`, …) — never silently dropped. The head-kernel deep-dive is aligned: an
+explicit **Backend ladder** line + a **backend column** in the Directions table.
+
+## Files
+- `e2e_workflow.js` — `Validate` agent gets `ARCHITECT_REPORT` + `FINAL_REPORT`; task string asks it to
+  reconcile the report. No phase reorder (order stays `Finalize → Report → Validate`).
+- `roles/director.md` — `validate` **step 7** (reconcile the report headline to the Director numbers) +
+  the two report paths added to Inputs.
+- `roles/system_architect.md` — headline written provisionally from the Finalize bench (tagged), reconciled
+  by the Director; timeline now requires stock-backend per op + one node per attempted/skipped backend; the
+  deep-dive gains a Backend-ladder line and a backend column in the Directions table.
+- Add `e2e_workflow/docs/pr-report-director-reconcile.md`.
+
+## Behavior when off / neutral
+No new runtime knobs. When the Director produces a usable number (the normal case) the report headline is
+made identical to `director_e2e_validation.json`; when it does not, the report is left on the Finalize
+fallback and annotated (previous behavior, now explicit). The backend-provenance changes are report-content
+only — they do not alter measurement, gating, or the overlay contract.
+
+## Validation
+- Root cause reproduced on a real run dir: report `640.4 → 709.0` vs `director_e2e_validation.json`
+  `621.365 → 698.373` (finalize-vs-director divergence).
+- `node --check` on `e2e_workflow.js` passes when wrapped (the file has a top-level `return` for the
+  single-kernel pass-through, so it must be checked inside a function wrapper; no standalone `node` parse).
+- The only JS change is two added keys in the `validate` agent's input object; delimiter balance preserved.

--- a/e2e_workflow/docs/pr-report-director-reconcile.md
+++ b/e2e_workflow/docs/pr-report-director-reconcile.md
@@ -47,6 +47,16 @@ verdict. Backends **considered but not run** appear marked `⊘` with a one-word
 absent`, `⊘ flydsl — seam mismatch`, …) — never silently dropped. The head-kernel deep-dive is aligned: an
 explicit **Backend ladder** line + a **backend column** in the Directions table.
 
+**4. Clearer validation vocabulary + honest emoji (report readability).** `validation_status = accepted`
+was misleading — on a no-win run (empty overlay, `0.9997×`) "accepted" read like a success. The Director
+verdict is now **three self-explaining values**: `validated_win` (real e2e-gated win over the noise band),
+`validated_no_win` (measurement trustworthy, final ≈ baseline — no regression, no win), `flagged`
+(regression / parity fail / claim mismatch / crash). The word `accepted` is no longer used for this field
+(no code branches on the literal, so this is safe). Separately, the timeline emoji must reflect the actual
+gate: a **rejected/regressed** integrate node (e.g. `A/B 1768.5 → 1536.7 = ✘−13.1%`) must use `❌`, never
+`⭐` — a slowdown never gets a star; `parity ✓` marks numeric parity only and never upgrades a `✘` delta;
+`⭐` is reserved for a candidate actually banked into the final stack.
+
 ## Files
 - `e2e_workflow.js` — `Validate` agent gets `ARCHITECT_REPORT` + `FINAL_REPORT`; task string asks it to
   reconcile the report. No phase reorder (order stays `Finalize → Report → Validate`).
@@ -54,7 +64,10 @@ explicit **Backend ladder** line + a **backend column** in the Directions table.
   the two report paths added to Inputs.
 - `roles/system_architect.md` — headline written provisionally from the Finalize bench (tagged), reconciled
   by the Director; timeline now requires stock-backend per op + one node per attempted/skipped backend; the
-  deep-dive gains a Backend-ladder line and a backend column in the Directions table.
+  deep-dive gains a Backend-ladder line and a backend column in the Directions table; emoji rule tightened
+  (rejected/regressed → `❌`, `⭐` only for a banked win) and the Validate node prints the status word.
+- `roles/director.md` — validate arbitration emits `validated_win|validated_no_win|flagged` (no more
+  `accepted`); step 7 reconciles the report status/conclusion to match honestly.
 - Add `e2e_workflow/docs/pr-report-director-reconcile.md`.
 
 ## Behavior when off / neutral

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -2023,11 +2023,17 @@ if (want('final')) {
 
   phase('Validate');
   validation = await safeAgent(
-    roleAgent('director', 'validate', 'Independently re-measure throughput + parity; arbitrate.', {
+    roleAgent('director', 'validate', 'Independently re-measure throughput + parity; arbitrate; then reconcile the report with the validated numbers.', {
       EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], BASELINE_THROUGHPUT: BASELINE_TPUT, NOISE_BAND_PCT: NOISE_BAND,
       FINAL_OVERLAY: (finalize && finalize.final_overlay) || curOverlay,
       FINAL_FLAGS: { flags: curFlags, env: curEnv },
       CLAIMED_THROUGHPUT: finalTput, WORKLOAD, APPLY_TO_ORIGINAL, E2E_REPEATS, SKILL_DIR: WORKFLOW_DIR,
+      // The Report phase already wrote these files with the Finalize-bundle bench (the Director had not
+      // run yet). After validation the Director MUST review + rewrite their headline throughput / speedup
+      // / TTFT / TPOT (and status/parity) to its authoritative same-session numbers, so report-vs-director
+      // can never disagree. Paths default to the standard EVAL_DIR names if the report result is absent.
+      ARCHITECT_REPORT: (report && report.report_path) || `${EVAL_DIR}/architect_report.md`,
+      FINAL_REPORT: `${EVAL_DIR}/final_report.md`,
     }),
     { phase: 'Validate', label: 'director:validate', schema: VALIDATE_SCHEMA });
   // A Validate that did NOT produce a usable number (e.g. its server crashed in

--- a/e2e_workflow/roles/director.md
+++ b/e2e_workflow/roles/director.md
@@ -160,12 +160,19 @@ TRUE baseline with the tight 2-block protocol and decide if the COMBINED result 
    vs the provided baseline for reference. The COMBINED stack counts as a real win only if
    `delta% > NOISE_BAND_PCT` AND non-overlapping; otherwise report it honestly as within-noise (the
    stacked kernels are real isolated speedups whose combined e2e effect is below the band).
-4. Arbitrate vs the claim:
-   - Final speedup within `NOISE_BAND_PCT` of claim, or Director higher → `accepted`.
-   - Director lower than claim by more than the noise band → `flagged` (use Director's measured
-     number as official).
-   - Parity fail / server fails to launch with overlay → `flagged`.
-5. Only if `APPLY_TO_ORIGINAL=true` AND `accepted`: write a clear "apply" bundle — the final overlay
+4. Arbitrate — set `validation_status` to one of THREE values. The status describes whether your
+   independent measurement is TRUSTWORTHY and whether it is a WIN; it does NOT mean "an optimization was
+   accepted" (a no-win run with an empty overlay is still a successful, trustworthy validation). Do NOT use
+   the word `accepted` for this field.
+   - **`validated_win`** — the final stack is a real, reproduced win: `delta% > NOISE_BAND_PCT` AND
+     non-overlapping ranges AND parity ok, and your number is within the noise band of the claim (or higher).
+   - **`validated_no_win`** — your measurement is trustworthy and shows **no regression and no win**: final
+     ≈ baseline within `NOISE_BAND_PCT` (overlapping ranges). This is the correct status for an empty overlay
+     / no-accepted-kernel run — the run is validated, it simply did not improve throughput.
+   - **`flagged`** — needs attention: a real regression (Director lower than baseline beyond the band), OR
+     Director lower than the claim by more than the band, OR parity fail, OR the server fails to launch with
+     the overlay. Use the Director's measured number as official and say what to re-task.
+5. Only if `APPLY_TO_ORIGINAL=true` AND status is `validated_win`: write a clear "apply" bundle — the final overlay
    dir + a `final_launch.sh` that sets `PYTHONPATH`/flags — into `EVAL_DIR/final/`. **Do not edit
    site-packages even here**; the deliverable is the overlay + launch script (per spec: "complete
    patch + launch/benchmark script"). Assemble `EVAL_DIR/final/final_patch.diff` (concatenated kernel patches)
@@ -184,6 +191,10 @@ TRUE baseline with the tight 2-block protocol and decide if the COMBINED result 
    - Edit ONLY those numbers; preserve every other line, table, and the phase/artifacts trees. Keep the
      already-correct convention that the Director value is OFFICIAL and, if the finalize bench differed,
      leave a one-line parenthetical noting the finalize number.
+   - Make the headline **read the outcome honestly**: use `validated_win` / `validated_no_win` / `flagged`
+     (never the bare word `accepted`), and word the conclusion so a `validated_no_win` (e.g. `0.9997×`) is
+     plainly "no win — validated, no regression", NOT a success. The `Validate` node in the phase tree must
+     show the same status.
    - If validation produced **no usable number** (server crashed / degenerate), do NOT rewrite — leave the
      finalize fallback in place and add one line stating validation produced no number.
    - Confirm consistency: after the edit, the report's headline throughput/speedup/TTFT/TPOT MUST equal
@@ -197,11 +208,11 @@ Return JSON:
   "director_verified_throughput_tok_s": 0.0,
   "throughput_speedup": 1.0,
   "claimed_throughput_tok_s": 0.0,
-  "validation_status": "accepted|flagged",
+  "validation_status": "validated_win|validated_no_win|flagged",
   "output_parity": "pass|fail|n/a",
   "applied_to_original": "true|false",
   "final_overlay": "<EVAL_DIR>/final",
   "final_launch_script": "<EVAL_DIR>/final/final_launch.sh",
-  "arbitration_note": "accept reason or what to re-task if flagged"
+  "arbitration_note": "win/no-win/flag reason: state the measured delta%, whether it cleared the noise band, and (if flagged) what to re-task"
 }
 ```

--- a/e2e_workflow/roles/director.md
+++ b/e2e_workflow/roles/director.md
@@ -122,7 +122,8 @@ Return JSON:
 
 Inputs: `EVAL_DIR`, `MODEL_PATH`, `SKILL_DIR`, `GPU_ID`, `BASELINE_THROUGHPUT`, `NOISE_BAND_PCT`,
 `E2E_REPEATS` (default 7), the candidate final overlay `FINAL_OVERLAY` (dir) + `FINAL_FLAGS` (json),
-the Architect/Integrator's claimed throughput, and `APPLY_TO_ORIGINAL`.
+the Architect/Integrator's claimed throughput, `APPLY_TO_ORIGINAL`, and the already-written report files
+`ARCHITECT_REPORT` (`architect_report.md`) + `FINAL_REPORT` (`final_report.md`) to reconcile in step 7.
 
 **Do NOT trust the claimed throughput — reproduce it from a clean warm server with the overlay.**
 
@@ -170,6 +171,23 @@ TRUE baseline with the tight 2-block protocol and decide if the COMBINED result 
    patch + launch/benchmark script"). Assemble `EVAL_DIR/final/final_patch.diff` (concatenated kernel patches)
    for the record.
 6. Write `EVAL_DIR/director_e2e_validation.json` with the full result.
+7. **Reconcile the report with your validated numbers (do this LAST, after 1–6).** The Architect's
+   `report` phase runs BEFORE this `validate` phase, so `ARCHITECT_REPORT` (`architect_report.md`) and
+   `FINAL_REPORT` (`final_report.md`) were already written using the **Finalize-bundle** bench — those
+   headline numbers can differ from your authoritative same-session A/B (the reported issue: e.g. report
+   says `640.4 → 709.0` while your Director A/B is `621.365 → 698.373`). Fix it:
+   - Read both report files. Wherever a headline metric was taken from the finalize bench, **overwrite it
+     with your Director same-session number**: **throughput** (baseline→final median + spread),
+     **speedup** (`×` and `%`), **TTFT**, **TPOT**, plus **validation_status** and **output_parity**.
+     Sources = `EVAL_DIR/director_e2e_validation.json` + `EVAL_DIR/validation/base/bench_summary.json` +
+     `EVAL_DIR/validation/final/bench_summary.json` (the exact files you just measured — never invent).
+   - Edit ONLY those numbers; preserve every other line, table, and the phase/artifacts trees. Keep the
+     already-correct convention that the Director value is OFFICIAL and, if the finalize bench differed,
+     leave a one-line parenthetical noting the finalize number.
+   - If validation produced **no usable number** (server crashed / degenerate), do NOT rewrite — leave the
+     finalize fallback in place and add one line stating validation produced no number.
+   - Confirm consistency: after the edit, the report's headline throughput/speedup/TTFT/TPOT MUST equal
+     `director_e2e_validation.json`.
 
 Return JSON:
 ```json

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -234,22 +234,30 @@ Write TWO files:
 > polished template — match its structure, tables, emoji, and the timed/aligned phase tree exactly so
 > every run's report looks the same. The OFFICIAL headline number is ALWAYS the Director's same-session
 > validation (`EVAL_DIR/director_e2e_validation.json` → `director_verified_throughput_tok_s` /
-> `throughput_speedup`), NOT the Finalize-bundle sanity bench — if they differ, quote the Director value
-> and note the finalize bench in parentheses. Read REAL files for every number; never invent.
+> `throughput_speedup`), NOT the Finalize-bundle sanity bench. Read REAL files for every number; never invent.
+>
+> **Ordering note:** your `report` phase runs BEFORE the Director's `validate` phase, so
+> `director_e2e_validation.json` does NOT exist yet. Write the headline throughput / speedup / TTFT / TPOT
+> from `FINAL_THROUGHPUT` + `EVAL_DIR/final/bench_final/bench_summary.json` (the Finalize bench) as a
+> **provisional** headline, and mark it e.g. `(provisional — pending Director validation)`. The Director,
+> in the subsequent `validate` phase, will **overwrite** those exact headline numbers with its authoritative
+> same-session A/B and drop the provisional tag. Everything else you write is final; only the headline
+> metrics are provisional. Keep them on clearly-identifiable lines so the Director can reconcile them.
 
-**(a) `EVAL_DIR/architect_report.md`** — the concise English summary. Its **Headline MUST quote the
-OFFICIAL Director-validated result** (`director_verified_throughput_tok_s`, `throughput_speedup`,
-`output_parity`); if the Finalize bundle bench read higher, add one line stating the conservative Director
-number is official. Then list the accepted stack (config + each kernel with its per-item e2e %), and the
+**(a) `EVAL_DIR/architect_report.md`** — the concise English summary. Its **Headline** carries throughput
+/ speedup / `output_parity` written **provisionally** from the Finalize bench (tag it `(provisional —
+pending Director validation)`); the Director's `validate` phase overwrites these with the OFFICIAL
+same-session numbers. Then list the accepted stack (config + each kernel with its per-item e2e %), and the
 remaining headroom. Keep it short.
 
 **(b) `EVAL_DIR/final_report.md`** — the COMPLETE timeline report (the headline deliverable). Keep EVERY
 attempt, win or not. REQUIRED sections, in order:
 
 1. **Run overview** — model/architecture, serving stack, workload (ISL/OSL/conc), GPU + serving invariant,
-   date, and a one-line **final conclusion that quotes the OFFICIAL Director number** (e.g.
-   `1581.4 → 2058.8 tok/s, 1.300× (+30.0%), parity pass`). If the finalize-bundle bench was higher, add a
-   parenthetical that the conservative Director value is official.
+   date, and a one-line **final conclusion** with the headline throughput/speedup (e.g.
+   `1581.4 → 2058.8 tok/s, 1.300× (+30.0%), parity pass`), written **provisionally** from the Finalize
+   bench and tagged `(provisional — pending Director validation)`. The Director overwrites this line with
+   its OFFICIAL same-session number in the `validate` phase.
 
 2. **Phases tree + timeline (wall-clock)** — MANDATORY, one timed fenced tree (NOT a plain tree). Rules:
    - Derive each phase's wall-clock from artifact mtimes (`t0` = eval-dir / `model_path.txt` mtime; phase
@@ -266,19 +274,36 @@ attempt, win or not. REQUIRED sections, in order:
    - One node per phase that actually ran (Setup→Validate). Under **HeadKernel**, show each head op (h0/h1…)
      as a child, and under each op its sub-steps (extract / bake-off+tune / each author language / integrate),
      each with its own `[ Δ ]`.
+   - **Backend provenance is MANDATORY in the tree** (this is a headline requirement — do not omit it):
+     - Each head-op child node MUST name the op's **ORIGINAL/stock backend + dtype** exactly as the live
+       server ran it (from the baseline profile Top-N `backend`/`class` + `meta.json` dtype/quant), e.g.
+       `h0 GEMM (mxfp4, stock=triton matmul_ogs)`. This is "what the kernel was before we touched it".
+     - Under each op, show **one sub-node per backend that was ATTEMPTED**, naming the backend and its
+       outcome — every Tier-A bake-off candidate AND every Tier-C author language. In **deep mode** this is
+       one sub-node per `(op × backend)` lane (`triton-fused/-splitk/-opt/-deep`, `flydsl`, `hip`, `ck`, …),
+       each with its best isolated `×` and the e2e verdict (`✓`/`✘`/`⊘`).
+     - Backends **considered but not run** MUST still appear, marked **`⊘`** with the one-word reason
+       (`⊘ CK — ckProfiler absent`, `⊘ hipBLASLt — no offline tune`, `⊘ flydsl — seam mismatch`,
+       `⊘ aiter — no mxfp4-grouped path`), so the timeline shows the FULL backend ladder that was weighed,
+       not just the one that ran. Never silently drop a backend.
    - Below the fence: a blockquote with **`🏁 TOTAL ≈ <wall-clock>`**, a **`🔥 top costs`** line, and any
      **`⚠️`** caveats; then a **Legend** line and a one-line **Final stack + official speedup**.
-   - Reference shape (reproduce emoji + alignment):
+   - Reference shape (reproduce emoji + alignment; note the stock backend on each op and one line per
+     attempted/skipped backend):
      ```
-     Phases                                                   [  step · cum  ]
-     ✅ 1  Setup        preflight + TRUE baseline <tok/s>      [ Δ17m  · 0:17 ]
-     ✅ 3  ConfigSweep  cfg0 ✘−X% · ⭐ aiter +Y% · cuda-graph ✓ [ Δ45m  · 1:49 ]
-     🔧 5  HeadKernel   extract+bake-off+author+integrate      [ Δ5h41m· 8:13 ]
-        ❌ h0 GEMM   <pct>%GPU — already optimal               [ Δ2h03m       ]
-           └ ✘ Triton  0.60× (prefill ✓ / decode ✘)           [ Δ1h24m       ]
-        ⭐ h1 attn    <pct>%GPU — ACCEPTED +Z%                 [ Δ3h39m       ]
-           └ ⭐ integrate  A/B <ref>→<cand> = +Z% · parity ✓   [ Δ27m         ]
-     🏁 9  Validate    Director A/B <base>→<final> = +W% (<x>×) [ Δ37m  · 9:43 ]
+     Phases                                                     [  step · cum  ]
+     ✅ 1  Setup        preflight + TRUE baseline <tok/s>        [ Δ17m  · 0:17 ]
+     ✅ 3  ConfigSweep  cfg0 ✘−X% · ⭐ aiter +Y% · cuda-graph ✓   [ Δ45m  · 1:49 ]
+     🔧 5  HeadKernel   extract+bake-off+author+integrate        [ Δ5h41m· 8:13 ]
+        ❌ h0 GEMM  <pct>%GPU · stock=triton matmul_ogs (mxfp4)  [ Δ2h03m       ]
+           ├ ✘ triton-opt     tile tune  1.12× iso · e2e ✘−0.4% [ Δ38m         ]
+           ├ ✘ triton-splitk  split-K    1.64× iso · e2e ✘−13%  [ Δ41m         ]
+           ├ ⊘ flydsl         author     seam mismatch (skipped)[ Δ0m          ]
+           └ ⊘ CK/hipBLASLt   bake-off   ckProfiler/bench absent[ Δ0m          ]
+        ⭐ h1 attn   <pct>%GPU · stock=CK unified_attn (bf16)    [ Δ3h39m       ]
+           ├ ⭐ aiter          backend    1.31× iso · e2e ✓+Z%   [ Δ12m         ]
+           └ ⭐ integrate      A/B <ref>→<cand> = +Z% · parity ✓ [ Δ27m         ]
+     🏁 9  Validate    Director A/B <base>→<final> = +W% (<x>×)   [ Δ37m  · 9:43 ]
      ```
 
 3. **Head-kernel deep-dive** (the centerpiece) — for EACH head op a `####` sub-section titled
@@ -286,11 +311,18 @@ attempt, win or not. REQUIRED sections, in order:
    - **GPU-time-share table**: rows `stock baseline` vs `accepted config`; columns `live kernel | backend |
      %GPU | calls` — shows how the accepted config (e.g. aiter) already re-routed the op and its %GPU on the
      final stack (stock from `profile/round_0`, accepted-stack from `profile/round_config`).
-   - **Original backend** line: dtype/quant, transpose/bias, and the live kernel on stock vs accepted.
+   - **Original backend** line: the op's stock/original backend + dtype/quant + transpose/bias, and the
+     live kernel name on stock vs accepted (stock backend/class from the baseline profile Top-N; dtype/quant
+     from `meta.json`). State it plainly, e.g. `stock: triton matmul_ogs (mxfp4 grouped MoE, NNT, bias=0)`.
    - **Weight-shape table** (GEMM: the distinct (N,K) served + the M-buckets).
-   - **Directions table** — one row per direction tried: `# | direction (cost tier) | what it did | result`.
+   - **Backend ladder** line — the FULL set of backends weighed for this op and each one's disposition:
+     `tried` (ran a lane), `⊘ unavailable` (+ reason: tool absent / arch-unavailable), or `⊘ dropped`
+     (+ reason: seam mismatch / wrong op). Mirrors the timeline's per-backend sub-nodes so the two agree.
+   - **Directions table** — one row per direction tried, WITH a backend column:
+     `# | backend | direction (cost tier) | what it did | isolated× | e2e Δ% | result`.
      Cover Tier-A backend bake-off, Tier-B per-shape tune, and Tier-C author **per language** — EVERY
-     direction incl. any that died on an infra/API error (say so explicitly; don't omit it).
+     direction incl. any that died on an infra/API error (say so explicitly; don't omit it), and one row
+     per `⊘` backend that was skipped (backend = its name, result = the skip reason).
    - For a **rejected authored kernel**: a **per-(N,K) × M speedup table** vs the baseline (from the recursive
      run's `director_validation.json` `per_case`) to expose the prefill-win/decode-loss split; end with geomean
      + the reject decision + root cause.
@@ -319,9 +351,12 @@ attempt, win or not. REQUIRED sections, in order:
 
 7. **Final deliverable + measurement caveats** (box drift → trust ONLY same-session A/B; the official number
    is the Director's same-session value) **+ next directions to explore.** Quote the FINAL serving numbers
-   from `EVAL_DIR/validation/final/bench_summary.json` — throughput (median + spread), **TTFT and TPOT** —
-   next to the baseline numbers, so the report shows the full E2E throughput / TTFT / TPOT delta (not just
-   throughput).
+   — throughput (median + spread), **TTFT and TPOT** — next to the baseline numbers, so the report shows the
+   full E2E throughput / TTFT / TPOT delta (not just throughput). At `report` time these come
+   **provisionally** from the Finalize bench (`EVAL_DIR/final/bench_final/bench_summary.json`, baseline
+   `EVAL_DIR/final/bench_baseline_ab/bench_summary.json`); tag them provisional. The Director's `validate`
+   phase reconciles this section to `EVAL_DIR/validation/{base,final}/bench_summary.json` (its authoritative
+   same-session TTFT/TPOT/throughput).
 
 Data sources (read the ACTUAL files, never invent): `director_e2e_validation.json`,
 `final/bench/bench_summary.json`, `config/sweep_results.json`, `overlay/cand_*/integrate_result.json`,

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -254,20 +254,31 @@ remaining headroom. Keep it short.
 attempt, win or not. REQUIRED sections, in order:
 
 1. **Run overview** — model/architecture, serving stack, workload (ISL/OSL/conc), GPU + serving invariant,
-   date, and a one-line **final conclusion** with the headline throughput/speedup (e.g.
-   `1581.4 → 2058.8 tok/s, 1.300× (+30.0%), parity pass`), written **provisionally** from the Finalize
-   bench and tagged `(provisional — pending Director validation)`. The Director overwrites this line with
-   its OFFICIAL same-session number in the `validate` phase.
+   date, and a one-line **final conclusion** with the headline throughput/speedup + the Director status word
+   (`validated_win` / `validated_no_win` / `flagged`), e.g. a win →
+   `1581.4 → 2058.8 tok/s, 1.300× (+30.0%), parity pass — validated_win`; a no-win →
+   `1790.8 → 1790.3 tok/s, 0.9997× (−0.03%) — validated_no_win (no regression, no win)`. Never phrase a
+   `validated_no_win` as a success and never use the bare word "accepted". Written **provisionally** from the
+   Finalize bench and tagged `(provisional — pending Director validation)`; the Director overwrites this line
+   with its OFFICIAL same-session number + final status in the `validate` phase.
 
 2. **Phases tree + timeline (wall-clock)** — MANDATORY, one timed fenced tree (NOT a plain tree). Rules:
    - Derive each phase's wall-clock from artifact mtimes (`t0` = eval-dir / `model_path.txt` mtime; phase
      boundaries from the relevant `*.log` / `*_summary.json` / `_exp/*` dir mtimes).
    - Every phase node ends with **`[ Δ<step> · <cum> ]`** (step duration + cumulative elapsed since t0);
      sub-step nodes show **`[ Δ<step> ]`** only, padded to the SAME closing column.
-   - **Color = emoji** (the only thing that renders colored inside a code fence): `✅` done/accepted ·
-     `❌` rejected/no-win · `⭐` entered the final stack (a real win) · `🔧` a work phase · `🏁` the
-     official validation/total · `⚠️` a caveat. Inside descriptions use the NARROW marks **`✓` / `✘`**
-     (width-1), never `✅/❌`, so the time column stays aligned.
+   - **Color = emoji** (the only thing that renders colored inside a code fence): `✅` phase done ·
+     `❌` rejected / no-win · `⭐` entered the final stack (a real, e2e-gated win) · `🔧` a work phase ·
+     `🏁` the official validation/total · `⚠️` a caveat. Inside descriptions use the NARROW marks
+     **`✓` / `✘`** (width-1), never `✅/❌`, so the time column stays aligned.
+   - **The emoji MUST reflect the node's actual gate/outcome — do not decorate.** `⭐` is ONLY for a
+     candidate that was ACCEPTED into the final stack (integrate `gate=accepted|stack`, a positive e2e
+     delta that cleared the noise band). A candidate whose A/B **regressed or was rejected** (e.g.
+     `integrate … ✘−13.1%`, `gate=rejected`) MUST use **`❌`**, never `⭐` — a slowdown never gets a star.
+     `parity ✓` marks NUMERIC output parity only; it is NOT a throughput result and never upgrades a `✘`
+     delta. The **Validate** node shows the Director status verbatim — `🏁 …= <x>× · validated_win` /
+     `❌ …= <x>× · flagged` / and for a no-improvement run **`✅ …= <x>× · validated_no_win`** (validated,
+     no regression, NO win — never write "accepted" and never imply a gain).
    - **Align the time column**: pad each line by VISUAL width — count emoji (`✅❌⭐🔧🏁🔥⚠`) as 2 cells and
      `├└│✓✘→·×–` as 1 — so every `[` starts at the same column (a tiny Python padder is fine). Keep lines
      **≤ ~96 cols**; push long detail to the per-op deep-dive below, not into the tree.
@@ -302,9 +313,13 @@ attempt, win or not. REQUIRED sections, in order:
            └ ⊘ CK/hipBLASLt   bake-off   ckProfiler/bench absent[ Δ0m          ]
         ⭐ h1 attn   <pct>%GPU · stock=CK unified_attn (bf16)    [ Δ3h39m       ]
            ├ ⭐ aiter          backend    1.31× iso · e2e ✓+Z%   [ Δ12m         ]
-           └ ⭐ integrate      A/B <ref>→<cand> = +Z% · parity ✓ [ Δ27m         ]
-     🏁 9  Validate    Director A/B <base>→<final> = +W% (<x>×)   [ Δ37m  · 9:43 ]
+           └ ⭐ integrate      A/B <ref>→<cand> = ✓+Z% · parity ✓[ Δ27m         ]
+     🏁 9  Validate    Director A/B <base>→<final> = +W% (<x>×) · validated_win [ Δ37m · 9:43 ]
      ```
+     A **rejected** integrate node uses `❌`, never `⭐` (a slowdown never gets a star), e.g.
+     `❌ integrate  A/B 1768.5 → 1536.7 = ✘−13.1% · parity ✓` — parity ✓ is numeric-only, the throughput
+     still ✘. A **no-win** run closes with `✅ Validate  Director A/B <b>→<f> = 0.9997× · validated_no_win`
+     (validated, no regression, NO win). Only `validated_win` earns a `🏁`+`⭐` final stack.
 
 3. **Head-kernel deep-dive** (the centerpiece) — for EACH head op a `####` sub-section titled
    `<id> — <op> (<pct>% GPU) — RESULT: <ACCEPTED +X% | no win | flagged>`, containing:


### PR DESCRIPTION
 ## Description
  - **Fix:** `final_report.md` / `architect_report.md` quoted the **Finalize-bundle** bench, not the authoritative `director_e2e_validation.json`, so report and Director disagreed on **throughput / speedup / TTFT / TPOT** (e.g. report `640.4 → 709.0` vs Director `621.365 → 698.373`). Generic (no model/kernel/backend hardcode).
  - **Root cause:** phase ordering — `Report` runs BEFORE `Validate`, but `system_architect.md` already mandates quoting the Director's same-session numbers, which don't exist yet at report time → Architect falls back to the finalize bench.
  - **Also:** the `accepted` verdict misled on no-win runs (`0.9997×` read as success), and a rejected/regressed integrate node was drawn with the win star `⭐`.
- https://github.com/AMD-AGI/GEAK/issues/340

  ## Changes
  - `e2e_workflow.js` — Director `validate` agent now gets the report paths (`ARCHITECT_REPORT`, `FINAL_REPORT`) to reconcile. No phase reorder.
  - `roles/director.md` — new `validate` **step 7**: after writing `director_e2e_validation.json`, overwrite only the report headline (throughput/speedup/TTFT/TPOT/status/parity) with the Director numbers; self-check consistency. Verdict vocabulary `accepted` → **`validated_win | validated_no_win | flagged`**.
  - `roles/system_architect.md` — headline written **provisionally** from the finalize bench (tagged), reconciled by the Director; **timeline records each kernel's stock backend + one node per backend attempted/`⊘`-skipped**; emoji reflects the gate (`❌` for rejected/regressed, `⭐` only for a banked win, `parity ✓` numeric-only).
  - Add `docs/pr-report-director-reconcile.md`.

  ## Impact
  - Report headline is now guaranteed identical to `director_e2e_validation.json`; a no-win run can no longer read as a success. No new knobs; no code branches on the status literal (safe). Backward-compatible (finalize fallback kept + annotated when the Director has no number).

  ## Testing
  - **Before (bug):** report and Director disagreed — `final_report.md` `640.4 → 709.0` vs `director_e2e_validation.json` `621.365 → 698.373`.
  - **After:** on a fresh e2e run the two sources agree — the `final_report.md` headline (throughput / speedup / TTFT / TPOT) is reconciled to and identical with `director_e2e_validation.json`; no more report-vs-director drift.

  Reproduce:
  ```
  Workflow({
    scriptPath: "<GEAK>/e2e_workflow/e2e_workflow.js",
    args: {
      model_path: "/data/.../model/openai/gpt-oss-120b",
      workflow_dir: "<GEAK>/e2e_workflow",
      backend: "vllm", tp: 1, gpu_ids: "0,1,2,3",
      isl: 1024, osl: 1024, conc: 64,
      exp_root: "/data/.../exp/gpt-oss_fix_num_order"
    }
  })
  // verify the fix: final_report.md headline == director_e2e_validation.json (throughput/speedup/TTFT/TPOT all identical).
  ```