### PR TITLE
docs: fix kernel-language notes and drop op-backend bake-off table

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -93,8 +93,8 @@ The serving stack is not baked in; `args.backend` selects `scripts/adapters/<bac
 |---|---|---|
 | Triton | Verified | Always a viable author target. |
 | FlyDSL | Verified | Preferred author target for dense / quantized GEMM (aiter's SOTA GEMM DSL, JIT, no build). Probed using `aiter.ops.flydsl.is_flydsl_available()`. |
-| HIP | Verified | GEAK escalates to HIP on its own when it judges the headroom justifies it. |
-| CK (Composable Kernel) | Verified | GEAK escalates to CK on its own when it judges the headroom justifies it; FP8 GEMM tuning. |
+| HIP | Verified | GEAK escalates to HIP when the headroom justifies it. |
+| CK (Composable Kernel) | Verified | GEAK escalates to CK when the headroom justifies it; FP8 GEMM tuning. |
 
 ## Precision and data types
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -93,8 +93,8 @@ The serving stack is not baked in; `args.backend` selects `scripts/adapters/<bac
 |---|---|---|
 | Triton | Verified | Always a viable author target. |
 | FlyDSL | Verified | Preferred author target for dense / quantized GEMM (aiter's SOTA GEMM DSL, JIT, no build). Probed using `aiter.ops.flydsl.is_flydsl_available()`. |
-| HIP | Verified | GEAK escalates to HIP when the headroom justifies it. |
-| CK (Composable Kernel) | Verified | GEAK escalates to CK when the headroom justifies it; FP8 GEMM tuning. |
+| HIP | Verified | GEAK chooses HIP based on its e2e experience. |
+| CK (Composable Kernel) | Verified | GEAK chooses CK based on its e2e experience; FP8 GEMM tuning. |
 
 ## Precision and data types
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -93,17 +93,8 @@ The serving stack is not baked in; `args.backend` selects `scripts/adapters/<bac
 |---|---|---|
 | Triton | Verified | Always a viable author target. |
 | FlyDSL | Verified | Preferred author target for dense / quantized GEMM (aiter's SOTA GEMM DSL, JIT, no build). Probed using `aiter.ops.flydsl.is_flydsl_available()`. |
-| HIP | Verified | Used when headroom justifies it. |
-| CK (Composable Kernel) | Verified | Used when headroom justifies it; FP8 GEMM tuning. |
-
-## Op-backend bake-off (`op_bench.py` head kernels)
-
-| Backend | Status |
-|---|---|
-| hipblaslt | Verified |
-| rocblas or TunableOp | Verified |
-| aiter | Verified |
-| triton (with `--triton-autotune`) | Verified |
+| HIP | Verified | GEAK escalates to HIP on its own when it judges the headroom justifies it. |
+| CK (Composable Kernel) | Verified | GEAK escalates to CK on its own when it judges the headroom justifies it; FP8 GEMM tuning. |
 
 ## Precision and data types
 


### PR DESCRIPTION
  - Kernel languages: clarify that GEAK decides on its own to escalate to                                                                
    HIP/CK based on the headroom it observes, rather than implying the                                                                   
    choice comes from an external orchestrator (Hyperloom).                                                                              
  - Remove the "Op-backend bake-off (op_bench.py head kernels)" section.