### PR TITLE
kernel_workflow: surface target-backend + target-language authoring k…

### DIFF
--- a/kernel_workflow/roles/deep_engineer.md
+++ b/kernel_workflow/roles/deep_engineer.md
@@ -57,6 +57,12 @@ When `KERNEL_KNOWLEDGE_DIR` is non-empty AND `KK_OPERATOR` is set, mine the card
 MFMA/numerics pitfalls, alternative backends worth mimicking). **Contract:** facts/how-to, not
 decisions; it may be stale/wrong; your measured benchmark is the floor; ignore stored `status`/TFLOPS
 as decisions. It can only add candidates, never narrow them. Skip entirely if empty / `KK_OPERATOR` null.
+**Cross-backend rewrite/port** (your rewrite targets a language ≠ the current source — ANY source→target,
+e.g. ck→flydsl, triton→tilelang, hip→ck): ALSO mine the TARGET backend card
+`operators/<KK_OPERATOR>/backends/<target>.md` and the target language's authoring how-to under
+`languages/<dir>/` (map: triton→`triton_amd`, hip→`hip_cpp`, ck→`composable_kernel`, asm→`asm_mfma`,
+flydsl→`flydsl`, tilelang→`tilelang`; read `overview.md`/`patterns.md`/`knobs.md`, plus flydsl's
+`authoring_*.md`) — the source card won't teach the target.
 
 ## Roofline targeting (how to know how far you really are)
 Your target may be expressed as "% of roofline". Estimate the ceiling, then drive toward it:

--- a/kernel_workflow/roles/engineer.md
+++ b/kernel_workflow/roles/engineer.md
@@ -41,6 +41,12 @@ Read, as reference (focused — start with the paths handed to you, don't crawl 
 - `KERNEL_KNOWLEDGE_DIR/operators/<KK_OPERATOR>/backends/<KK_LANGUAGE>.md` — the card for your exact
   language (skeleton + knobs + pitfalls), plus `operators/<KK_OPERATOR>/{tuning,numerics,fusion}.md`.
 - `KERNEL_KNOWLEDGE_DIR/index/recipes.md` — durable how-to / knob dictionaries.
+- **Cross-backend port** (your `DIRECTION` rewrites into a language ≠ the current source — ANY
+  source→target, e.g. ck→flydsl, triton→tilelang, hip→ck): ALSO read the TARGET backend card
+  `operators/<KK_OPERATOR>/backends/<target>.md` and that language's authoring how-to under
+  `languages/<dir>/` (map: triton→`triton_amd`, hip→`hip_cpp`, ck→`composable_kernel`, asm→`asm_mfma`,
+  flydsl→`flydsl`, tilelang→`tilelang`; read `overview.md`/`patterns.md`/`knobs.md`, plus flydsl's
+  `authoring_*.md`) — the source card does not teach the target backend.
 
 **Contract (do not violate — this guarantees the base can only help, never hurt):**
 - *Facts/how-to, not decisions.* The base may be stale/incomplete/wrong. It only *adds candidates and

--- a/kernel_workflow/roles/tech_lead.md
+++ b/kernel_workflow/roles/tech_lead.md
@@ -82,6 +82,16 @@ analysis below exactly as before.)
      `operators/<kk_operator>/tuning.md`, `operators/<kk_operator>/backends/<kk_language>.md`,
      `operators/<kk_operator>/{numerics,fusion}.md`, `index/recipes.md`. Verify each path exists
      (`ls`); drop any that don't. Empty `[]` when `kk_operator` is `null`.
+   - **Cross-backend port / migration** (the TASK asks to rewrite the kernel into a DIFFERENT backend —
+     ANY `source→target`, e.g. `ck→flydsl`, `triton→tilelang`, `hip→ck`, `ck→ck_tile`): keep `kk_language`
+     = the CURRENT editable source, but `kk_refs` MUST ALSO include (a) the TARGET backend card
+     `operators/<kk_operator>/backends/<target>.md` and (b) the TARGET language's authoring how-to under
+     `languages/<dir>/` — map the language id to its dir: triton→`triton_amd`, hip→`hip_cpp`,
+     ck→`composable_kernel`, asm→`asm_mfma`, flydsl→`flydsl`, tilelang→`tilelang`, gluon→`gluon`,
+     hipkittens→`hipkittens` — reading whatever how-to it has (`overview.md`/`patterns.md`/`knobs.md`;
+     flydsl additionally has the full `authoring_gemm_levers.md` / `authoring_optimization.md` /
+     `authoring_tile_programming.md` / `debugging.md` set). The source-backend card alone does NOT teach how
+     to write the target — without this the engineer re-implements the new backend blind.
    Treat all of this as facts/how-to to *widen* the candidate set — not decisions (see the contract
    above). Do not let it override the per-case data or measurement.
 5. Write `EVAL_DIR/analysis.json` and `EVAL_DIR/codebase_context.md` (human-readable, INCLUDE the

--- a/perf_knowledge/operators/dense_gemm/backends/flydsl.md
+++ b/perf_knowledge/operators/dense_gemm/backends/flydsl.md
@@ -96,7 +96,7 @@ AITER_CONFIG_GEMM_BF16=/tmp/fly.csv AITER_LOG_TUNED_CONFIG=1 <launch> ; grep 'li
 [[operators/dense_gemm/backends/aiter]] (dispatch + deploy) · [[operators/dense_gemm/backends/triton]]
 (easier to author, lower ceiling) · [[operators/dense_gemm/backends/hipblaslt]] (library default) ·
 [[operators/dense_gemm/backends/ck]] (the fallback) · [[operators/grouped_gemm_moe/backends/aiter]]
-(FlyDSL MoE) · language deep-dive `languages/flydsl/` (P1) · authoring how-to: [[languages/flydsl/authoring_gemm_levers]] (tiling / LDS / MFMA-loop / epilogue when writing a GEMM `@flyc.kernel`) + [[languages/flydsl/authoring_tile_programming]].
+(FlyDSL MoE) · language deep-dive `languages/flydsl/` (P1) · authoring how-to: [[languages/flydsl/authoring_gemm_levers]] (tiling / LDS / MFMA-loop / epilogue when writing a GEMM `@flyc.kernel`) + [[languages/flydsl/authoring_tile_programming]] (CuTe tile model) + [[languages/flydsl/authoring_optimization]] (structure-first workflow) + [[languages/flydsl/debugging]] (correctness / NaN / hang triage).
 
 ## Sources
 - On-box: `/sgl-workspace/aiter/aiter/ops/flydsl/gemm_kernels.py` (`flydsl_hgemm` signature),

--- a/perf_knowledge/operators/fused_moe_grouped_gemm/backends/flydsl.md
+++ b/perf_knowledge/operators/fused_moe_grouped_gemm/backends/flydsl.md
@@ -115,6 +115,12 @@ pytest -sv /sgl-workspace/aiter/aiter/ops/flydsl/test_flydsl_moe_a4w4.py
 [[operators/act_and_mul_silu_gelu/backends/flydsl]] (the fused silu+quant kernel) ·
 [[operators/quant_fp4_mxfp]] (MXFP4 quantization) · [[operators/dense_gemm/backends/flydsl]].
 
+**Authoring / optimizing a FlyDSL MoE GEMM `@flyc.kernel`** (write from scratch OR port ck→flydsl):
+[[languages/flydsl/authoring_gemm_levers]] (tiling / LDS / XCD-swizzle / epilogue) ·
+[[languages/flydsl/authoring_optimization]] (structure-first workflow) ·
+[[languages/flydsl/authoring_tile_programming]] (CuTe tile model) ·
+[[languages/flydsl/debugging]] (correctness / NaN / hang triage).
+
 ## Sources
 - On-box: `/sgl-workspace/aiter/aiter/ops/flydsl/moe_kernels.py` (fp4 stage1/stage2, `_get_compiled_silu_fused`),
   `kernels/mixed_moe_gemm_2stage.py` (`GateMode`, `compile_mixed_moe_gemm1/2`),

--- a/perf_knowledge/operators/scaled_quant_gemm/backends/ck.md
+++ b/perf_knowledge/operators/scaled_quant_gemm/backends/ck.md
@@ -41,8 +41,18 @@ sources:
 ## How to verify
 - bf16 accuracy gate + TFLOPS vs peak ([../numerics.md](../numerics.md)).
 
+## Porting to FlyDSL (ck→flydsl)
+If the TASK is to rewrite this CK kernel as a **FlyDSL** kernel (e.g. fp8 a8w8 blockscale `ck→flydsl`),
+the CK tuning knobs above do **not** transfer — the relevant how-to is the FlyDSL authoring knowledge.
+Read the FlyDSL SOTA card [[operators/scaled_quant_gemm/backends/flydsl]] plus the FlyDSL GEMM authoring
+docs: [[languages/flydsl/authoring_gemm_levers]] (tiling / LDS / XCD-swizzle / epilogue levers),
+[[languages/flydsl/authoring_optimization]] (structure-first optimization workflow),
+[[languages/flydsl/authoring_tile_programming]] (`@flyc.kernel` CuTe tile model), and
+[[languages/flydsl/debugging]] (NaN / mismatch / compile / hang triage). Validated ck→flydsl recipe:
+expert_skill `flydsl_gfx950_fp8_blockscale_gemm` (enable with `use_expert_skills=true`).
+
 ## Alternatives / cross-links
-[triton.md](triton.md) · [aiter.md](aiter.md) · [hip.md](hip.md) · [asm.md](asm.md) · [hipblaslt.md](hipblaslt.md) · [../overview.md](../overview.md)
+[triton.md](triton.md) · [aiter.md](aiter.md) · [hip.md](hip.md) · [asm.md](asm.md) · [hipblaslt.md](hipblaslt.md) · [../overview.md](../overview.md) · FlyDSL authoring: [[languages/flydsl/authoring_gemm_levers]] · [[languages/flydsl/authoring_optimization]] · [[languages/flydsl/authoring_tile_programming]] · [[languages/flydsl/debugging]]
 
 ## Sources
 - Composable Kernel: https://github.com/ROCm/composable_kernel

--- a/perf_knowledge/operators/scaled_quant_gemm/backends/flydsl.md
+++ b/perf_knowledge/operators/scaled_quant_gemm/backends/flydsl.md
@@ -108,6 +108,12 @@ pytest -q aiter/ops/flydsl/test_flydsl_moe_a4w4.py                              
 [[operators/gemm_epilogue_fused/backends/flydsl]] (C-shuffle epilogue) ·
 [[operators/grouped_gemm_moe/backends/aiter]] (FlyDSL MoE GEMM).
 
+**Authoring / optimizing a FlyDSL GEMM `@flyc.kernel`** (write from scratch OR port ck→flydsl):
+[[languages/flydsl/authoring_gemm_levers]] (tiling / LDS / XCD-swizzle / epilogue) ·
+[[languages/flydsl/authoring_optimization]] (structure-first workflow) ·
+[[languages/flydsl/authoring_tile_programming]] (CuTe tile model) ·
+[[languages/flydsl/debugging]] (correctness / NaN / hang triage).
+
 ## Sources
 - On-box: `/sgl-workspace/aiter/aiter/ops/flydsl/kernels/preshuffle_gemm.py`
   (`compile_preshuffle_gemm_a8`, `compile_preshuffle_gemm_w4`, `use_mfma_scale_128` /


### PR DESCRIPTION
## Summary
Cross-backend kernel **port/migration** runs (e.g. rewriting an fp8 a8w8 blockscale
GEMM from CK to FlyDSL) previously only surfaced the **source** backend's knowledge
card. The agent never pulled in the **target** language's general-GEMM authoring
docs, so the engineer re-implemented the new backend "blind" — boxed in by the
source card (or a narrow block-scale/expert card) instead of the target backend's
full authoring how-to.
This PR makes `kernel_workflow` knowledge-selection also surface the **target**
backend card **and** the target language's authoring documentation on any
cross-backend port — for **any** `source→target` pair (ck→flydsl, triton→tilelang,
hip→ck, …), not just ck→flydsl.
## Root cause
- `tech_lead` analyze set `kk_language` = current (source) language and populated
  `kk_refs` only from the source backend card — no target-side refs.
- `engineer` / `deep_engineer` read/mined only `backends/<KK_LANGUAGE>.md` (source).
- Operator backend cards had no cross-links to the target language's authoring docs
  (e.g. the CK card never pointed at the FlyDSL authoring docs).
## What changed (prompt + docs only — no runtime/kernel code)
**Role prompts**
- `tech_lead.md` (analyze): on a cross-backend port, keep `kk_language` = editable
  source, but `kk_refs` now ALSO includes (a) the target backend card
  `operators/<op>/backends/<target>.md` and (b) the target language's authoring
  how-to under `languages/<dir>/`, via an id→dir map:
  `triton→triton_amd`, `hip→hip_cpp`, `ck→composable_kernel`, `asm→asm_mfma`,
  `flydsl→flydsl`, `tilelang→tilelang`, `gluon→gluon`, `hipkittens→hipkittens`.
- `engineer.md` / `deep_engineer.md`: on a cross-backend rewrite, also read/mine the
  target backend card + target language authoring docs (same map).
**Operator cards (cross-links to the FlyDSL GEMM authoring docs)**
- `scaled_quant_gemm/backends/ck.md` — new "Porting to FlyDSL (ck→flydsl)" section.
- `scaled_quant_gemm/backends/flydsl.md`, `fused_moe_grouped_gemm/backends/flydsl.md`,
  `dense_gemm/backends/flydsl.md` — "Authoring / optimizing a FlyDSL GEMM" links to
  `authoring_gemm_levers` / `authoring_optimization` / `authoring_tile_programming` /
  `debugging`.
## Before → After (ck→flydsl fp8 blockscale)
- **Before:** analyze emits `kk_refs` = CK card only → engineer sees CK tuning knobs
  (which don't transfer) → reimplements FlyDSL blind.
- **After:** analyze emits CK card **+ FlyDSL SOTA card + FlyDSL authoring docs** →
  engineer gets tiling / LDS / XCD-swizzle / epilogue levers, structure-first
  optimization workflow, the `@flyc.kernel` tile-programming model, and debugging
  triage for the target.
## Scope / generality
Rules are written for **any** `source→target` migration via the id→dir map; ck→flydsl
is just the motivating case (a2b / c2d all covered).