### PR TITLE
[geak v4]  docs: add SECURITY.md + CONTRIBUTING.md, fix README quickstart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to GEAK
+
+Thank you for your interest in contributing to GEAK! This document provides guidelines for contributing to this project.
+
+## Getting Started
+
+1. Fork the repository and clone your fork locally.
+2. Follow the installation instructions in the [README](README.md).
+3. Create a new branch from `main` for your changes.
+
+## Development Workflow
+
+1. **Create a branch** — use a descriptive name (e.g., `fix/kernel-race-condition`, `feat/triton-autotuner`).
+2. **Make your changes** — keep commits focused and atomic.
+3. **Test your changes** — ensure existing tests pass and add new tests where appropriate.
+4. **Submit a pull request** — target the `main` branch.
+
+## Pull Request Process
+
+- PRs require **2 approving reviews** before merging.
+- Link any related issues (e.g., `Fixes #123`).
+- Keep PRs focused — one logical change per PR.
+
+## Code Style
+
+- Follow the existing code style and conventions in the repository.
+- Use meaningful variable and function names.
+- Keep functions focused and reasonably sized.
+
+## Reporting Issues
+
+- Search existing issues before creating a new one.
+- When opening an issue, include enough detail to reproduce the problem (environment, steps, logs).
+
+## License
+
+By contributing to GEAK, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ IS_SANDBOX=1 claude --dangerously-skip-permissions
 
 ```bash
 git clone https://github.com/AMD-AGI/GEAK.git && cd GEAK
-git checkout GEAK_v4
 IS_SANDBOX=1 claude --dangerously-skip-permissions
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in GEAK, please report it through GitHub's **Private Vulnerability Reporting** feature:
+
+1. Go to the [Security tab](https://github.com/AMD-AGI/GEAK/security) of this repository.
+2. Click **"Report a vulnerability"**.
+3. Fill in the details and submit.
+
+**Please do NOT open a public issue for security vulnerabilities.**
+
+## What to Include
+
+When reporting a vulnerability, please include:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce the issue.
+- Any relevant logs, screenshots, or proof-of-concept code.
+
+## Response Timeline
+
+- We will acknowledge receipt of your report within **5 business days**.
+- We will provide an initial assessment within **10 business days**.
+- We will work with you to understand and address the issue before any public disclosure.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest (`main`) | Yes |
+| Older releases | Best effort |
+
+## Scope
+
+This policy applies to the GEAK repository and its official releases. Third-party dependencies are outside the scope of this policy; please report those to the respective maintainers.


### PR DESCRIPTION
  ## What & why
  
  Adds the standard governance docs and fixes a stale quickstart step.

  ### Changes
  - **`SECURITY.md`** (new) — vulnerability-reporting policy via GitHub Private Vulnerability Reporting, response timeline, supported versions, scope. Ported from the `v3.2.2` reference.
  - **`CONTRIBUTING.md`** (new) — contribution workflow, PR process, code style, issue reporting. Adapted from `v3.2.2` with two corrections for this repo:
    - License reference changed **MIT → Apache 2.0** to match this repo's actual `LICENSE`.
    - Dropped links to `.github` templates that don't exist here (`CODE_OF_CONDUCT.md`, `PULL_REQUEST_TEMPLATE.md`, `ISSUE_TEMPLATE/`) so there are no 404 links.
  - **`README.md`** — removed the obsolete `git checkout GEAK_v4` step from the clone quickstart (the default branch is now `main`).

  ### Notes
  - **`LICENSE` intentionally unchanged** (stays Apache 2.0). The `v3.2.2` `LICENSE.md` is MIT with an inherited third-party copyright header (`Kilian A. Lieret and Carlos E. Jimenez`), which does not apply here — so it was **not**
  ported.
  
  Docs-only; no code or behavior changes.