### PR TITLE
fix(interface): backfill dropped attribution on a Director-validated win (#377)

### DIFF
--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -983,6 +983,41 @@ def _wf_best_accepted_delta_pct(wf: dict) -> float:
     return best
 
 
+def _best_ledger_win(wf: dict) -> dict | None:
+    """Largest positive-``e2e_delta_pct`` direction the run actually MEASURED.
+
+    Read from the workflow return's in-run experience ledger
+    (``state.history.ledger`` — the Architect's per-direction record). This is the
+    honest source for the winning op's identity when the accepted lists were
+    dropped. Returns ``None`` when the ledger is absent or holds no positive
+    direction (never fabricates a winner).
+    """
+    ledger = (((wf.get("state") or {}).get("history") or {}).get("ledger") or [])
+    best: dict | None = None
+    best_delta = 0.0
+    for entry in ledger:
+        if not isinstance(entry, dict):
+            continue
+        if not (entry.get("direction") or entry.get("short_name")):
+            continue
+        try:
+            delta = float(entry.get("e2e_delta_pct") or 0.0)
+        except (TypeError, ValueError):
+            delta = 0.0
+        if delta > best_delta:
+            best, best_delta = entry, delta
+    return best
+
+
+def _state_op_names(wf: dict, queue: str) -> set[str]:
+    """``short_name`` set of the return's ``state.<queue>`` (headQueue|kernelQueue)."""
+    names: set[str] = set()
+    for op in ((wf.get("state") or {}).get(queue) or []):
+        if isinstance(op, dict) and op.get("short_name"):
+            names.add(str(op["short_name"]))
+    return names
+
+
 def normalize_result(h: dict, wf: dict) -> dict:
     eval_dir = Path(wf["eval_dir"])
     validation = _read_json(eval_dir / "director_e2e_validation.json")
@@ -1047,6 +1082,47 @@ def normalize_result(h: dict, wf: dict) -> dict:
         result_source = "disk_director_validation"
     else:
         result_source = "workflow_return"
+
+    # ── Reconcile a VALIDATED win whose ATTRIBUTION was dropped (director
+    # override) ───────────────────────────────────────────────────────────────
+    # A live return can carry a real, Director-validated speedup
+    # (validation_status == "validated_win") yet ship EMPTY accepted_heads AND
+    # accepted_kernels — e.g. the head-track Amdahl plausibility guard marked the
+    # winning direction "dead_end" (scored on a single head's mass) and the
+    # Director's later validated_win never wrote it back, so result.json credits a
+    # real win to nothing. Recover the winner's IDENTITY from the in-run ledger
+    # (state.history.ledger — the direction the run actually MEASURED) and route it
+    # to accepted_heads / accepted_kernels by which queue it came from. Do-no-harm:
+    # fires ONLY on a live workflow_return with a positive validated speedup and
+    # BOTH accepted lists empty; never overrides a populated list; never fabricates
+    # (no ledger winner => no change). Tagged accepted_via="director_override" so the
+    # provenance is auditable. See interface/run_e2e.md + GEAK#377.
+    if (
+        result_source == "workflow_return"
+        and speedup > 1.0
+        and (validation.get("validation_status") == "validated_win"
+             or wf.get("validation_status") == "validated_win")
+        and not (wf.get("accepted_kernels") or wf.get("accepted_heads"))
+    ):
+        _win = _best_ledger_win(wf)
+        if _win is not None:
+            _name = str(_win.get("direction") or _win.get("short_name") or "")
+            _entry = {
+                "short_name": _name,
+                "e2e_delta_pct": _win.get("e2e_delta_pct"),
+                "isolated": _win.get("isolated_speedup"),
+                "backend": "geak",
+                "accepted_via": "director_override",
+                "note": _win.get("lesson"),
+            }
+            _kernels = _state_op_names(wf, "kernelQueue")
+            _heads = _state_op_names(wf, "headQueue")
+            wf = dict(wf)   # don't mutate the caller's return object
+            if _name and _name in _kernels and _name not in _heads:
+                wf["accepted_kernels"] = [_entry]
+            else:
+                wf["accepted_heads"] = [_entry]
+            wf["attribution_backfilled"] = True
 
     # baseline measurement-protocol cross-check (GEAK-E2E vs Hyperloom-E2E divergence).
     # GEAK's measured baseline is already seeded with Hyperloom's accepted config (map_args forwards

--- a/interface/test_run_e2e_recovery.py
+++ b/interface/test_run_e2e_recovery.py
@@ -320,6 +320,109 @@ def test_normalize_does_not_reconcile_genuine_no_gain(tmp_path):
     assert out["result_source"] == "workflow_return"
 
 
+# ── validated-win ATTRIBUTION backfill (the Qwen3.5-27B-FP8 director-override) ─
+
+def test_normalize_backfills_validated_win_attribution_head(tmp_path):
+    """A live return with a Director validated_win (speedup 1.59) but EMPTY
+    accepted_heads AND accepted_kernels: the winning head was ledgered 'dead_end'
+    by the single-head Amdahl guard and the Director's override never wrote it
+    back. normalize_result must recover the attribution into accepted_heads (from
+    the in-run ledger, routed by headQueue), tagged director_override — while
+    accepted_kernels stays [] (it was NOT an authored kernel)."""
+    eval_dir = tmp_path / "e2e_validated_dropped"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "director_e2e_validation.json").write_text(json.dumps({
+        "validation_status": "validated_win",
+        "throughput_speedup": 1.5948,
+        "director_verified_throughput_tok_s": 1684.6,
+        "baseline_throughput_tok_s": 1058.9,
+        "output_parity": "pass",
+    }), encoding="utf-8")
+    wf = {
+        "eval_dir": str(eval_dir),
+        "throughput_speedup": 1.5948,
+        "final_throughput_tok_s": 1684.6,
+        "baseline_throughput_tok_s": 1058.9,
+        "validation_status": "validated_win",
+        "accepted_heads": [],
+        "accepted_kernels": [],
+        "accepted_config": {"flags": "--context-length 6144", "env": "SGLANG_USE_AITER=1"},
+        "state": {
+            "headQueue": [
+                {"id": "h0", "short_name": "fp8 a8w8 blockscale GEMM — up/gate", "pct_gpu_time": 33.74},
+                {"id": "h1", "short_name": "fp8 a8w8 blockscale GEMM — down-proj", "pct_gpu_time": 16.08},
+            ],
+            "kernelQueue": [
+                {"id": "k0", "short_name": "chunk_gated_delta_rule_fwd_kernel", "pct_gpu_time": 2.04},
+            ],
+            "history": {"ledger": [
+                {"direction": "fp8 a8w8 blockscale GEMM — up/gate",
+                 "isolated_speedup": 1.72, "e2e_delta_pct": 58.99, "verdict": "dead_end",
+                 "lesson": "implausible_speedup (+59.0% >> Amdahl ceiling +16.4%)"},
+            ]},
+        },
+    }
+    out = rx.normalize_result(_handoff(eval_dir), wf)
+    assert out["status"] == "ok"
+    assert out["result_source"] == "workflow_return"
+    # accepted_kernels stays empty (the win was NOT an authored kernel).
+    assert out["accepted_kernels"] == []
+    # the head win is recovered into accepted_heads, tagged director_override.
+    assert len(out["accepted_heads"]) == 1
+    head = out["accepted_heads"][0]
+    assert head["short_name"] == "fp8 a8w8 blockscale GEMM — up/gate"
+    assert head["accepted_via"] == "director_override"
+    assert head["e2e_delta_pct"] == pytest.approx(58.99)
+
+
+def test_normalize_backfill_routes_kernel_from_kernelqueue(tmp_path):
+    """When the dropped winner matches the kernelQueue (an editable kernel, not a
+    head), the backfill routes it to accepted_kernels — not accepted_heads."""
+    eval_dir = tmp_path / "e2e_validated_kernel"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "director_e2e_validation.json").write_text(json.dumps({
+        "validation_status": "validated_win", "throughput_speedup": 1.2,
+    }), encoding="utf-8")
+    wf = {
+        "eval_dir": str(eval_dir), "throughput_speedup": 1.2,
+        "validation_status": "validated_win",
+        "accepted_heads": [], "accepted_kernels": [],
+        "state": {
+            "headQueue": [{"short_name": "some_gemm_head", "pct_gpu_time": 30}],
+            "kernelQueue": [{"short_name": "fused_recurrent_gated_delta", "pct_gpu_time": 3}],
+            "history": {"ledger": [
+                {"direction": "fused_recurrent_gated_delta", "isolated_speedup": 1.4,
+                 "e2e_delta_pct": 8.0, "verdict": "confirmed"},
+            ]},
+        },
+    }
+    out = rx.normalize_result(_handoff(eval_dir), wf)
+    assert out["accepted_heads"] == []
+    assert len(out["accepted_kernels"]) == 1
+    assert out["accepted_kernels"][0]["short_name"] == "fused_recurrent_gated_delta"
+    assert out["accepted_kernels"][0]["accepted_via"] == "director_override"
+
+
+def test_normalize_backfill_noop_without_validated_win(tmp_path):
+    """Do-no-harm: a positive-speedup return WITHOUT a Director validated_win must
+    NOT be backfilled (the guard requires the override signal) — empty attribution
+    lists stay empty, never fabricated."""
+    eval_dir = tmp_path / "e2e_no_validated"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "director_e2e_validation.json").write_text(json.dumps({
+        "validation_status": "flagged", "throughput_speedup": 1.3,
+    }), encoding="utf-8")
+    wf = {
+        "eval_dir": str(eval_dir), "throughput_speedup": 1.3,
+        "accepted_heads": [], "accepted_kernels": [],
+        "state": {"headQueue": [{"short_name": "x", "pct_gpu_time": 30}],
+                  "history": {"ledger": [{"direction": "x", "e2e_delta_pct": 20.0}]}},
+    }
+    out = rx.normalize_result(_handoff(eval_dir), wf)
+    assert out["accepted_heads"] == []
+    assert out["accepted_kernels"] == []
+
+
 def test_result_source_no_gain(tmp_path):
     eval_dir = _make_no_gain_eval_dir(tmp_path)
     wf = rx._recover_workflow_return(eval_dir.parent)


### PR DESCRIPTION
## Summary

A GEAK run can return a real, Director-`validated_win` throughput gain while shipping **empty `accepted_kernels` AND `accepted_heads`** in `result.json` — a validated win credited to *nothing*. Consumers that read `result.json` then undercount which optimization actually won.

This PR adds a minimal, do-no-harm reconciliation in the interface layer (`normalize_result`) so `result.json` never drops the attribution of a validated win.

Refs #377.

## Root cause

Two subsystems disagree and the disagreement is never reconciled:

1. The **System Architect's** Amdahl plausibility guard scored the winning direction against a *single head's* GPU share and marked it `verdict: dead_end` ("implausible_speedup"), so it was never promoted into `accepted_heads`.
2. The **Director** independently re-measured and returned `validation_status: validated_win`, but that override only updates the throughput number + status — it never writes the winner back into the accepted lists.

Result: `throughput_speedup > 1` + `validated_win`, yet `accepted_kernels == [] and accepted_heads == []`.

Observed on **Qwen3.5-27B-FP8** (`20260714T102310Z`): `throughput_speedup=1.5948`, `validation_status=validated_win`, both accepted lists empty, while `state.history.ledger` records the winning direction (`fp8 a8w8 blockscale GEMM — up/gate`, `e2e_delta_pct=58.99`, `verdict=dead_end`).

## What this PR changes

`interface/run_e2e.py` — in `normalize_result`, after `result_source` is resolved:

- When a **live `workflow_return`** carries a **positive, `validated_win`** speedup but **both** accepted lists are empty, recover the winner's identity from the in-run ledger (`state.history.ledger`, the direction the run actually measured) and route it to `accepted_heads` / `accepted_kernels` by which queue it came from (`state.headQueue` / `state.kernelQueue`).
- Each recovered entry is tagged `accepted_via: "director_override"` for auditable provenance.
- Two small pure helpers added: `_best_ledger_win`, `_state_op_names`.

**Do-no-harm guarantees:**
- Fires *only* on `result_source == "workflow_return"` + `speedup > 1` + `validated_win` + both lists empty.
- **Never overrides** a populated accepted list.
- **Never fabricates** — if there is no positive-delta ledger winner, nothing changes.
- Does not mutate the caller's return object (works on a copy), so `workflow_return.json` and `kernel_journey.json` are unchanged.

## Test plan

- [x] `python3 -m pytest interface/test_run_e2e_recovery.py interface/test_run_e2e_alignment.py` → **42 passed, 1 skipped** (pre-existing skip).
- [x] New unit tests added:
  - `test_normalize_backfills_validated_win_attribution_head` — the Qwen3.5-27B case → head recovered into `accepted_heads`, `accepted_kernels` stays `[]`.
  - `test_normalize_backfill_routes_kernel_from_kernelqueue` — a kernelQueue winner routes to `accepted_kernels`.
  - `test_normalize_backfill_noop_without_validated_win` — no `validated_win` ⇒ no backfill (empty stays empty).
- [x] Smoke-tested the **actual** patched `normalize_result` against the **real** Qwen3.5-27B `workflow_return.json` + `director_e2e_validation.json`: recovers `accepted_heads=[{fp8 a8w8 blockscale GEMM …, accepted_via: director_override, e2e_delta_pct: 58.99}]`, `accepted_kernels=[]`.
- [x] Verified **no false positives**: the guard does not fire on the 5 other real wins (GPT-OSS-120B, Qwen3-14B, DS-R1, Kimi-K2.6, MiniMax-M3) — each already has a populated accepted list.

## Scope / follow-ups (tracked in #377)

This is the interface-layer safety net (the last gate before `result.json`), chosen because it is minimal and fully testable. Complementary upstream hardening remains in #377:
- producer-side reconciliation in `e2e_workflow.js` (make the Director override authoritative for attribution at the source);
- the Architect's Amdahl guard aggregating mass over a shared `live_call_seam` and downgrading "implausible" from a hard veto to a deep-validation flag;
- a stronger Director accuracy/output-length gate for outlier wins.
