### PR TITLE
GEAK install shallow-clone the repo (--depth 1) and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Two workflows ship here:
   `rocprofv3` / `rocprof`), Python 3.8+.
 - For E2E: a running-capable serving backend (`sglang` or `vllm`) and the model weights on disk.
 
+> **⚠️ Build your kernel environment first.** GEAK does **not** install the toolchains your kernels
+> need (e.g. PyTorch, Triton, FlyDSL, hipBLASLt) — these differ per kernel. Set up and verify the
+> baseline builds/runs before starting a workflow.
+
 ### 2. Set up
 
 Installing GEAK does three things: installs the `geak` Python package + deps, clones the GEAK repo, and installs
@@ -55,7 +59,20 @@ pip install .
 ```
 
 It leaves **PATH and API access** setting in Claude Code to you — follow its printed next-steps to add `~/.local/bin` to
-PATH and to configure Anthropic API access. 
+PATH and to configure API access:
+
+```bash
+# Anthropic API directly:
+export ANTHROPIC_API_KEY=sk-ant-...
+# Standard gateway (x-api-key / bearer):
+export ANTHROPIC_BASE_URL=https://your-gateway ANTHROPIC_AUTH_TOKEN=your-token
+```
+
+> **AMD Gateway** uses a custom `Ocp-Apim-Subscription-Key` header, not `x-api-key` / bearer, so set:
+> ```bash
+> export ANTHROPIC_BASE_URL=https://<amd-gateway-endpoint>
+> export ANTHROPIC_CUSTOM_HEADERS="Ocp-Apim-Subscription-Key: <your-key>"
+> ```
 
 ### 3. Launch Claude Code in auto mode
 

--- a/README.md
+++ b/README.md
@@ -65,13 +65,15 @@ PATH and to configure API access:
 # Anthropic API directly:
 export ANTHROPIC_API_KEY=sk-ant-...
 # Standard gateway (x-api-key / bearer):
-export ANTHROPIC_BASE_URL=https://your-gateway ANTHROPIC_AUTH_TOKEN=your-token
+export ANTHROPIC_BASE_URL=https://your-gateway
+export ANTHROPIC_AUTH_TOKEN=your-token
 ```
 
-> **AMD Gateway** uses a custom `Ocp-Apim-Subscription-Key` header, not `x-api-key` / bearer, so set:
+> If your gateway authenticates with a **custom header** instead of `x-api-key` / a bearer token
+> (e.g. `Ocp-Apim-Subscription-Key`), set it via `ANTHROPIC_CUSTOM_HEADERS`:
 > ```bash
-> export ANTHROPIC_BASE_URL=https://<amd-gateway-endpoint>
-> export ANTHROPIC_CUSTOM_HEADERS="Ocp-Apim-Subscription-Key: <your-key>"
+> export ANTHROPIC_BASE_URL=https://your-gateway
+> export ANTHROPIC_CUSTOM_HEADERS="Your-Header-Name: <your-key>"
 > ```
 
 ### 3. Launch Claude Code in auto mode

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cd GEAK
 pip install .
 ```
 
-### 3. Launch Claude Code (auto mode)
+### 3. Launch Claude Code in auto mode
 
 **Set up PATH and API access**
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,17 @@ cd GEAK
 pip install .
 ```
 
-It leaves **PATH and API access** setting in Claude Code to you — follow its printed next-steps to add `~/.local/bin` to
-PATH and to configure API access:
+### 3. Launch Claude Code (auto mode)
+
+**Set up PATH and API access**
+
+You'll need to add `~/.local/bin` to your PATH and configure API access yourself — follow the installer's printed next-steps:
 
 ```bash
-# Anthropic API directly:
+# Option 1: Anthropic API directly
 export ANTHROPIC_API_KEY=sk-ant-...
-# Standard gateway (x-api-key / bearer):
+
+# Option 2: Standard gateway (x-api-key / bearer)
 export ANTHROPIC_BASE_URL=https://your-gateway
 export ANTHROPIC_AUTH_TOKEN=your-token
 ```
@@ -76,7 +80,7 @@ export ANTHROPIC_AUTH_TOKEN=your-token
 > export ANTHROPIC_CUSTOM_HEADERS="Your-Header-Name: <your-key>"
 > ```
 
-### 3. Launch Claude Code in auto mode
+**Launch Claude Code**
 
 The workflows spawn many sub-agents and run profiling / benchmark / build commands on the box, so run
 Claude Code with permissions auto-approved (≥ 2.1.177 for the dynamic Workflow feature):

--- a/geak/bootstrap.py
+++ b/geak/bootstrap.py
@@ -161,7 +161,9 @@ def clone_repo() -> None:
 
     parent = os.path.dirname(GEAK_HOME) or "."
     os.makedirs(parent, exist_ok=True)
-    cmd = ["git", "clone"]
+    # Shallow clone: GEAK is used as a runtime checkout, not for history, and the
+    # repo is large (perf_knowledge + example artifacts). --depth 1 keeps it fast.
+    cmd = ["git", "clone", "--depth", "1"]
     if REPO_REF:
         cmd += ["--branch", REPO_REF]
     cmd += [REPO_URL, GEAK_HOME]


### PR DESCRIPTION
The runtime checkout does not need git history, and the repo carries large blobs (perf_knowledge + example artifacts) across its history. A plain clone pulled ~180 MB; --depth 1 pulls ~5 MB and finishes in ~1s instead of minutes.