### PR TITLE
docs: add blog and documentation links under logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
   <img src="examples/images/logo.png" alt="GEAK v4" width="300">
 </p>
 
+<p align="center">
+  <a href="https://www.amd.com/en/developer/resources/technical-articles/2026/geak-v4.html"><b>📝 Blog</b></a>
+  &nbsp;•&nbsp;
+  <a href="https://rocm.docs.amd.com/projects/geak/en/latest/"><b>📚 Documentation</b></a>
+</p>
+
 GEAK is an autonomous optimization agent that makes AMD Instinct GPUs run faster, automatically. Built as a
 multi-agent system with an evolving knowledge base, it learns from every optimization run and continuously
 improves its strategies over time. Point it at a single kernel or a live model-serving stack such as vLLM or


### PR DESCRIPTION
  ## Summary
  
  Adds a centered links row directly under the logo in the README, pointing to the
  GEAK v4 blog post and the official ROCm documentation for quick access.

  ## Changes
  
  - New centered `<p align="center">` block below the logo with two links:
    - 📝 **Blog** — https://www.amd.com/en/developer/resources/technical-articles/2026/geak-v4.html
    - 📚 **Documentation** — https://rocm.docs.amd.com/projects/geak/en/latest/
  - Links separated by a `•` bullet for a clean, centered look.

  ## Notes

  Docs-only change; no code or behavior affected.