### PR TITLE
Fix no_engagement for kernel wins needing a backend-select prerequisite

### DIFF
--- a/e2e_workflow/roles/config_tuner.md
+++ b/e2e_workflow/roles/config_tuner.md
@@ -5,7 +5,11 @@ source: launch flags, environment variables, and source-level backend SELECTION 
 hipBLASLt vs CK, a tuning DB, quant, cuda-graph, torch.compile). This is the cheapest, highest-ROI,
 landscape-reshaping lever — so you run FIRST (the spec's "optional" step; default-ON per the locked
 design, but the orchestration may disable you with `CONFIG_TUNE_ENABLED=false`). You never rewrite a
-kernel; that's the kernel squad's job. After your wins, the profile is re-taken because you change
+kernel; that's the kernel squad's job. NOTE: `CONFIG_TUNE_ENABLED=false` disables only your *exploratory*
+config sweep — it does NOT forbid a backend-select switch (env/overlay) that a kernel head REQUIRES to
+engage its tuning artifact on the live seam; that switch is a kernel-engagement prerequisite carried in
+the kernel result (`apply_env`/`code_patch`), applied at integrate regardless of this flag.
+After your wins, the profile is re-taken because you change
 which kernels dominate.
 
 You are invoked per PHASE. Read first: `SKILL_DIR/knowledge/e2e_optimization.md` (Tier 0 knobs),

--- a/e2e_workflow/roles/e2e_integrator.md
+++ b/e2e_workflow/roles/e2e_integrator.md
@@ -113,8 +113,13 @@ unchanged; you just also persist the diagnostics the deep feedback/harness-refin
    extraction (anti-cheating). If tampered → REJECT. (For a synthesized-GEMM op task with no
    `reference_io.pt`, instead confirm `meta.json` shapes/dtype are unchanged.)
 2. **Build the candidate config/overlay** = current accepted + this ONE change, by `winner_kind`:
-   - **env** (TunableOp CSV, `HIPBLASLT_TUNING_FILE`, …): no overlay; candidate env = `CURRENT_ENV +
+   - **env** (TunableOp CSV, `HIPBLASLT_TUNING_FILE`, …): candidate env = `CURRENT_ENV +
      KERNEL_RESULT.apply_env`. Keep the tuning artifact under `$EVAL_DIR/config/` so it's reproducible.
+     **Backend-engagement prerequisite:** a tuning artifact only binds if the backend that consumes it is
+     the one dispatched at the live seam. If this env winner ALSO carries a non-empty
+     `KERNEL_RESULT.code_patch` (a reversible routing overlay that switches the live seam to the tuned
+     backend), it is part of this SAME ONE change — apply it too via `add-module` (per the **patch** branch
+     below), do NOT drop it. The `ENGAGEMENT_CHECK` gate then proves the artifact actually bound.
    - **flag** (`--quantization fp8`, `--attention-backend …`): candidate flags = `CURRENT_FLAGS +
      KERNEL_RESULT.apply_flags`.
    - **patch** (a triton/hip/ck `code_patch` that REWRITES an existing installed module): inject ONLY

--- a/e2e_workflow/roles/op_benchmarker.md
+++ b/e2e_workflow/roles/op_benchmarker.md
@@ -82,6 +82,15 @@ well (Tier C), not just tuned — that is the lever the old design skipped.
     `apply_env=AITER_CONFIG_GEMM_A8W8_BLOCKSCALE=<csv>` PLUS `code_patch=<fp8_utils CK-switch overlay diff>`
     and `tuning_artifact=<tuned.csv>`; the Integrator overlays it and gates on e2e. (bpreshuffle / a4w4
     blockscale follow the same skill with their own dump site + CK tuner.)
+    ⚙️ **The CK-switch mechanism is FRAMEWORK-SPECIFIC — do NOT assume the live seam already dispatches CK.**
+    The `fp8_utils.py` import overlay above is the *sglang* seam; on another framework (e.g. vLLM) the live
+    dense fp8 linear may default to a Triton/blockscale impl and route to CK only via that framework's
+    aiter-enable switch (a backend-select env) or the equivalent reversible overlay — in which case the
+    tuned CSV alone binds to nothing. **SELF-VERIFY engagement before returning**: warm-probe with the
+    deploy env+overlay and `grep -c 'is tuned on cu_num' <server.log>`; if it is 0, add the missing
+    backend-select switch to `apply_env` (or the routing overlay to `code_patch`) — that switch is a kernel
+    prerequisite, applied at integrate regardless of `CONFIG_TUNE_ENABLED` — and re-probe until engagement
+    > 0. Never return a known-0-engagement candidate.
     ⛔ **FORBIDDEN alternatives for this op in this eval — do NOT take any of these lighter levers, even
     though a prior may rank them higher:** (a) the **Triton config-JSON overlay** of
     `aiter.ops.triton.gemm_a8w8_blockscale` (dropping `gfx942-GEMM-A8W8_BLOCKSCALE-N=*-K=*.json` /

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -107,8 +107,16 @@ OPTIONAL upstream TraceLens prior (may be empty strings — treat empty/missing 
    `integration_lever` that reaches THAT seam. Match the candidate's signature to the seam's signature:
    - **Standalone GEMM** — the op is dispatched as a discrete `gemm(XQ,WQ,x_scale,w_scale,…)` call (e.g. a
      Linear layer: `Fp8LinearMethod.apply` → `aiter_w8a8_block_fp8_linear`). A per-shape tune or a
-     `GEMM_SYNTH` standalone swap IS reachable → route to the GEMM-synth head track (`integration_lever:
-     standalone-gemm-swap` or `dense-linear-env-overlay`).
+     `GEMM_SYNTH` standalone swap is reachable **only for the backend actually dispatched behind that seam**
+     → route to the GEMM-synth head track (`integration_lever: standalone-gemm-swap` or
+     `dense-linear-env-overlay`). **NEVER assume which impl is live**: a tuning artifact (per-shape DB / env
+     CSV / config JSON) binds ONLY to the backend that consumes it, so if the seam dispatches a different
+     impl by default (e.g. a Triton blockscale kernel instead of the tuned CK/aiter one) the artifact binds
+     to nothing → `no_engagement`. Verify the live dispatch; if the tuned backend is not the default, the
+     switch that selects it (a backend-select env, or a reversible routing overlay) is a
+     **kernel-engagement prerequisite** — carry it in the candidate (`apply_env` / `code_patch`) so it is
+     applied at integrate **regardless of `CONFIG_TUNE_ENABLED`** (that flag gates only the exploratory
+     config fast path, never a kernel's required backend selection), and attach an `engagement_check`.
    - **Fused / asm kernel** — the op is a monolithic kernel whose constituent GEMMs execute INSIDE it and
      are NEVER dispatched as standalone `gemm(...)` calls (e.g. aiter `fmoe_bf16_blockscaleFp8_g1u1_vs_silu`,
      dispatched via `asm_moe_tkw1(hidden_states, w1, w2, topk_weight, topk_ids, …, activation=Silu)`). A
@@ -150,7 +158,7 @@ Return JSON:
      "is_fused_kernel": false,
      "live_call_seam": "module:attr(sig) actually dispatched at runtime (e.g. 'sglang...Fp8LinearMethod.apply' for a standalone GEMM, or 'aiter.fused_moe_bf16_asm:asm_moe_tkw1(hidden_states,w1,w2,topk_weight,topk_ids,...)' for a fused MoE)",
      "integration_lever": "standalone-gemm-swap|dense-linear-env-overlay|fused-op-tune-hook|author-fused-replacement",
-     "engagement_check": "REQUIRED for fused heads: concrete live-server assertion the Integrator verifies before a full A/B (e.g. \"is tuned on cu_num > 0\"); '' for standalone heads",
+     "engagement_check": "concrete live-server assertion the Integrator verifies before a full A/B (e.g. \"is tuned on cu_num > 0\"). REQUIRED for every fused head AND for any standalone head whose win needs a backend-select switch (env/overlay) to bind; '' ONLY when the tuned backend is already the default live dispatch",
      "amdahl_priority": 0.0, "rationale": "why this is the head; what win to expect; if is_fused_kernel, WHY the chosen lever reaches live_call_seam (signature match)",
      "source_hint": "<TraceLens source_file/source_path if any, else ''>",
      "launcher_hint": "<TraceLens kernel_path/launcher_source_file if any, else ''>",


### PR DESCRIPTION
  A head whose win is delivered via a tuning artifact (per-shape DB / env CSV / config JSON) was rejected no_engagement when the tuned backend was not the default live
  dispatch and CONFIG_TUNE_ENABLED=false. Root cause was two doctrine bugs (not a real env restriction — the integrate legs already accept arbitrary env):
                                                                                                                                                                        
  1. system_architect assumed a standalone-GEMM tune "IS reachable" and the schema exempted standalone heads from engagement_check. But a tuning artifact only binds to
  the backend actually dispatched at the seam; if the seam defaults to another impl (e.g. a Triton blockscale kernel instead of the tuned CK one), the artifact binds to
  nothing. Now: never assume the live impl — if the tuned backend is not the default, the switch that selects it (a backend-select env, or a reversible routing
  overlay) is a kernel-engagement prerequisite carried in apply_env/code_patch, applied at integrate regardless of CONFIG_TUNE_ENABLED; engagement_check is required for
  such heads.                                                                        
  2. e2e_integrator built legs strictly by winner_kind: the env branch said "no overlay", silently dropping a routing code_patch carried alongside a winner_kind=env
  candidate. Now an env winner's routing code_patch is applied via add-module too (same single change).                                                                 
                                          
  Also: generalized the fp8-blockscale CK-switch doctrine in op_benchmarker (the mechanism is framework-specific; added a mandatory pre-return engagement self-probe),  
  and clarified in config_tuner that CONFIG_TUNE_ENABLED=false disables only the exploratory config sweep — not a kernel's required backend-select switch.            

  No orchestration change was needed: apply_env/code_patch/engagement_check already flow ungated, and accepted_overlay+curEnv already persist overlay-and-config
  together.                                                                          

  Validation                                                                         
                                                                                     
  Reproduced the exact prior-bug scenario on Hyperloom + GEAK (DeepSeek-R1-0528, vLLM TP4, MI300X). The run was launched with --no-explore --no-framework-agent so GEAK
  received a RAW handoff accepted_env (VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 only — no master VLLM_ROCM_USE_AITER), i.e. the aiter-backed head is not the default
  live dispatch — the precise condition that previously produced no_engagement.      

  With this fix, GEAK now self-adds VLLM_ROCM_USE_AITER=1 as an engagement_prerequisite on the candidate leg, and the head's e2e integrate reports:

  - gate = accepted
  - engagement = proven ("ENGAGED on all 4 TP workers; Using AITER Fp8 MoE backend") 

  vs. the pre-fix behavior of gate = rejected, no_engagement.

  The engagement bug is resolved: a kernel win that requires a non-default backend now engages on the live serving path even with config-tuning disabled.