### PR TITLE
use output throughput as default metric

### DIFF
--- a/e2e_workflow/scripts/bench_e2e.sh
+++ b/e2e_workflow/scripts/bench_e2e.sh
@@ -33,7 +33,7 @@
 # KEY OUTPUTS (written to $OUT_DIR):
 #   bench_runs.jsonl       one bench result object per repeat
 #   bench_summary.json     {throughput_tok_s_median (metric-neutral; see metric_basis), metric_basis,
-#                           ttft_ms_median, tpot_ms_median, spread, runs}  (E2E_METRIC=total default)
+#                           ttft_ms_median, tpot_ms_median, spread, runs}  (E2E_METRIC=output default)
 #   SUMMARY line on stdout: "E2E_SUMMARY <metric_basis>=<median> spread=<pct> ttft_ms=<med> tpot_ms=<med>"
 #   profile/                trace (if PROFILE=1)
 set -uo pipefail
@@ -569,10 +569,11 @@ def pick(d, *keys):
     for k in keys:
         if k in d and isinstance(d[k], (int, float)): return float(d[k])
     return None
-# metric selection: default = TOTAL token throughput ((input+output)/s); set E2E_METRIC=output for
-# output-only tok/s (Magpie-aligned). Same key is read for baseline+cand so the accept RATIO is
-# consistent; metric_basis records which was used.
-_metric = (os.environ.get("E2E_METRIC") or "total").strip().lower()
+# metric selection: default = OUTPUT-only token throughput (output/s), to match the Hyperloom
+# orchestrator's baseline/explore basis (see collectors/_common.py + collectors/explore.py, both read
+# output_throughput). Set E2E_METRIC=total for total (input+output)/s. Same key is read for
+# baseline+cand so the accept RATIO is consistent; metric_basis records which was used.
+_metric = (os.environ.get("E2E_METRIC") or "output").strip().lower()
 _is_total = _metric in ("total", "total_token", "total_throughput")
 _TPUT_KEYS = (("total_token_throughput", "total_throughput", "total_token_throughput_tok_s")
               if _is_total else

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -1203,9 +1203,15 @@ def normalize_result(h: dict, wf: dict) -> dict:
         "bench_script": str(eval_dir / "bench_e2e.sh"),
         "final_patch": str(eval_dir / "final" / "final_patch.diff"),
         "final_overlay": wf.get("final_overlay") or str(eval_dir / "final" / "overlay"),
-        # Measurement basis: reports aggregate output tok/s (not per-GPU),
-        # matching Hyperloom's Magpie output_throughput. See run_e2e.md alignment table.
-        "metric_basis": "aggregate_output_tok_s",
+        # Measurement basis: read back from the bench_summary.json that actually produced these numbers
+        # (bench_e2e.sh records "aggregate_output_tok_s" or "aggregate_total_token_tok_s" per E2E_METRIC),
+        # so the label never lies about the basis. Falls back to output when neither summary carries it.
+        # See run_e2e.md alignment table.
+        "metric_basis": (
+            final_summary.get("metric_basis")
+            or baseline_summary.get("metric_basis")
+            or "aggregate_output_tok_s"
+        ),
         # Which bench client measured these numbers. "inferencex" => identical
         # client to Hyperloom/Magpie (benchmark_serving.py); "native" => the
         # backend's own client (small cross-harness differences may remain).


### PR DESCRIPTION
# Align GEAK e2e throughput metric basis with Hyperloom (output-only)

Fixes AMD-AGI/GEAK#370

## Problem

The GEAK e2e harness (`bench_e2e.sh`) reported **total** token throughput
`(input+output)/s` by default, while the Hyperloom orchestrator's baseline and
explore phases report **output-only** throughput `output/s`. Both pipelines
consume the same underlying benchmark
(`InferenceX/utils/bench_serving/benchmark_serving.py`, which emits both
`output_throughput` and `total_token_throughput`), so the two harnesses were
silently comparing numbers on two different metric bases.

With a symmetric workload (`ISL == OSL`, `RANDOM_RANGE_RATIO=1.0`), total is
exactly 2× output, so GEAK's baseline came out ~2× higher than the
orchestrator's baseline for the identical server/config. This surfaced as a
bogus ~93% "baseline divergence" and a fictitious ~2.2× cross-pipeline
speedup ratio, making every cross-harness comparison meaningless and making the
orchestrator baseline look like a phantom regression.

Additionally, `result.json` hardcoded `metric_basis: "aggregate_output_tok_s"`
even though the aggregated `bench_summary.json` files all recorded
`aggregate_total_token_tok_s` — a mislabel that hid the mismatch.

## Root cause

- `e2e_workflow/scripts/bench_e2e.sh`: `_metric` defaulted to `"total"`, so
  `throughput_tok_s_median` / `metric_basis` were total-based.
- `interface/run_e2e.py`: `metric_basis` in the emitted `result.json` was a hard
  coded string, decoupled from what the summaries actually measured.
- Hyperloom only ever reads `output_throughput`
  (`breakdown/collectors/_common.py`, `breakdown/collectors/explore.py`), so it
  cannot produce a total-based number — the two sides could never match while
  GEAK defaulted to total.

## Changes

1. **`bench_e2e.sh` — default metric basis `total` → `output`.**
   Aligns GEAK's default with Hyperloom's baseline/explore basis
   (`output_throughput`). `E2E_METRIC=total` remains available as an explicit
   opt-in. Header comment updated accordingly.

2. **`run_e2e.py` — read `metric_basis` back from `bench_summary.json`.**
   The emitted `result.json` now reflects the basis that actually produced the
   numbers (`final_summary` → `baseline_summary` → `"aggregate_output_tok_s"`
   fallback), so the label can no longer lie about the basis.

## Effect

- `baseline_divergence_pct` and `gain_vs_orchestrator_baseline` are now computed
  between same-basis numbers, so the ~2× artifact disappears (residual reflects
  only real box drift / config differences).
- Cross-pipeline comparisons are valid again; the orchestrator baseline no
  longer looks like a phantom regression.
- `result.json.metric_basis` is now consistent with the underlying
  `bench_summary.json`.
- Bonus (no Hyperloom change needed): in output mode the
  `output_throughput_tok_s_median` field is populated (it was `None` in total
  mode), which fixes `_geak_sweep.py` reading `None` and GEAK's own
  `recovered_no_gain` path.

## Scope / compatibility

- No Hyperloom-side changes. The environment never sets `E2E_METRIC` explicitly,
  so the new default takes effect everywhere; `E2E_METRIC=total` still works for
  callers that want total-token throughput.
- The GEAK accept ratio (baseline vs candidate) is unaffected — both legs use
  the same key, so the ratio was already basis-consistent within a run.

## Testing

- [ ] `pytest GEAK/interface/test_run_e2e_alignment.py`
- [ ] Manual: run one e2e bench, confirm `bench_summary.json.metric_basis ==
      result.json.metric_basis == "aggregate_output_tok_s"` and that
      `baseline_divergence_pct` is small (single digits) on a symmetric workload.