### PR TITLE
rename perfskills to geak

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -267,8 +267,8 @@ Stable **handoff.json** fields: `model_path`, `framework` (→ `backend`), `tp`,
 `workload{isl, osl, conc}`, `accepted_flags` / `env`, `exp_root`, `bench_client`, `bench_protocol`,
 `inferencex_path`, `raw_baseline_tput`.
 
-Env knobs: `PERFSKILLS_CLAUDE_MODEL` (`claude-opus-4-8`), `PERFSKILLS_CLAUDE_EFFORT` (`ultracode`),
-`PERFSKILLS_E2E_TIMEOUT_S` (`43200` = 12h), `PERFSKILLS_ROOT`, `PERFSKILLS_EVAL_DIR`, `INFERENCEX_PATH`.
+Env knobs: `GEAK_CLAUDE_MODEL` (`claude-opus-4-8`), `GEAK_CLAUDE_EFFORT` (`ultracode`),
+`GEAK_E2E_TIMEOUT_S` (`43200` = 12h), `GEAK_ROOT`, `GEAK_EVAL_DIR`, `INFERENCEX_PATH`.
 See [`interface/run_e2e.md`](../interface/run_e2e.md) for the full contract.
 
 ---

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -33,7 +33,7 @@ const KERNEL_WF_SCRIPT = `${KERNEL_WF_DIR}/kernel_workflow.js`;
 const EXP_ROOT = String(A.exp_root || (WORKFLOW_DIR.replace(/\/[^/]*$/, '') + '/exp')).replace(/\/+$/, '');
 
 // ---- Upstream TraceLens / kernel-agent prior (OPTIONAL; forwarded by run_e2e.py as args.tracelens) ----
-// run_e2e.py resolves these paths beside the perfskills handoff and forwards ONLY the non-null ones.
+// run_e2e.py resolves these paths beside the geak handoff and forwards ONLY the non-null ones.
 // They are a PRIOR for the Profile/Strategize/Extract phases: if analysis_md exists the Profiler skips
 // its own trace collection and builds the Top-N from TraceLens (and runs an EXTRA parse_profile pass on
 // trace_file when present); the Architect uses kernel_candidates as a routing prior. ENTIRELY ADDITIVE:
@@ -68,7 +68,7 @@ const SERVING_TP = parseInt(A.tp != null ? A.tp : (A.serving_tp != null ? A.serv
 const SERVING_GPU = String(A.serving_gpu != null ? A.serving_gpu
   : GPU_LIST.slice(0, Math.max(1, SERVING_TP)).join(',') || '0');
 // ---- WALL-CLOCK BUDGET (opt-in; default OFF when absent => byte-identical) ---------------------------
-// time_budget_s is the EXTERNAL orchestrator's HARD kill budget (run_e2e.py PERFSKILLS_E2E_TIMEOUT_S),
+// time_budget_s is the EXTERNAL orchestrator's HARD kill budget (run_e2e.py GEAK_E2E_TIMEOUT_S),
 // forwarded so GEAK can self-pace and FINISH (Finalize/Report/Validate + workflow_return flush) BEFORE
 // the SIGKILL — instead of being torn down mid-flight (the deep 24h-budget-vs-12h-kill failure). This is
 // the SINGLE place the orchestrator budget is interpreted. When the arg is ABSENT (GEAK invoked directly,
@@ -250,7 +250,7 @@ const OSL = parseInt(A.osl != null ? A.osl : 1024, 10);
 const CONC = parseInt(A.conc != null ? A.conc : 64, 10);
 const WORKLOAD = { isl: ISL, osl: OSL, conc: CONC };
 // Seed config: when an external orchestrator (e.g. Hyperloom) already did
-// config/param search, it passes its accepted best flags/env so the PerfSkills
+// config/param search, it passes its accepted best flags/env so the GEAK
 // baseline is measured ON that config (fair engagement start), not the stack
 // default. Serving TP/GPU are handled by SERVING_TP / SERVING_GPU above.
 const INIT_FLAGS = String(A.initial_extra_server_args || '');

--- a/e2e_workflow/roles/director.md
+++ b/e2e_workflow/roles/director.md
@@ -78,7 +78,7 @@ Steps:
    Every later e2e measurement (sweep, integrate, validate) MUST match this exact `TP=SERVING_TP
    GPU=SERVING_GPU` config, or deltas are meaningless.
    **Seed config**: if `INIT_FLAGS`/`INIT_ENV` are given (the caller's already-searched best config),
-   the baseline MUST be measured ON them (pass `EXTRA_SERVER_ARGS`/`EXTRA_ENV`), so PerfSkills' baseline
+   the baseline MUST be measured ON them (pass `EXTRA_SERVER_ARGS`/`EXTRA_ENV`), so GEAK's baseline
    == the caller's best config and later kernel gains compound on top of it. Use the copied bench script
    (substitute the actual SERVING_TP / SERVING_GPU values from your inputs):
    ```bash
@@ -136,7 +136,7 @@ TRUE baseline with the tight 2-block protocol and decide if the COMBINED result 
    overlay + flags), each `E2E_REPEATS` (default 7) timed repeats on ONE server:
    The TRUE-baseline block MUST reproduce the seed config the baseline was measured on (the caller's
    best config = the recorded `baseline` flags/env, i.e. the same `INIT_FLAGS`/`INIT_ENV`) — NOT
-   `FINAL_FLAGS` minus PerfSkills' kernel wins. Use the same `TP=SERVING_TP GPU=SERVING_GPU` as setup.
+   `FINAL_FLAGS` minus GEAK's kernel wins. Use the same `TP=SERVING_TP GPU=SERVING_GPU` as setup.
    ```bash
    # fresh TRUE-baseline block (baseline seed flags/env, NO kernel overlay) — re-measured NOW for drift.
    # Serving config MUST be the run-wide invariant: TP=SERVING_TP GPU=SERVING_GPU (from your inputs).

--- a/e2e_workflow/scripts/adapters/clients/inferencex.sh
+++ b/e2e_workflow/scripts/adapters/clients/inferencex.sh
@@ -6,7 +6,7 @@
 # benchmark is driven by the EXACT same client Hyperloom uses: InferenceX's
 # utils/bench_serving/benchmark_serving.py (OpenAI-compatible --backend vllm),
 # with the same dataset / warmups / percentile metrics. That removes the
-# "different bench client" residual when comparing PerfSkills numbers to a
+# "different bench client" residual when comparing GEAK numbers to a
 # Hyperloom Magpie baseline.
 #
 # Enable with:  BENCH_CLIENT=inferencex  (bench_e2e.sh sources this and preserves

--- a/interface/run_e2e.md
+++ b/interface/run_e2e.md
@@ -19,8 +19,8 @@ python interface/run_e2e.py <handoff.json> <result.json> [--dry-run]
 * `--dry-run` → print the mapped `e2e_workflow.js` args + the prompt and
   exit `0` (no GPU work). Use this to validate the mapping in CI.
 
-Discovery: the installer should export `PERFSKILLS_E2E_RUNNER` pointing at this
-file (`$PERFSKILLS_ROOT/interface/run_e2e.py`) so the caller has a single
+Discovery: the installer should export `GEAK_E2E_RUNNER` pointing at this
+file (`$GEAK_ROOT/interface/run_e2e.py`) so the caller has a single
 hard-coded handle.
 
 The fast-path artifacts live under `<exp_root>/geak_e2e_moe_int4/`
@@ -41,7 +41,7 @@ The fast-path artifacts live under `<exp_root>/geak_e2e_moe_int4/`
   "accepted_env": "SGLANG_USE_AITER=1",
   "launch_recipe": "/path/baseline_config.with_envs.yaml",  // optional launch script/recipe
   "raw_baseline_tput": 1485.4,           // caller's official raw baseline (carried for reference)
-  "exp_root": "/work/perfskills_exp",    // where the timestamped run dir is created
+  "exp_root": "/work/experiment/geak",   // basename MUST be `geak`; the timestamped run dir is created here
   "bench_client": "auto",                // auto|inferencex|native — see口径 alignment below
   "inferencex_path": "/opt/InferenceX",  // optional; else taken from $INFERENCEX_PATH
   "bench_protocol": {                    // optional; caller's measurement 口径 (see below)
@@ -56,7 +56,7 @@ The fast-path artifacts live under `<exp_root>/geak_e2e_moe_int4/`
 Required: `model_path`, `exp_root`. Everything else has a default.
 
 `bench_protocol` is optional and **partial-friendly**: only the keys present are
-applied. Omit it entirely (standalone PerfSkills, no external orchestrator) and
+applied. Omit it entirely (standalone GEAK, no external orchestrator) and
 `bench_e2e.sh` keeps its own defaults unchanged. When the caller (Hyperloom)
 supplies it, those values are the EXACT knobs the caller's official baseline was
 measured with — forwarding them is what makes the workflow's numbers
@@ -88,8 +88,8 @@ a ~10-15% 口径 gap. Both default to `0` (fixed) so the standalone and forwarde
 ### TraceLens prior auto-discovery (owned by `run_e2e.py:resolve_tracelens_report`)
 
 An upstream orchestrator may have already profiled the SAME baseline workload with
-TraceLens and dropped its artifacts beside the handoff's `perfskills` dir (i.e.
-under the experiment root = the parent of `perfskills`). `map_args` resolves them
+TraceLens and dropped its artifacts beside the handoff's `geak` dir (i.e.
+under the experiment root = the parent of `geak`). `map_args` resolves them
 by glob (each `**` is a randomly-named nested dir) and forwards the **non-null**
 paths to the workflow as `args.tracelens`:
 
@@ -100,7 +100,7 @@ paths to the workflow as `args.tracelens`:
 | `tracelens_report_json` | `kernel-agent/**/tracelens/tracelens_report.json` | full TraceLens report (same `hot_kernels[]` shape) |
 | `trace_file` | `runs/roofline/**/torch_trace` | the roofline torch-trace **directory** (per-TP-rank `*.pt.trace.json.gz`) |
 
-Resolution prefers the parent of the `perfskills` segment in `exp_root`; if that
+Resolution prefers the parent of the `geak` segment in `exp_root`; if that
 path is not present on the box it falls back to the on-disk grandparent of the
 handoff file. The same four paths are also surfaced (with nulls) in the human
 `tracelens_report` block of the driver prompt.
@@ -123,7 +123,7 @@ the baseline prior is stale) the workflow profiles/strategizes exactly as before
 {
   "schema_version": 1,
   "status": "ok | no_gain | error",
-  "eval_dir": "/work/perfskills_exp/e2e_<model>_<ts>",
+  "eval_dir": "/work/experiment/geak/e2e_<model>_<ts>",
   "baseline_throughput_tok_s": 1485.4,   // baseline (= caller best config)
   "final_throughput_tok_s": 1551.4,
   "throughput_speedup": 1.044,

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PerfSkills/GEAK e2e runner — the ONLY entry point Hyperloom (or any external
+"""GEAK e2e runner — the ONLY entry point Hyperloom (or any external
 orchestrator) calls.
 
 Contract (stable, see interface/run_e2e.md):
@@ -41,14 +41,14 @@ SCHEMA_VERSION = 1
 
 # interface/ is a sibling of e2e_workflow/ under the repo root.
 INTERFACE_DIR = Path(__file__).resolve().parent
-PERFSKILLS_ROOT = INTERFACE_DIR.parent
-E2E_DIR = PERFSKILLS_ROOT / "e2e_workflow"
+GEAK_ROOT = INTERFACE_DIR.parent
+E2E_DIR = GEAK_ROOT / "e2e_workflow"
 E2E_SCRIPT = E2E_DIR / "e2e_workflow.js"
 BENCH_SCRIPT = E2E_DIR / "scripts" / "bench_e2e.sh"
 
 # Workflow primitives are only available at this effort tier (see README).
-CLAUDE_EFFORT = os.environ.get("PERFSKILLS_CLAUDE_EFFORT", "ultracode")
-CLAUDE_MODEL = os.environ.get("PERFSKILLS_CLAUDE_MODEL", "claude-opus-4-8")
+CLAUDE_EFFORT = os.environ.get("GEAK_CLAUDE_EFFORT", "ultracode")
+CLAUDE_MODEL = os.environ.get("GEAK_CLAUDE_MODEL", "claude-opus-4-8")
 ALLOWED_TOOLS = ["Workflow", "Bash", "Read", "Write"]
 
 # Public claude builds (>=2.1.x) REJECT "--effort ultracode". The Workflow /
@@ -58,14 +58,14 @@ ALLOWED_TOOLS = ["Workflow", "Bash", "Read", "Write"]
 # executes the JS pipeline instead of the agent merely "backgrounding" it.
 VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
 WORKFLOW_SETTINGS = os.environ.get(
-    "PERFSKILLS_CLAUDE_SETTINGS",
+    "GEAK_CLAUDE_SETTINGS",
     json.dumps({"enableWorkflows": True, "ultracode": True}),
 )
 # Override which claude binary the SDK drives. The claude_agent_sdk otherwise
 # prefers its OWN bundled CLI (claude_agent_sdk/_bundled/claude) over $PATH, so
 # swapping the system claude alone has no effect on the SDK path. Set
-# PERFSKILLS_CLAUDE_BIN to pin a specific build (e.g. an older native version).
-CLAUDE_BIN = os.environ.get("PERFSKILLS_CLAUDE_BIN", "").strip()
+# GEAK_CLAUDE_BIN to pin a specific build (e.g. an older native version).
+CLAUDE_BIN = os.environ.get("GEAK_CLAUDE_BIN", "").strip()
 
 # Background-task completion race (see _invoke_via_sdk completion gate):
 # when the SDK turn "looks done" (a background task notified terminal + the
@@ -77,8 +77,8 @@ CLAUDE_BIN = os.environ.get("PERFSKILLS_CLAUDE_BIN", "").strip()
 # backgrounded workflow alive) and poll the disk for the terminal marker for a
 # BOUNDED grace window. The outer anyio.fail_after(timeout_s) is the ultimate
 # backstop, so this can never exceed the run's hard budget.
-DONE_GRACE_S = float(os.environ.get("PERFSKILLS_DONE_GRACE_S", "1800"))
-DONE_POLL_S = float(os.environ.get("PERFSKILLS_DONE_POLL_S", "15"))
+DONE_GRACE_S = float(os.environ.get("GEAK_DONE_GRACE_S", "1800"))
+DONE_POLL_S = float(os.environ.get("GEAK_DONE_POLL_S", "15"))
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +144,7 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
     # scaffold beside the authoritative run. Honor an explicit handoff/env
     # override first (resume); otherwise mint a single fresh dir here so BOTH
     # the preflight smoke and the real baseline/profile/kernel land under it.
-    eval_dir = str(h.get("eval_dir") or os.environ.get("PERFSKILLS_EVAL_DIR", "")).strip()
+    eval_dir = str(h.get("eval_dir") or os.environ.get("GEAK_EVAL_DIR", "")).strip()
     if not eval_dir:
         model_name = Path(h["model_path"]).name
         ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
@@ -164,8 +164,8 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
 # ---------------------------------------------------------------------------
 # TraceLens / kernel-agent artifact discovery.
 # ---------------------------------------------------------------------------
-# The four artifacts live ABOVE the handoff's ``perfskills`` directory, under
-# the experiment root (the parent of ``perfskills``). ``**`` denotes one or
+# The four artifacts live ABOVE the handoff's ``geak`` directory, under
+# the experiment root (the parent of ``geak``). ``**`` denotes one or
 # more randomly-named nested directories, so the lookup is glob based
 # (recursive) and stays generic across runs.
 _TRACELENS_ARTIFACT_PATTERNS = {
@@ -177,13 +177,13 @@ _TRACELENS_ARTIFACT_PATTERNS = {
 
 
 def _experiment_root_from_exp_root(exp_root: str) -> str:
-    """Return the experiment root (the directory that CONTAINS ``perfskills``).
+    """Return the experiment root (the directory that CONTAINS ``geak``).
 
-    ``handoff.exp_root`` points at ``<experiment_root>/perfskills`` so the four
-    TraceLens artifacts live one level up, beside ``perfskills``.
+    ``handoff.exp_root`` points at ``<experiment_root>/geak`` so the four
+    TraceLens artifacts live one level up, beside ``geak``.
     """
     norm = str(exp_root or "").rstrip("/")
-    if os.path.basename(norm) == "perfskills":
+    if os.path.basename(norm) == "geak":
         return os.path.dirname(norm)
     return norm
 
@@ -199,7 +199,7 @@ def _find_latest_artifact(root: str, pattern: str) -> str | None:
 
 
 def resolve_tracelens_report(exp_root: str) -> dict:
-    """Resolve the four TraceLens artifacts beside the handoff's ``perfskills``.
+    """Resolve the four TraceLens artifacts beside the handoff's ``geak``.
 
     Returns a dict with ``search_root`` plus the four artifact paths
     (``analysis_md``, ``kernel_candidates_json``, ``tracelens_report_json``,
@@ -304,7 +304,7 @@ def apply_bench_protocol(h: dict) -> dict:
     agents make overrides its built-in default with the orchestrator's value.
 
     IMPORTANT: only keys actually present in the handoff are exported. When
-    ``bench_protocol`` is absent (e.g. PerfSkills run standalone, no external
+    ``bench_protocol`` is absent (e.g. GEAK run standalone, no external
     orchestrator), nothing is exported and ``bench_e2e.sh`` keeps its own
     defaults — so the standalone path is unchanged.
 
@@ -679,7 +679,7 @@ def _parse_last_json_line(raw: str) -> dict:
 def _classify_error(exc: BaseException) -> str:
     """Map an internal failure onto a stable ``error_class`` for Hyperloom.
 
-    Hyperloom's session-breakdown PerfSkills collector reads ``error_class`` to
+    Hyperloom's session-breakdown GEAK collector reads ``error_class`` to
     attribute *why* an e2e run missed. Keep these values stable; unknown
     failures fall back to ``runner_error``.
     """
@@ -793,7 +793,7 @@ def normalize_result(h: dict, wf: dict) -> dict:
     else:
         result_source = "workflow_return"
 
-    # baseline measurement-protocol cross-check (PerfSkills-E2E vs Hyperloom-E2E divergence).
+    # baseline measurement-protocol cross-check (GEAK-E2E vs Hyperloom-E2E divergence).
     # GEAK's measured baseline is already seeded with Hyperloom's accepted config (map_args forwards
     # accepted_flags/accepted_env), so it should match Hyperloom's own baseline. Surface BOTH numbers
     # plus their divergence so the caller can tell a real win from a measurement mismatch (different
@@ -919,11 +919,11 @@ def _discover_eval_dir(exp_root: Path) -> Path | None:
     it. Pick the most-recently-modified ``e2e_*`` dir that carries one of those
     completion markers; fall back to the newest ``e2e_*`` dir.
 
-    A pinned ``PERFSKILLS_EVAL_DIR`` (set by main() from the single eval_dir
+    A pinned ``GEAK_EVAL_DIR`` (set by main() from the single eval_dir
     map_args minted for this run) short-circuits the glob/guess: recovery then
     targets EXACTLY the dir this run used, never a sibling from another run.
     """
-    pinned = os.environ.get("PERFSKILLS_EVAL_DIR", "").strip()
+    pinned = os.environ.get("GEAK_EVAL_DIR", "").strip()
     if pinned and Path(pinned).is_dir():
         return Path(pinned)
     if not exp_root.is_dir():
@@ -1068,7 +1068,7 @@ def _recover_workflow_return(exp_root: Path) -> dict | None:
     # Sound general attribution: when EXACTLY one kernel was accepted it is, by
     # definition, responsible for the whole measured e2e delta — credit it.
     # With >1 we cannot split, so leave per-kernel gain null (the headline gain
-    # still folds via the perfskills section + cumulative_gain).
+    # still folds via the geak section + cumulative_gain).
     if len(accepted_kernels) == 1 and overall_delta_pct is not None:
         accepted_kernels[0]["e2e_delta_pct"] = overall_delta_pct
 
@@ -1393,7 +1393,7 @@ def _journey_discovery_runs(eval_dir: Path, selected: set[str]) -> list[dict]:
         "source": "bypass",
         "status": "success",
         "duration_sec": None,
-        "scan": {"candidates_path": f"perfskills:{eval_dir}",
+        "scan": {"candidates_path": f"geak:{eval_dir}",
                  "profiler": prof.get("source") or "rocprofv3",
                  "num_distinct_kernels": prof.get("num_distinct_kernels")},
         "hot_kernel_count": len(hot),
@@ -1418,7 +1418,7 @@ def _journey_overlay_entry(eval_dir: Path, short: str, ir: dict, wf: dict,
     ``display_name`` is the profiler's real kernel symbol (with its leading
     underscore intact) resolved from the discovery table; when given it is used
     as ``name`` so the kernels[] entry, the discovery hot_kernel, and the
-    perfskills accepted-kernel backfill all carry the SAME human-readable name.
+    geak accepted-kernel backfill all carry the SAME human-readable name.
     The overlay dir name (``short``, underscore-stripped for filesystem safety)
     is only a fallback when the kernel was not in the profiler table.
     """
@@ -1460,7 +1460,7 @@ def _journey_overlay_entry(eval_dir: Path, short: str, ir: dict, wf: dict,
         entry["backend_result"] = {
             "kernel_id": kernel_id, "run_id": str(eval_dir),
             "attempts": [], "verification": {},
-            "metadata": {"root_dir": str(PERFSKILLS_ROOT), "version": geak_sha,
+            "metadata": {"root_dir": str(GEAK_ROOT), "version": geak_sha,
                          "note": "e2e A/B incomplete (cut off before result)"},
         }
         entry["dispatch"]["task_group"] = "ab_incomplete"
@@ -1485,7 +1485,7 @@ def _journey_overlay_entry(eval_dir: Path, short: str, ir: dict, wf: dict,
         }],
         "verification": {"micro_speedup": micro, "best_attempt_id": attempt_id,
                          "best_backend": backend},
-        "metadata": {"root_dir": str(PERFSKILLS_ROOT), "version": geak_sha},
+        "metadata": {"root_dir": str(GEAK_ROOT), "version": geak_sha},
     }
     entry["e2e"] = {
         "kernel_id": kernel_id,
@@ -1531,7 +1531,7 @@ def _journey_return_entry(eval_dir: str, k: dict, idx: int, wf: dict,
             }],
             "verification": {"micro_speedup": isolated, "best_attempt_id": attempt_id,
                              "best_backend": backend},
-            "metadata": {"root_dir": str(PERFSKILLS_ROOT), "version": geak_sha},
+            "metadata": {"root_dir": str(GEAK_ROOT), "version": geak_sha},
         },
         "e2e": {
             "kernel_id": kid, "integrated": True, "e2e_gain_pct": k.get("e2e_delta_pct"),
@@ -1559,7 +1559,7 @@ def build_kernel_journey(wf: dict, normalized: dict) -> dict:
     """
     eval_dir_str = str(normalized.get("eval_dir") or wf.get("eval_dir") or "")
     eval_dir = Path(eval_dir_str) if eval_dir_str else None
-    geak_sha = _git_short_sha(PERFSKILLS_ROOT)
+    geak_sha = _git_short_sha(GEAK_ROOT)
     overall_parity = _parity_passed(wf.get("output_parity") or normalized.get("output_parity"))
 
     selected = _journey_selected_names(eval_dir) if eval_dir else set()
@@ -1653,7 +1653,7 @@ def build_kernel_journey(wf: dict, normalized: dict) -> dict:
     if not discovery_runs and synth_hot:
         discovery_runs = [{
             "source": "bypass", "status": "success", "duration_sec": None,
-            "scan": {"candidates_path": f"perfskills:{eval_dir_str}"},
+            "scan": {"candidates_path": f"geak:{eval_dir_str}"},
             "hot_kernel_count": len(synth_hot), "hot_kernels": synth_hot, "error": None,
         }]
 
@@ -1670,11 +1670,11 @@ def build_kernel_journey(wf: dict, normalized: dict) -> dict:
 def _geak_versions() -> dict:
     """The top-level ``versions`` section (schema §1) — GEAK's authoritative tool
     version, shared by the full and the empty-kernels journey shapes."""
-    geak_sha = _git_short_sha(PERFSKILLS_ROOT)
+    geak_sha = _git_short_sha(GEAK_ROOT)
     return {
         "geak": {
             "tool": "geak",
-            "root_dir": str(PERFSKILLS_ROOT),
+            "root_dir": str(GEAK_ROOT),
             "commit": geak_sha,
             "version": geak_sha,
         }
@@ -1739,7 +1739,7 @@ def main(argv: list[str]) -> int:
         )
         return 2
     handoff_path, result_path = Path(args[0]), Path(args[1])
-    timeout_s = int(os.environ.get("PERFSKILLS_E2E_TIMEOUT_S", "43200"))  # 12h
+    timeout_s = int(os.environ.get("GEAK_E2E_TIMEOUT_S", "43200"))  # 12h
 
     h = _read_json(handoff_path)
     if not h:
@@ -1750,7 +1750,7 @@ def main(argv: list[str]) -> int:
     # Pin the single eval_dir into the environment so BOTH the live completion
     # check (_workflow_done_on_disk) and the scrape-independent disk recovery
     # (_discover_eval_dir) target EXACTLY this run's dir, deterministically.
-    os.environ["PERFSKILLS_EVAL_DIR"] = ps_args["eval_dir"]
+    os.environ["GEAK_EVAL_DIR"] = ps_args["eval_dir"]
     bench_client = apply_bench_client(h)
     bench_protocol = apply_bench_protocol(h)
     prompt = build_prompt(ps_args)
@@ -1766,7 +1766,7 @@ def main(argv: list[str]) -> int:
     eval_dir_hint = ps_args["eval_dir"]
 
     # ── Guaranteed interface-file emission ──────────────────────────────────
-    # CONTRACT: as long as PerfSkills produced ANY measured E2E effect on disk,
+    # CONTRACT: as long as GEAK produced ANY measured E2E effect on disk,
     # result.json (+ kernel_journey.json) MUST be written. No termination,
     # timeout, signal, or exception may leave the interface files missing.
     #   * idempotent (writes once), best-effort (never raises),
@@ -1870,11 +1870,11 @@ def main(argv: list[str]) -> int:
             wf = None
         if wf is not None:
             sys.stderr.write(
-                f"PerfSkills e2e: workflow handoff failed [{err_class}]; "
+                f"GEAK e2e: workflow handoff failed [{err_class}]; "
                 f"recovered from disk artifacts ({wf.get('eval_dir')}).\n"
             )
         else:
-            sys.stderr.write(f"PerfSkills e2e failed [{err_class}]: {e}\n")
+            sys.stderr.write(f"GEAK e2e failed [{err_class}]: {e}\n")
     finally:
         out = _emit(wf=wf, error=err, error_class=err_class)
 

--- a/interface/test_run_e2e_recovery.py
+++ b/interface/test_run_e2e_recovery.py
@@ -2,7 +2,7 @@
 """Tests for run_e2e's guaranteed interface-file emission + intermediate-win
 recovery.
 
-CONTRACT under test: as long as PerfSkills produced ANY measured E2E effect on
+CONTRACT under test: as long as GEAK produced ANY measured E2E effect on
 disk, result.json (+ kernel_journey.json) MUST be written — no termination,
 timeout, signal, or exception may leave the interface files missing.
 


### PR DESCRIPTION
PR for #341
# Rename e2e optimizer env/tokens to `GEAK`; sync the `geak` directory contract

## Summary
Renames the standalone e2e optimizer's `PERFSKILLS_*` env vars and tokens to `GEAK_*`,
and aligns the cross-repo artifact directory contract with Hyperloom (which now hands off
under a `geak/` experiment root).

## Changes
- **`interface/run_e2e.py`**: `PERFSKILLS_*` env/tokens → `GEAK_*`; the experiment-root
  detection now keys off the `geak` basename (`exp_root`/`_experiment_root_from_exp_root`),
  and the TraceLens artifact scan prefix changes `perfskills:` → `geak:`.
- **`interface/run_e2e.md`**: doc sync — `exp_root`/`eval_dir` examples and the "parent of
  `geak`" resolution wording now match the code (was `perfskills`).
- **`e2e_workflow/e2e_workflow.js`**: contract comment `perfskills handoff` → `geak handoff`.
- **`e2e_workflow/roles/director.md`**, **`.../adapters/clients/inferencex.sh`**: brand
  references `PerfSkills` → `GEAK`.
- **`interface/test_run_e2e_recovery.py`**: updated to the new tokens.

## Rationale
Hyperloom now calls this optimizer simply `geak` and writes the handoff under
`<session_dir>/geak`. Keeping the doc/code contract on `perfskills` would break TraceLens
prior auto-discovery (parent-of-`geak` resolution) and confuse the brand.

## Notes
- No upstream branch/tag was renamed; only in-repo naming/contract.
- Real historical example paths under `examples/**` and VCS-provenance mentions are left
  untouched intentionally.

## Cross-repo dependency
Pairs with the Hyperloom `fix/perfskills_to_geak` PR.