### PR TITLE
Harden workflow prompts to require args as a JSON object

### DIFF
--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -359,6 +359,10 @@ def build_prompt(ps_args: dict) -> str:
         "Invoke the Workflow tool exactly once with:\n"
         f'  scriptPath: "{E2E_SCRIPT}"\n'
         f"  args: {json.dumps(ps_args)}\n"
+        "CRITICAL: pass `args` as a real JSON OBJECT (a mapping), NOT as a "
+        "JSON-encoded string. Do not wrap it in quotes or call json.dumps on it. "
+        "If args arrives as a string the workflow cannot read args.workflow_dir "
+        "and aborts immediately.\n"
         "Run the full e2e pipeline (Setup -> Profile -> Strategize -> "
         "HeadKernel -> Milestone -> Finalize -> Report -> Validate). The workflow "
         f'persists its full return value to "{eval_dir}/workflow_return.json" as '

--- a/kernel_workflow/README.md
+++ b/kernel_workflow/README.md
@@ -56,6 +56,10 @@ This is a Workflow, run via the `Workflow` tool with `scriptPath` and `args`. **
 hard-coded in the script** — it is portable to any install location. Set `scriptPath` to wherever
 this folder lives and pass that same folder as `args.workflow_dir`:
 
+> **IMPORTANT:** pass `args` as a real JSON **object** (a mapping), **not** as a JSON-encoded
+> string. Do not wrap it in quotes or `json.dumps()` it. If `args` arrives as a string the
+> workflow cannot read `args.workflow_dir` / `args.kernel_path` and aborts immediately.
+
 ```
 Workflow({
   scriptPath: "<WF_DIR>/kernel_workflow.js",   // <WF_DIR> = absolute path to THIS kernel_workflow/ folder


### PR DESCRIPTION
The e2e/kernel workflows are driven by an LLM agent that relays args into the Workflow tool. When the agent passes args as a JSON-encoded string instead of a real object, the JS reads args.workflow_dir off a string (undefined), so WORKFLOW_DIR is empty and the workflow aborts immediately.

Add explicit guidance at both prompt entry points that args must be a real JSON object, not a stringified one:
- interface/run_e2e.py build_prompt: CRITICAL note in the Workflow invoke instructions
- kernel_workflow/README.md: IMPORTANT note in the invocation block

Prompt-only fix; the workflow JS files are left untouched (kernel_workflow is the immutable single-kernel layer).