### PR TITLE
feat(e2e): gsm8k parity fallback so real throughput wins aren't byte-parity-rejected

### DIFF
--- a/e2e_workflow/README.md
+++ b/e2e_workflow/README.md
@@ -104,6 +104,10 @@ Workflow({
     gpu_ids: "0",         // comma-separated
     isl: 1024, osl: 1024, conc: 64,  // workload (profile + bench use the SAME)
     task: "focus on ...", // optional steer
+    parity_fallback_gsm8k: "true",   // default ON: a REAL e2e win that fails byte-exact parity is NOT
+                          //   auto-rejected — the Integrator falls back to the quick sampled gsm8k
+                          //   task-accuracy gate (accuracy_limit subset, accuracy_tol) and accepts iff
+                          //   quality holds. Set "false" to restore the old strict byte-only reject.
     apply_to_original: "false"       // if "true", emit an apply bundle (overlay + launch), never edits site-packages
   }
 })
@@ -135,20 +139,19 @@ achievable number (it is broader = more backends, deeper = more/faster rounds, p
 spare GPUs while the e2e gate runs on the serving slot, with matched in-window A/B so parallelism never
 corrupts a measurement).
 
-## Accuracy gate (gsm8k) — OFF by default
-By default the e2e gate accepts a kernel on **throughput delta + greedy output parity**
-(`accuracy_gate:"none"`). For QUANTIZED kernels (MXFP8/fp8) byte-parity is too strict — a within-tolerance
-kernel rounds differently and flips a few borderline greedy argmaxes — so you can switch the bar to
-**task accuracy**:
-```
-args: { ...same..., accuracy_gate:"gsm8k", accuracy_limit:200, accuracy_tol:0.01 }
-```
-- `accuracy_gate:"gsm8k"` → the Integrator serves a fresh TRUE baseline vs the candidate, runs sampled
-  gsm8k (5-shot, greedy, fixed seed), and accepts iff `cand_em >= baseline_em - accuracy_tol`.
-- `accuracy_limit` = #questions (default **200**; deep uses a larger sample at finalize to de-noise the
-  boundary). `accuracy_tol` = allowed exact-match drop (default **0.01**).
-- The eval client is `scripts/gsm8k_eval.py` (model-agnostic; queries the OpenAI-compatible endpoint).
-- Leaving it unset (`"none"`) changes nothing vs before — the gate stays throughput + parity only.
+## Accuracy gate (gsm8k)
+gsm8k task-accuracy can enter the e2e gate two ways, both using `scripts/gsm8k_eval.py` (5-shot, greedy,
+fixed seed, sampled `--limit` subset) with the `accuracy_limit` (default **200**) / `accuracy_tol`
+(default **0.01**) knobs. The Integrator scores a fresh TRUE baseline vs the candidate (reusing the
+throughput-A/B servers) and accepts iff `cand_em >= baseline_em - accuracy_tol` (`parity_kind:"accuracy"`).
+
+- **Parity fallback — ON by default (`parity_fallback_gsm8k:"true"`).** Byte-exact parity is still tried
+  first; only a candidate that is a real throughput win but fails byte-parity falls back to the gsm8k gate
+  instead of being rejected. This rescues numerically-different-but-task-correct kernels (a tuned CK/aiter
+  fp8 GEMM, an FP-accum-reordered attention). It only turns a would-be reject into an accept when quality
+  holds — never downgrades a byte-exact accept. Set `"false"` to restore the strict byte-only reject.
+- **Primary bar — opt-in (`accuracy_gate:"gsm8k"`).** For QUANTIZED kernels (MXFP8/fp8) byte-parity is the
+  wrong bar from the start, so this replaces it for the gate entirely.
 
 ## Output
 Everything lands under `<exp_root>/e2e_<model>_<timestamp>/`:

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -191,7 +191,7 @@ function parityIsSoft(integ) {
   const pk = integ && integ.parity_kind;               // 'byte_exact' | 'accuracy' | 'none' (optional)
   if (pk === 'accuracy') return true;
   if (pk === 'byte_exact' || pk === 'none') return false;
-  return ACCURACY_GATE !== 'none';                      // unknown -> soft only when the run uses an accuracy gate
+  return GSM8K_GATE_ON;                                 // unknown -> soft only when a gsm8k gate (explicit OR parity-fallback) is live
 }
 function isImplausibleSpeedup(pct_gpu_time, isolated, integ) {
   if (!parityIsSoft(integ)) return false;              // hard byte-exact correctness -> trust the speedup
@@ -294,8 +294,25 @@ const DEEP_FINAL_ACCURACY_LIMIT = parseInt(A.deep_final_accuracy_limit != null ?
 const ACCURACY_GATE = String(A.accuracy_gate || 'none').trim();          // 'none' | 'gsm8k'
 const ACCURACY_LIMIT = parseInt(A.accuracy_limit != null ? A.accuracy_limit : 200, 10); // sampled gsm8k subset size
 const ACCURACY_TOL = parseFloat(A.accuracy_tol != null ? A.accuracy_tol : 0.01);        // allowed absolute exact_match drop vs baseline
-const ACCURACY_INPUTS = (ACCURACY_GATE !== 'none')
-  ? { ACCURACY_GATE, ACCURACY_LIMIT, ACCURACY_TOL, GSM8K_EVAL_SCRIPT: `${WORKFLOW_DIR}/scripts/gsm8k_eval.py` }
+// ---- PARITY FALLBACK (default ON) -------------------------------------------------------------------
+// The strict byte-exact parity gate over-rejects a whole class of REAL wins: a numerically-different but
+// task-correct kernel (a tuned CK/aiter fp8 GEMM, an FP-accum-reordered attention) beats the baseline
+// end-to-end yet is dropped for a ~1e-4 output drift. Observed: DeepSeek-R1 aiter-CK `gemm_a8w8_blockscale`
+// measured +17.8% e2e but was withheld for accuracy-only parity; an offline gsm8k check later showed the
+// task accuracy was within noise (0.906 -> 0.902 on the full set). So: when a candidate is a REAL e2e win
+// (delta>noise AND cand_min>ref_max) but FAILS byte-exact parity, the integrator no longer auto-rejects —
+// it FALLS BACK to the quick sampled gsm8k task-accuracy gate (same machinery as accuracy_gate=gsm8k,
+// SUBSET via ACCURACY_LIMIT, not the full set) and accepts iff cand_score >= baseline_score - accuracy_tol.
+// Set parity_fallback_gsm8k="false" to restore the old strict byte-only reject.
+const PARITY_FALLBACK_GSM8K = String(A.parity_fallback_gsm8k != null ? A.parity_fallback_gsm8k : 'true') === 'true';
+// The gsm8k gate is live either as the PRIMARY bar (accuracy_gate=gsm8k, replaces byte-parity for quant
+// kernels) or as the byte-parity FALLBACK (parity_fallback_gsm8k, default). Either way the integrator
+// needs the eval script + subset size + tolerance.
+const GSM8K_GATE_ON = ACCURACY_GATE === 'gsm8k' || PARITY_FALLBACK_GSM8K;
+const ACCURACY_INPUTS = GSM8K_GATE_ON
+  ? { ACCURACY_GATE: (ACCURACY_GATE === 'gsm8k' ? 'gsm8k' : 'fallback'),
+      PARITY_FALLBACK_GSM8K: PARITY_FALLBACK_GSM8K ? 'true' : 'false',
+      ACCURACY_LIMIT, ACCURACY_TOL, GSM8K_EVAL_SCRIPT: `${WORKFLOW_DIR}/scripts/gsm8k_eval.py` }
   : {};
 // The AMD authoring knowledge base (REFERENCE ONLY — facts/how-to, never decisions; agents always
 // measure). Default: sibling perf_knowledge/. Workflows enumerate candidates from
@@ -668,6 +685,10 @@ const abDone = (integ) => !!(integ && integ.gate !== 'incomplete' && integ.ab_co
 // (head, milestone, finalize-gate, disk-recovered): an A/B never ends after the
 // reference leg alone — it is driven to a complete ref+cand measurement.
 async function runIntegrateBothLegs(intro, inputs, label, phaseName) {
+  // Central injection: every head/milestone/finalize-gate integrate goes through here, so the gsm8k
+  // gate inputs (explicit accuracy_gate OR the default byte-parity fallback) reach ALL of them. Caller
+  // keys win on conflict (spread last) — e.g. a per-site ACCURACY_LIMIT override is preserved.
+  inputs = { ...ACCURACY_INPUTS, ...inputs };
   let integ = await safeAgent(
     roleAgent('e2e_integrator', 'integrate', intro, inputs),
     { phase: phaseName, label, schema: INTEGRATE_SCHEMA });
@@ -1326,7 +1347,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
             CURRENT_OVERLAY: curOverlay, CURRENT_FLAGS: curFlags, CURRENT_ENV: curEnv,
             CURRENT_THROUGHPUT: curTput, SKILL_DIR: WORKFLOW_DIR, DEEP_FEEDBACK: true,
             ...ACCURACY_INPUTS,
-            ...(opts.final && ACCURACY_GATE !== 'none' ? { ACCURACY_LIMIT: DEEP_FINAL_ACCURACY_LIMIT } : {}),   // de-noise the finalize accuracy decision
+            ...(opts.final && GSM8K_GATE_ON ? { ACCURACY_LIMIT: DEEP_FINAL_ACCURACY_LIMIT } : {}),   // de-noise the finalize accuracy decision (explicit gate OR parity fallback)
           }),
           { phase: 'HeadKernel', label: `integrate ${c.uid} g${e2eGateCount}`, schema: INTEGRATE_SCHEMA });
         if (integ && integ.output_parity === 'fail') {

--- a/e2e_workflow/roles/e2e_integrator.md
+++ b/e2e_workflow/roles/e2e_integrator.md
@@ -34,12 +34,19 @@ e2e_optimization.md` (measurement discipline + the Amdahl stop rule).
    at the first token vs a deterministic baseline, while every per-leg check "passed"). So run the parity
    probe with the CAND overlay vs a FRESH no-overlay baseline server (both greedy/temp=0/fixed seed). 
    - If the baseline is deterministic (re-run it twice; byte-exact) and the CAND diverges on ANY prompt →
-     it is a REAL output change, NOT FP noise. For a NON-quant change → REJECT.
-   - For a QUANTIZED kernel (MXFP8/fp8 — byte-parity is expected to drift from rounding/argmax) → do NOT
-     accept on throughput alone: run a small TASK-ACCURACY gate (e.g. a fixed greedy eval set / agreement
-     rate vs the true baseline) and accept ONLY if quality holds within tolerance; otherwise `rejected`
-     with reason `needs_accuracy_gate`/`parity_regression`. Never let cumulative MXFP8 drift ride through
-     as "parity pass vs the prior leg."
+     it is a REAL output change, NOT FP noise.
+   - **PARITY FALLBACK (default; active when `PARITY_FALLBACK_GSM8K=true` or `ACCURACY_GATE` ∈
+     {`gsm8k`,`fallback`} is in your inputs).** A byte-divergent candidate is NOT auto-rejected when it is
+     a REAL throughput win (delta > NOISE_BAND_PCT AND `cand_min > ref_max`). Byte-exact drift of ~1e-4
+     (a tuned CK/aiter fp8 GEMM, an FP-accum-reordered attention) routinely flips a borderline greedy
+     argmax without hurting task quality — rejecting it on byte-parity alone throws away a genuine win
+     (observed: DeepSeek-R1 aiter-CK `gemm_a8w8_blockscale`, +17.8% e2e, task accuracy within noise). So
+     when byte-parity FAILS on a real win, FALL BACK to the TASK-ACCURACY gate below (do NOT reject on
+     byte-parity). This applies to ANY kernel, not just quant. Only if the fallback is OFF
+     (`PARITY_FALLBACK_GSM8K=false` and no `ACCURACY_GATE`) does a byte-divergent change → REJECT.
+   - For a QUANTIZED kernel (MXFP8/fp8 — byte-parity is expected to drift from rounding/argmax) → NEVER
+     accept on throughput alone; the TASK-ACCURACY gate below is the correct bar. Never let cumulative
+     MXFP8 drift ride through as "parity pass vs the prior leg."
 
 5. **Report `parity_kind` on every ACCEPT** so the orchestrator can trust the win correctly:
    `"byte_exact"` when acceptance rests on hard greedy byte-parity vs the TRUE baseline; `"accuracy"`
@@ -85,18 +92,25 @@ verified_isolated_speedup, pct_gpu_time; for a HEAD-op winner also: `op_kind`, `
 ∈ {env,flag,patch}, `apply_env`, `apply_flags`, `code_patch`, `tuning_artifact`, `parity_note`),
 `CURRENT_OVERLAY`, `CURRENT_FLAGS`/`CURRENT_ENV`, `CURRENT_THROUGHPUT`, `SKILL_DIR`.
 
-**ACCURACY GATE (only if `ACCURACY_GATE=gsm8k` is in your inputs; else use the normal parity gate).**
-For a QUANTIZED kernel, byte-exact greedy parity is the WRONG bar (a within-tolerance kernel rounds
-differently → flips borderline argmaxes → over-rejects valid kernels). Instead, score TASK ACCURACY:
-- Launch a FRESH TRUE-baseline server (no overlay) and the CAND server (with the candidate overlay), each
-  greedy/temp=0, and run `python3 $GSM8K_EVAL_SCRIPT --base-url http://127.0.0.1:<port>/v1 --model <MODEL_PATH>
-  --limit $ACCURACY_LIMIT --out <dir>/gsm8k_<tag>.json` against each (it prints `GSM8K_EXACT_MATCH=<s>`).
+**ACCURACY GATE (runs when `ACCURACY_GATE` ∈ {`gsm8k`,`fallback`} or `PARITY_FALLBACK_GSM8K=true` is in
+your inputs).** Two modes, SAME machinery:
+  - `gsm8k` (PRIMARY, opt-in) — for a QUANTIZED kernel byte-exact parity is the WRONG bar (a
+    within-tolerance kernel rounds differently → flips borderline argmaxes → over-rejects valid kernels),
+    so this REPLACES byte-parity for the quant gate from the start.
+  - `fallback` / `PARITY_FALLBACK_GSM8K=true` (DEFAULT) — byte-exact parity is still tried FIRST (it is
+    cheap and, on a pass, gives the strongest `parity_kind:"byte_exact"` guarantee). Run this accuracy
+    gate ONLY when byte-parity FAILS on a candidate that is already a REAL throughput win. Do NOT waste it
+    on a candidate that isn't a throughput win — reject those on the throughput gate as usual.
+Score TASK ACCURACY:
+- Reuse the SAME warm TRUE-baseline (no-overlay) and CAND servers you already stood up for the throughput
+  A/B — do NOT relaunch. Run `python3 $GSM8K_EVAL_SCRIPT --base-url http://127.0.0.1:<port>/v1
+  --model <MODEL_PATH> --limit $ACCURACY_LIMIT --out <dir>/gsm8k_<tag>.json` against each (it prints
+  `GSM8K_EXACT_MATCH=<s>`). `$ACCURACY_LIMIT` is a SUBSET (default 200) — a quick signal, NOT the full set.
   The script samples the SAME fixed gsm8k subset for both (seed-pinned), so the scores are comparable.
 - ACCEPT the candidate iff `cand_score >= baseline_score - $ACCURACY_TOL` (quality preserved); otherwise
-  `rejected` with reason `accuracy_regression` (record both scores). This REPLACES byte-parity for the
-  quant gate — a byte-divergent kernel that holds gsm8k accuracy is a LEGITIMATE win. Still apply the
-  throughput + engagement + memory gates as usual. (You can reuse the same two servers for the throughput
-  A/B to avoid extra launches.)
+  `rejected` with reason `accuracy_regression` (record both scores). A byte-divergent kernel that holds
+  gsm8k accuracy is a LEGITIMATE win. On an accuracy-based ACCEPT report `parity_kind:"accuracy"` and put
+  both scores in `parity_note`. Still apply the throughput + engagement + memory gates as usual.
 
 **DEEP-MODE feedback (only if `DEEP_FEEDBACK` is in your inputs; a normal/fast run omits it).** Besides
 the gate decision, the deep-mode scheduler needs the WHY so the next co-opt waves can fix the


### PR DESCRIPTION
## Problem

  The e2e integrator gates every candidate on byte-exact greedy output parity, which over-rejects a whole class of genuine wins: a numerically-different but task-correct kernel (a tuned CK/aiter fp8 GEMM, an FP-accum-reordered
  attention) beats the baseline end-to-end yet is dropped for a ~1e-4 output drift that flips a few borderline argmaxes. The root cause was that the gsm8k task-accuracy machinery needed to validate such kernels already existed but was
  effectively unreachable in a normal run — two doctrine bugs:

  1. In `e2e_workflow.js`, `ACCURACY_INPUTS` was populated only when `accuracy_gate=gsm8k` was explicitly passed, and was spread into the deep-mode gate site only. So a normal/fast run's head/milestone/finalize integrates never received
  the gsm8k script or tolerances, and the integrator had no option but to byte-parity-reject a byte-divergent win.

  2. In `roles/e2e_integrator.md`, the parity gate treated any byte-divergence on a non-quant kernel as a hard reject, and only ran the task-accuracy check when `accuracy_gate=gsm8k` was present — so a real throughput win that failed
  byte-parity was thrown away instead of being validated.

  ## Changes

  This PR adds a new arg `parity_fallback_gsm8k` (default `"true"`): when a candidate is a real throughput win (`delta > noise` AND `cand_min > ref_max`) but fails byte-exact parity, the integrator falls back to the quick sampled gsm8k
  gate (a subset via `accuracy_limit`, not the full set) and accepts iff `cand_em >= baseline_em - accuracy_tol`. `ACCURACY_INPUTS` is now populated whenever the gate is live and injected centrally in `runIntegrateBothLegs`, so every
  integrate site receives it; `parityIsSoft` and the finalize de-noise condition key on the new `GSM8K_GATE_ON`.

  Also generalizes the integrator role so the fallback applies to any kernel (not just quant), keeps byte-exact parity as the cheap first check, and clarifies that the fallback reuses the warm A/B servers rather than launching new ones.

  ## Validation

  Reproduced the DeepSeek-R1-0528 case (vLLM, TP=4, gfx950) where the aiter-CK `gemm_a8w8_blockscale` swap was previously withheld for accuracy-only parity.

  - gate: candidate now ACCEPTED via the gsm8k fallback, `parity_kind:"accuracy"`.
  - accuracy: sampled gsm8k held within tolerance vs the true baseline (no task-quality regression).

  vs. before the fix: the same candidate was rejected on byte-parity despite a real e2e throughput win.