### PR TITLE
Feat/roofline guided routing

### DIFF
--- a/e2e_workflow/README.md
+++ b/e2e_workflow/README.md
@@ -98,6 +98,11 @@ Workflow({
     milestone_min_pct: 5, // Milestone only optimizes editable kernels with pct_gpu_time >= this (default 5);
                           //   overrides min_kernel_tasks — sub-threshold kernels are skipped (Amdahl)
     config_tune: "true",  // Tier-0 sweep on/off (default ON)
+    analysis_skill: "roofline", // profile-analysis skill (default "roofline"; "none" disables).
+                          //   Enriches the Top-N with % of the hardware roofline -> attainable speedup ->
+                          //   expected e2e gain, so budget goes to the kernel with HEADROOM, not merely
+                          //   the biggest one. ADVISORY: annotates + reorders, never prunes a candidate
+                          //   and never overrides the measured pct_gpu_time. See "Roofline" below.
     use_expert_skills: "false", // consult perf_knowledge/expert_skills (advisory priors) on/off (default OFF, opt-in);
                           //   set "true" to enable. When OFF (default) nothing is injected -> behavior is
                           //   byte-identical to a run without the feature. Threaded down to the kernel layer too.
@@ -135,6 +140,40 @@ achievable number (it is broader = more backends, deeper = more/faster rounds, p
 spare GPUs while the e2e gate runs on the serving slot, with matched in-window A/B so parallelism never
 corrupts a measurement).
 
+## Roofline-guided routing (`analysis_skill`, default `roofline`)
+
+`pct_gpu_time` tells you where the time goes; it does **not** tell you whether that time is
+*recoverable*. A kernel already running at the memory or compute ceiling has nothing left to give no
+matter how much of the profile it owns. So after the Profiler emits the Top-N it runs one pluggable
+**analysis skill** (`knowledge/analysis_skills/<name>/SKILL.md`) which estimates, per kernel:
+`roofline_pct` → `attainable_speedup` → `expected_e2e_gain_pct = pct_gpu_time × (1 − 1/attainable)`.
+The Architect then reports **both** orderings — by `%GPU` and by expected gain — and says which it
+followed; a disagreement between them is the useful signal, so it is never blended into one number.
+
+**Roofline is advisory and can never prune a candidate.** Same doctrine as the TraceLens prior: the
+measured `pct_gpu_time` is the judge. Confidence is staged — profile-time shape estimates are `low`
+(display only, not ranked on), real extracted shapes are `medium`, rocprofv3 counter measurements
+(`FETCH_SIZE`/`WRITE_SIZE`/`MfmaFlops*`) are `high`. Five degradation levels end in "emit nothing and
+behave exactly as before", so a missing peak table, an unmodellable op or a bad number cannot fail a run.
+
+**A saturated head is rerouted, not dropped** — the point that matters most for the *largest* kernel.
+Being at the wall means it is done with micro-tuning, not done being optimized; it routes to a
+**byte-reduction track** (fuse an adjacent op away, stop reading unrouted experts, layout/packing,
+lower-precision weights). Those levers must preserve the measurement contract: the user-supplied
+workload (`isl`/`osl`/`conc`/batch) is fixed and speculative decoding is not an optimization.
+
+Calibrated on a real run (Qwen3.5-35B-A3B-FP8, gfx950, vLLM TP1, 1k/1k, conc 64) — see
+`scripts/tests/test_roofline_skill.py`:
+
+| kernel | %GPU | of roofline | attainable | predicted e2e | measured |
+|---|---|---|---|---|---|
+| `fused_moe_kernel` | **26.45%** | 88% (memory-bound) | 1.02× | +0.6% | 1.047× iso, **−0.064% e2e** |
+| `kernel_paged_attention_2d` | 8.86% | 18% | 2.8× | +5.7% | **1.56× iso** |
+
+Ranking by `%GPU` sends the budget to the MoE, where it was in fact wasted; ranking by headroom sends
+it to attention, where the win was. Add a skill by dropping a directory into
+`knowledge/analysis_skills/`; swap with `analysis_skill=<name>`; disable with `analysis_skill=none`.
+
 ## Accuracy gate (gsm8k) — OFF by default
 By default the e2e gate accepts a kernel on **throughput delta + greedy output parity**
 (`accuracy_gate:"none"`). For QUANTIZED kernels (MXFP8/fp8) byte-parity is too strict — a within-tolerance
@@ -167,6 +206,7 @@ Everything lands under `<exp_root>/e2e_<model>_<timestamp>/`:
 e2e_workflow.js   orchestration (deterministic; recursively calls ../kernel_workflow/kernel_workflow.js)
 roles/                 director, system_architect, profiler, config_tuner, kernel_extractor, op_benchmarker, e2e_integrator
 knowledge/             e2e_optimization, profile_parse, preflight (env self-check), backend_playbook + gemm_attention_backends (persistent), sglang_internals, shape_capture
+knowledge/analysis_skills/  pluggable profile-analysis skills (INDEX.md + one dir per skill; `roofline` ships by default)
 scripts/               bench_e2e.sh (backend-agnostic dispatcher), adapters/{sglang,vllm}.sh, parse_profile.py (Top-N), op_bench.py, capture_shapes.py, overlay_setup.py
 ```
 

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -32,6 +32,22 @@ const KERNEL_WF_SCRIPT = `${KERNEL_WF_DIR}/kernel_workflow.js`;
 // EXP_ROOT = where timestamped run dirs go. Default: sibling "exp/" next to this workflow dir.
 const EXP_ROOT = String(A.exp_root || (WORKFLOW_DIR.replace(/\/[^/]*$/, '') + '/exp')).replace(/\/+$/, '');
 
+// ---- Profile-analysis skill (OPTIONAL, pluggable; see knowledge/analysis_skills/INDEX.md) ----
+// After parse_profile.py emits the standardized Top-N, the Profiler may run ONE analysis skill to
+// enrich it with a headroom estimate the Architect can route on. Default `roofline`: per-kernel % of
+// the hardware ceiling -> attainable speedup -> expected e2e gain, so budget goes to the kernel with
+// HEADROOM rather than merely the biggest one. STRICTLY ADVISORY: it annotates and suggests an
+// ordering, never prunes a candidate and never overrides the measured pct_gpu_time.
+// `analysis_skill=none` (or a missing/unreadable skill dir) disables the step and the run behaves
+// exactly as it did before the feature existed -> ANALYSIS_SKILL_* are '' and nothing is injected.
+const ANALYSIS_SKILL = String(A.analysis_skill != null ? A.analysis_skill : 'roofline').trim();
+const ANALYSIS_SKILL_ON = !!ANALYSIS_SKILL && ANALYSIS_SKILL !== 'none' && ANALYSIS_SKILL !== 'false';
+const ANALYSIS_SKILL_INPUTS = ANALYSIS_SKILL_ON ? {
+  ANALYSIS_SKILL: ANALYSIS_SKILL,
+  ANALYSIS_SKILL_DIR: `${WORKFLOW_DIR}/knowledge/analysis_skills/${ANALYSIS_SKILL}`,
+} : { ANALYSIS_SKILL: '', ANALYSIS_SKILL_DIR: '' };
+if (ANALYSIS_SKILL_ON) log(`Profile-analysis skill: ${ANALYSIS_SKILL} (advisory; annotates + reorders, never prunes).`);
+
 // ---- Upstream TraceLens / kernel-agent prior (OPTIONAL; forwarded by run_e2e.py as args.tracelens) ----
 // run_e2e.py resolves these paths beside the geak handoff and forwards ONLY the non-null ones.
 // They are a PRIOR for the Profile/Strategize/Extract phases: if analysis_md exists the Profiler skips
@@ -991,7 +1007,7 @@ if (want('setup')) {
     roleAgent('profiler', 'baseline', 'Capture a warm trace and emit the standardized Top-N.', {
       EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, ROUND: 0,
       OVERLAY_PYTHONPATH: '', EXTRA_SERVER_ARGS: curFlags, EXTRA_ENV: curEnv, SKILL_DIR: WORKFLOW_DIR,
-      ...TRACELENS_INPUTS,
+      ...TRACELENS_INPUTS, ...ANALYSIS_SKILL_INPUTS,
     }),
     { phase: 'Profile', label: 'profiler:baseline', schema: PROFILE_SCHEMA });
   log(`Baseline profiled. ${profile ? (profile.top_kernels || []).length : 0} top kernels.`);
@@ -1001,7 +1017,7 @@ if (want('setup')) {
     roleAgent('system_architect', 'strategize', 'Route the Top-N into config/kernel/host tracks by Amdahl.', {
       EVAL_DIR, PROFILE_TOPN: profile ? profile.profile_topN_json : '', BASELINE_THROUGHPUT: BASELINE_TPUT,
       WORKLOAD, BUDGET, HEAD_THRESHOLD_PCT, CONFIG_TUNE_ENABLED, SKILL_DIR: WORKFLOW_DIR,
-      ...TRACELENS_INPUTS,
+      ...TRACELENS_INPUTS, ...ANALYSIS_SKILL_INPUTS,
     }),
     { phase: 'Strategize', label: 'architect:strategize', schema: STRATEGY_SCHEMA });
   kernelQueue = (strategy && strategy.kernel_candidates) ? strategy.kernel_candidates.slice() : [];
@@ -1064,6 +1080,7 @@ if (want('config') && CONFIG_TUNE_ENABLED && strategy && (strategy.config_direct
       roleAgent('profiler', 'reprofile', 'Re-profile after the config sweep.', {
         EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, ROUND: 'config',
         OVERLAY_PYTHONPATH: '', EXTRA_SERVER_ARGS: curFlags, EXTRA_ENV: curEnv, SKILL_DIR: WORKFLOW_DIR,
+        ...ANALYSIS_SKILL_INPUTS,
       }),
       { phase: 'Profile', label: 'profiler:post-config', schema: PROFILE_SCHEMA });
     // Re-strategize the kernel queue against the new profile.
@@ -1071,6 +1088,7 @@ if (want('config') && CONFIG_TUNE_ENABLED && strategy && (strategy.config_direct
       roleAgent('system_architect', 'strategize', 'Re-route after config changed the landscape.', {
         EVAL_DIR, PROFILE_TOPN: profile ? profile.profile_topN_json : '', BASELINE_THROUGHPUT: curTput,
         WORKLOAD, BUDGET, HEAD_THRESHOLD_PCT, CONFIG_TUNE_ENABLED: false, SKILL_DIR: WORKFLOW_DIR,
+        ...ANALYSIS_SKILL_INPUTS,
       }),
       { phase: 'Strategize', label: 'architect:re-strategize', schema: STRATEGY_SCHEMA });
     if (restrat && restrat.kernel_candidates) kernelQueue = restrat.kernel_candidates.slice();
@@ -1968,6 +1986,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
       roleAgent('profiler', 'reprofile', 'Re-profile after head-kernel wins.', {
         EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, ROUND: 'head',
         OVERLAY_PYTHONPATH: curOverlay, EXTRA_SERVER_ARGS: curFlags, EXTRA_ENV: curEnv, SKILL_DIR: WORKFLOW_DIR,
+        ...ANALYSIS_SKILL_INPUTS,
       }),
       { phase: 'Profile', label: 'profiler:post-head', schema: PROFILE_SCHEMA });
   }
@@ -2004,6 +2023,7 @@ while (want('kernel') && !TIME_DEADLINE_HIT && dispatched < BUDGET && (dispatche
         BASELINE_THROUGHPUT: BASELINE_TPUT, NOISE_BAND_PCT: NOISE_BAND, MILESTONE_MIN_PCT,
         MIN_KERNEL_TASKS, DISPATCHED_SO_FAR: dispatched, BELOW_MIN_FLOOR: belowFloor,
         PROFILE_TOPN: profile ? profile.profile_topN_json : '', HISTORY: history, SKILL_DIR: WORKFLOW_DIR,
+        ...ANALYSIS_SKILL_INPUTS,
       }),
       { phase: 'Milestone', label: `architect:plan m${milestone}`, schema: PLAN_SCHEMA });
 
@@ -2143,6 +2163,7 @@ while (want('kernel') && !TIME_DEADLINE_HIT && dispatched < BUDGET && (dispatche
       roleAgent('profiler', 'reprofile', 'Re-profile the new best server.', {
         EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, ROUND: milestone,
         OVERLAY_PYTHONPATH: curOverlay, EXTRA_SERVER_ARGS: curFlags, EXTRA_ENV: curEnv, SKILL_DIR: WORKFLOW_DIR,
+        ...ANALYSIS_SKILL_INPUTS,
       }),
       { phase: 'Profile', label: `profiler:reprofile m${milestone}`, schema: PROFILE_SCHEMA });
   } else {
@@ -2155,6 +2176,7 @@ while (want('kernel') && !TIME_DEADLINE_HIT && dispatched < BUDGET && (dispatche
       ROUND: milestone, EVAL_DIR, MODEL_NAME, SKILL_DIR: WORKFLOW_DIR,
       MILESTONE_RESULTS: history.ledger.slice(-cands.length),
       REPROFILE_SHIFT: profile ? profile.shift_note : '', PRIOR_HISTORY: history,
+      ...ANALYSIS_SKILL_INPUTS,
     }),
     { phase: 'Milestone', label: `architect:experience m${milestone}`, schema: EXPERIENCE_SCHEMA });
   if (exp) {
@@ -2297,6 +2319,7 @@ if (want('final')) {
       ACCEPTED_CONFIG: { flags: curFlags, env: curEnv }, ACCEPTED_KERNELS: allAccepted,
       ACCEPTED_HEADS: acceptedHeads, FLAGGED_HEADS: flaggedHeads, MILESTONES: milestone, BUDGET_USED: dispatched, BUDGET, MIN_KERNEL_TASKS,
       PROFILE_TOPN: profile ? profile.profile_topN_json : '', WORKLOAD, MODEL_NAME, SKILL_DIR: WORKFLOW_DIR,
+      ...ANALYSIS_SKILL_INPUTS,
     }),
     { phase: 'Report', label: 'architect:report', schema: REPORT_SCHEMA });
 

--- a/e2e_workflow/knowledge/analysis_skills/INDEX.md
+++ b/e2e_workflow/knowledge/analysis_skills/INDEX.md
@@ -1,0 +1,32 @@
+# Analysis skills — index
+
+Pluggable **profile-analysis** skills. The Profiler runs at most ONE of these after `parse_profile.py`
+has produced the standardized Top-N, to enrich it with a headroom estimate the Architect can route on.
+
+Selected by the `analysis_skill` arg (`e2e_workflow.js`). `analysis_skill=none` (or an unknown /
+unreadable skill dir) disables the step entirely and the run behaves exactly as it did before this
+feature existed — see "Degradation" in each skill.
+
+| skill | dir | what it adds | when to use |
+|---|---|---|---|
+| `roofline` | `roofline/` | per-kernel % of the hardware roofline, bound type, attainable speedup, expected e2e gain | default; any GPU-bound serving run |
+| `none` | — | nothing (pre-feature behavior) | reproducing an old run byte-for-byte; skill is misbehaving |
+
+## Contract every skill must honour
+
+1. **Advisory only.** A skill may ADD fields, ADD annotations and SUGGEST an ordering. It may never
+   prune a candidate, never overwrite the measured `pct_gpu_time`, and never be the sole reason a
+   kernel is or isn't optimized. The on-box measurement is always the judge.
+2. **Markdown-first.** The skill's logic lives in its `SKILL.md` so an agent can execute it by reading.
+   Helper scripts are OPTIONAL mechanical primitives (parsing, unit math). If a helper is missing or
+   raises, the agent completes the analysis by hand from `SKILL.md` — a broken script must not disable
+   the skill, and a broken skill must not fail the run.
+3. **Degrade, never fail.** Every skill defines an explicit degradation ladder ending in "emit nothing
+   and let the caller fall back to the pre-skill behavior".
+4. **Declare confidence.** Every emitted number carries a confidence level, and the consumer is told
+   what it is allowed to do at each level.
+
+## Adding a skill
+
+Drop a new directory here containing a `SKILL.md` that follows the contract above, add one row to the
+table, and pass `analysis_skill=<dirname>`. No orchestration or role change is required.

--- a/e2e_workflow/knowledge/analysis_skills/roofline/SKILL.md
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/SKILL.md
@@ -1,0 +1,272 @@
+# SKILL — roofline headroom analysis
+
+Turn the standardized Top-N into a per-kernel answer to: **"how much of this hardware's ceiling is this
+kernel already getting, and therefore how much is left to win?"**
+
+You (an agent) can execute this skill by reading this file. `roofline_tools.py` next to it holds
+mechanical primitives (peak-table parsing, counter parsing, unit math) — use them if they import, do
+the arithmetic yourself if they don't. **A broken helper must not disable this skill; a broken skill
+must not fail the run.**
+
+---
+
+## 0. The one doctrine that matters
+
+> `roofline_pct` measures **how well the kernel executes its current algorithm's byte/FLOP budget.**
+> It says **nothing about whether that budget is necessary.**
+
+A kernel at 90% of the memory roofline is not "done" — it is **done with kernel micro-tuning**. The
+remaining lever is to move fewer bytes. Never read a high `roofline_pct` as "stop optimizing this
+kernel", especially when it is the largest consumer of GPU time. See §7.
+
+Corollary: this skill is **advisory**. It reorders and annotates. `pct_gpu_time` remains the primary
+key and the measurement remains the judge. This skill may never prune a candidate.
+
+---
+
+## 1. Inputs
+
+- `profile/round_<R>/profile_topN.json` — the standardized Top-N (required).
+- `env_report.json` — `gfx`, `model_arch_class`, `model_dtype`, `workload` (required).
+- The model's `config.json` — layer count, expert count, hidden/intermediate sizes, head counts
+  (optional but needed for a good MoE/attention byte model).
+- `peaks.md` — hardware denominators, keyed by `gfx`.
+- Optionally, captured shapes from the Kernel Extractor and/or rocprofv3 counters (stage B/C, §5).
+
+## 2. Output artifact
+
+Write `profile/round_<R>/profile_roofline.json` and a human-readable `profile_roofline.md` beside it.
+
+```jsonc
+{
+  "skill": "roofline", "skill_version": "1",
+  "gfx": "gfx950",
+  "peaks": { "hbm_bw_bytes_s": 8.0e12, "flops": {"fp8": 5.0e15},
+             "source": "table|derived", "confidence": "high|low" },
+  "stage": "A|B|C",
+  "entries": [{
+    "name": "...", "short_name": "...",
+    "pct_gpu_time": 26.45,              // COPIED verbatim from the Top-N, never recomputed
+    "regime": "decode|prefill",
+    "op_class": "gemm|moe|attn|elementwise|unknown",
+    "modeled": true,
+    "t_ms": 0.049471,                   // per-launch time for this regime
+    "launches_per_step": 80,
+    "bytes_est": 0, "flops_est": 0,
+    "achieved_bw_bytes_s": 0, "achieved_flops": 0,
+    "arithmetic_intensity": 4.6, "ridge_point": 625.0,
+    "bound_type": "memory|compute",
+    "roofline_pct": 0.88,               // achieved / peak on the binding axis
+    "target_eff": 0.90,
+    "attainable_speedup": 1.023,
+    "expected_e2e_gain_pct": 0.59,
+    "headroom_class": "underperforming|moderate|saturated|unknown",
+    "confidence": "low|medium|high",
+    "suspect": false,
+    "byte_reduction_levers": ["..."],   // populated only when headroom_class=saturated
+    "notes": "assumptions made, what would sharpen this"
+  }],
+  "ranking_by_pct": ["..."],            // BOTH rankings are emitted, side by side
+  "ranking_by_expected_gain": ["..."],
+  "degraded": [ {"name": "...", "reason": "..."} ],
+  "skill_errors": []
+}
+```
+
+`ranking_by_pct` and `ranking_by_expected_gain` are **both** emitted deliberately. The consumer must
+see the disagreement rather than a single blended number that hides it.
+
+## 3. Procedure
+
+1. Resolve peaks for `gfx` from `peaks.md`. Not found → derive from device props, set
+   `peaks.confidence="low"` (§6 L1).
+2. For each Top-N entry, pick the **e2e-critical regime** — the one carrying the launches
+   (`serving.n_decode_steps` vs `n_prefill_steps`; a decode-dominated run means decode). Use that
+   regime's `base_latency_ms` as `t_ms`.
+3. Classify `op_class` from `name`/`classification`/shapes.
+4. Apply the §4 byte/FLOP model for that class. Cannot model it → §6 L2 (degrade this entry only).
+5. Compute:
+   ```
+   achieved_bw    = bytes_est / t
+   achieved_flops = flops_est / t
+   AI             = flops_est / bytes_est
+   ridge_point    = peak_flops / peak_bw
+   bound_type     = "compute" if AI > ridge_point else "memory"
+   roofline_pct   = achieved_bw/peak_bw   (memory)   |   achieved_flops/peak_flops (compute)
+   attainable_speedup    = max(1.0, target_eff / roofline_pct)
+   expected_e2e_gain_pct = pct_gpu_time × (1 − 1/attainable_speedup)
+   ```
+6. Classify headroom, banded against `target_eff` (**not** against the raw roofline — what matters is
+   the distance to what a good implementation of this class can realistically reach):
+   `roofline_pct ≥ 0.9×target_eff` → **saturated**; `≥ 0.6×target_eff` → **moderate**; else →
+   **underperforming**; unmodelled or low-confidence → **unknown**.
+   *88% against a 0.90 target is **saturated**, not "nearly there" — tuning has nothing left to give.*
+7. Sanity-check (§6 L3), emit both rankings, write the artifact.
+
+**Per-launch, not aggregate.** Compare bytes for ONE launch against ONE launch's `base_latency_ms`. If
+a logical op is split across several launches (e.g. a fused-MoE layer issuing a stage-1 and a stage-2
+kernel), sum the launches for one logical unit and compare against the summed time. Getting this
+factor wrong is the single most common way to produce a nonsense `roofline_pct` — state in `notes`
+which unit you used.
+
+## 4. Byte / FLOP models by op class
+
+Weight bytes use the **weight** dtype (fp8 = 1 B/elem, bf16 = 2 B). Activation bytes use the activation
+dtype. Only count HBM traffic — a tensor re-read within one launch and small enough to sit in L2
+(`l2_bytes`) counts once.
+
+### dense GEMM `[M,K]×[K,N]`
+```
+flops = 2·M·N·K
+bytes = M·K·a + K·N·w + M·N·a            # A + B + C
+```
+
+### MoE / grouped expert GEMM
+The decisive question is **how many expert weights are streamed**, which dominates at decode.
+```
+pairs        = M · top_k
+experts_hit  = E · (1 − (1 − 1/E)^pairs)      # expected distinct experts touched
+flops = 2 · pairs · (per-expert MAC count for this stage)
+bytes ≈ experts_hit · (per-expert weight elems) · w   + activations
+```
+If the implementation streams **all** `E` experts regardless of routing, use `E` instead of
+`experts_hit` — and note that the difference between the two IS a byte-reduction lever (§7). When
+unsure which the kernel does, compute both, report the `experts_hit` figure, and put the all-expert
+figure in `notes`.
+
+### attention (paged decode)
+KV traffic dominates; Q and the output are negligible at decode.
+```
+bytes ≈ batch · seq_len · n_kv_heads · head_dim · 2 (K and V) · kv_dtype_bytes
+flops ≈ 2 · batch · n_q_heads · seq_len · head_dim · 2 (QK^T and PV)
+```
+`seq_len` is the *current* average context, not the max — for an isl/osl workload sampled mid-run,
+`isl + osl/2` is a reasonable estimate. Say so in `notes`; it is a real source of error.
+
+### elementwise / norm / quant
+```
+bytes = (input elems · in_dtype) + (output elems · out_dtype)
+flops = small — assume memory-bound unless clearly otherwise
+```
+
+### unknown
+Do not guess. Emit `modeled: false` and degrade this entry (§6 L2).
+
+## 5. Confidence stages — the estimate sharpens as the run proceeds
+
+| stage | source of shapes/bytes | confidence | consumer may |
+|---|---|---|---|
+| **A** profile time | `est_shape`/`shapes` from the Top-N, model `config.json` | `low` | display + annotate only — **do not rank on it** |
+| **B** after extract | the REAL shapes/dtypes the Kernel Extractor captured for the unittest | `medium` | rank as a secondary key |
+| **C** after op_bench | rocprofv3 counters on the isolated op (measured bytes/FLOPs) | `high` | rank as a secondary key; may be cited in the report |
+
+Stage A is inherently coarse: at profile time the exact operand shapes have not been captured yet.
+**Re-run this skill at stage B/C and overwrite the artifact.** Because the decision to spend the *next*
+budget unit happens after the *previous* kernel's extract, refined numbers arrive in time to matter.
+
+### Stage C — counter measurement (rocprofv3)
+Measure on the ISOLATED op (the Op Benchmarker already has it isolated — no extra server run):
+- bytes: `FETCH_SIZE` + `WRITE_SIZE` (both in **KiB**) → `(FETCH_SIZE + WRITE_SIZE) · 1024`
+- FLOPs: `MfmaFlops`, or `MfmaFlopsBF16`/`F16`/`F32`/`F64` per dtype
+- **fp8 has no `MfmaFlopsF8`** on current builds — use `SQ_INSTS_VALU_MFMA_MOPS_F8` and convert
+  MFMA-ops → FLOPs for the instruction shape in play.
+- corroborate `bound_type` with `MemUnitStalled`, `MfmaUtil`, `OccupancyPercent`.
+
+Counter names and availability vary by ROCm build. Probe with `rocprofv3 --list-avail`; a missing
+counter degrades to stage A/B (§6 L4), it does not fail the skill.
+
+## 6. Degradation ladder — every level is non-fatal
+
+| level | trigger | behavior |
+|---|---|---|
+| **L0** | `analysis_skill=none`, skill dir missing/unreadable | Emit nothing. Caller behaves exactly as before this feature existed. |
+| **L1** | `gfx` absent from `peaks.md` | Derive peaks from device props; `peaks.confidence="low"` → every entry is `confidence: low` → display-only. |
+| **L2** | an op class cannot be modelled | Degrade **that entry only**: `modeled:false`, `headroom_class:"unknown"`, add to `degraded[]`. Other entries are unaffected and the consumer falls back to the pre-skill prior for this one. |
+| **L3** | result is impossible: `roofline_pct > 1.0`, or `< 0.001`, or a negative/zero byte count | Clamp to `[0,1]`, set `suspect:true`, downgrade to display-only, and flag the entry as a **stage-C counter-measurement candidate**. Record the raw value in `notes`. |
+| **L4** | counters unavailable / unstable | Keep the stage-A/B analytic result; do not raise confidence. |
+| **L5** | anything else raises | Catch it, append to `skill_errors[]`, write whatever entries succeeded, and continue. **The run never fails because of this skill.** |
+
+`roofline_pct > 1.0` is a real and expected occurrence — it usually means the byte model over-counts
+(e.g. assuming all experts are streamed when the kernel skips unrouted ones). Treat it as a signal that
+the model needs stage-C measurement, not as a hardware anomaly.
+
+## 7. `target_eff` and how to route on the result
+
+`target_eff` = how close a **well-implemented** kernel of this class gets to its roofline bound. It is
+set by **access regularity**, not by how important the kernel is.
+
+| op class | `target_eff` | why |
+|---|---|---|
+| dense GEMM | **0.90** | regular, dense compute |
+| MoE / grouped GEMM | **0.90** | decode weight streaming is essentially a memcpy |
+| elementwise / norm / quant | 0.85–0.90 | pure streaming |
+| attention decode (paged) | **0.50** | irregular paged KV access, occupancy-sensitive |
+
+These are **priors, not constants** — §8 corrects them from observed outcomes.
+
+### Routing table (the actual point of this skill)
+
+| `headroom_class` | `pct_gpu_time` | route |
+|---|---|---|
+| underperforming | high | **kernel track, top priority** — real micro-optimization headroom |
+| **saturated** | **high** | **byte-reduction / algorithmic track — NOT dropped** (§7.1) |
+| any | low | low priority (ordinary Amdahl) |
+| unknown, or `confidence: low` | any | **fall back entirely to `pct_gpu_time` ordering** |
+
+### 7.1 Saturated + high `pct_gpu_time` → byte-reduction levers
+
+The biggest kernel stays the biggest target; only the *class of fix* changes. Enumerate levers that
+make the kernel move **fewer bytes for the same work**:
+
+- **Fuse an adjacent op away.** If a prologue/epilogue kernel (activation quant, silu, a norm) appears
+  separately in the Top-N, fusing it into the saturated kernel removes an entire activation round-trip
+  — and removes that kernel's own GPU time too.
+- **Stop reading what isn't used.** If the kernel streams all `E` experts but routing only touches
+  `experts_hit`, the difference is pure waste.
+- **Layout / packing.** Remove padding waste, improve coalescing, improve L2 reuse between stages of
+  the same logical op.
+- **Lower-precision weights** (e.g. fp8 → fp4). Directly cuts bytes. **Lossy — must pass the accuracy
+  gate.**
+
+**Hard constraints on every byte-reduction lever (do not violate):**
+> The **measurement contract and output semantics are fixed.** The workload — `isl`, `osl`,
+> **`conc` / batch size — is supplied by the user and must not be changed**. Do **not** introduce
+> speculative decoding (MTP or otherwise) as an optimization. A lever that raises throughput by
+> changing what is being measured is not a win. Lossy levers (fp4, kv-cache-dtype) must pass the
+> accuracy gate before they count.
+
+## 8. Guarding against being wrong
+
+1. **Sanity band** — §6 L3.
+2. **Contradiction check.** If a kernel squad measures an isolated speedup **larger** than this skill's
+   `attainable_speedup`, the model was wrong. Flag it, and prefer the measurement — always.
+3. **Self-correction across runs.** Record `predicted vs actual` (predicted `attainable_speedup` and
+   `expected_e2e_gain_pct` vs measured isolated speedup and measured e2e delta) into
+   `knowledge/backend_playbook.md`, which already grows every run. Systematic error in a class's
+   `target_eff` or byte model shows up there and is corrected in the next run.
+4. **Never sole authority.** No candidate is ever pruned because of this skill; no result is ever
+   accepted because of it. The e2e gate decides.
+
+## 9. Worked example (real data — Qwen3.5-35B-A3B-FP8, gfx950, vLLM, TP1, isl/osl 1k, conc 64)
+
+Decode-dominated (2033 decode steps vs 24 prefill). Peaks: 8.0 TB/s HBM, 5.0 PFLOP/s fp8.
+
+**`fused_moe_kernel`** — `pct_gpu_time` 26.45%, decode `t` = 49.47 µs/launch, 80 launches/step over 40
+layers ⇒ 2 launches per layer ⇒ one logical layer = 98.9 µs.
+E=256, top_k=8, hidden=2048, moe_intermediate=512, fp8 weights. At M=64, `pairs`=512 ⇒
+`experts_hit` ≈ 221/256. Layer weight bytes ≈ 697 MB (all-expert: 805 MB).
+⇒ achieved 7.04 TB/s = **88% of roofline**, AI ≈ 4.6 ≪ ridge 625 ⇒ **memory-bound**.
+⇒ `attainable_speedup` = 0.90/0.88 = **1.023×**, `expected_e2e_gain_pct` = **+0.59%** → **saturated**.
+*(All-expert bytes give 102% — an L3 `suspect` case, and evidence for the "stop reading unused
+experts" lever.)*
+
+**`kernel_paged_attention_2d`** — `pct_gpu_time` 8.86%, decode `t` = 141.1 µs, 10 launches/step
+(= the 10 full-attention layers of 40, `full_attention_interval`=4).
+⇒ achieved ≈ 1.4–2.3 TB/s = **18–29% of roofline** ⇒ `attainable_speedup` ≈ **1.7–2.8×**,
+`expected_e2e_gain_pct` ≈ **+3.7%** → **underperforming**.
+
+**Why this matters:** ranking by `pct_gpu_time` puts MoE first (26.45% vs 8.86%). Ranking by roofline
+headroom puts attention first. The run that produced these numbers spent its budget on the MoE and
+measured **−0.064% e2e** (isolated 1.047×, predicted 1.023× ✅); the attention kernel it reached later
+yielded **1.56× isolated** (predicted 1.7× ✅). Both predictions were calibrated — and the MoE was
+correctly identified as needing a byte-reduction lever, not another tuning pass.

--- a/e2e_workflow/knowledge/analysis_skills/roofline/SKILL.md
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/SKILL.md
@@ -54,9 +54,10 @@ Write `profile/round_<R>/profile_roofline.json` and a human-readable `profile_ro
     "launches_per_step": 80,
     "bytes_est": 0, "flops_est": 0,
     "achieved_bw_bytes_s": 0, "achieved_flops": 0,
+    "hbm_util": 0.88, "compute_util": 0.01,   // achieved/peak on each axis; the pair decides bound_type
     "arithmetic_intensity": 4.6, "ridge_point": 625.0,
-    "bound_type": "memory|compute",
-    "roofline_pct": 0.88,               // achieved / peak on the binding axis
+    "bound_type": "memory|compute|latency|unknown",  // latency = neither roof near its ceiling
+    "roofline_pct": 0.88,               // achieved / peak on the AI-selected roof
     "target_eff": 0.90,
     "attainable_speedup": 1.023,
     "expected_e2e_gain_pct": 0.59,
@@ -94,13 +95,30 @@ see the disagreement rather than a single blended number that hides it.
    ```
    achieved_bw    = bytes_est / t
    achieved_flops = flops_est / t
+   hbm_util       = achieved_bw    / peak_bw
+   compute_util   = achieved_flops / peak_flops
    AI             = flops_est / bytes_est
    ridge_point    = peak_flops / peak_bw
-   bound_type     = "compute" if AI > ridge_point else "memory"
-   roofline_pct   = achieved_bw/peak_bw   (memory)   |   achieved_flops/peak_flops (compute)
+
+   # AI picks which roof the kernel walks TOWARD; roofline_pct is measured on that roof.
+   roof_axis    = "compute" if AI > ridge_point else "memory"
+   roofline_pct = compute_util if roof_axis == "compute" else hbm_util
+
+   # But which roof actually BINDS is decided by utilization, not by AI alone. A small AI does NOT
+   # by itself mean memory-bound — that is the most common mislabel. If neither roof is near its
+   # ceiling (both utils < 0.60) and the launch is above the dispatch floor, the kernel is
+   # LATENCY / occupancy-bound, not bandwidth- or compute-bound.
+   bound_type   = "latency" if (hbm_util < 0.60 and compute_util < 0.60) else roof_axis
+
    attainable_speedup    = max(1.0, target_eff / roofline_pct)
    expected_e2e_gain_pct = pct_gpu_time × (1 − 1/attainable_speedup)
    ```
+   A latency-bound kernel **still gets a headroom verdict** (its `roofline_pct` on the AI-selected
+   roof is real, and `target_eff` already prices in the occupancy penalty for irregular classes like
+   paged attention) — so a low-utilization head still ranks by its headroom. What changes is the
+   **lever**: latency-bound underperformance is fixed by occupancy / shorter dependency chains /
+   fusion, **not** by byte reduction (§7.1). Byte reduction only helps a genuinely bandwidth-bound
+   (high-`hbm_util`) head.
 6. Classify headroom, banded against `target_eff` (**not** against the raw roofline — what matters is
    the distance to what a good implementation of this class can realistically reach):
    `roofline_pct ≥ 0.9×target_eff` → **saturated**; `≥ 0.6×target_eff` → **moderate**; else →
@@ -111,10 +129,14 @@ see the disagreement rather than a single blended number that hides it.
    is not evidence about the kernel:
    - **Dispatch-bound** — the per-launch time is within launch-overhead scale (~5 µs), so the launch is
      timed by dispatch, not by its transfer or its math. Emit `bound_type: "latency"`; the lever is
-     fusion / graph capture, not kernel tuning. Typical of tiny high-call-count kernels.
+     fusion / graph capture, not kernel tuning. Typical of tiny high-call-count kernels. *This is the
+     no-verdict sub-case of latency-bound* — distinct from the general latency-bound kernel in step 5
+     (low utilization but well above the dispatch floor), which **keeps its verdict** because it is
+     doing real work and has recoverable occupancy/dependency headroom.
    - **Infeasible** — `roofline_pct` outside `(0,1]`. That is the byte/FLOP model being wrong, not the
      kernel being at the wall. **A clamped 100% must NEVER be reported as `saturated`** — that turns a
-     modelling failure into a routing decision. See §6 L3.
+     modelling failure into a routing decision. A compute-axis ratio above 1.0 is most often an
+     **unvalidated peak** (the BF16 MFMA microbench commonly reads ~2× low; see §4). See §6 L3.
 
    `bound_type` is a CLOSED set: `memory | compute | latency | unknown`. If none fits, emit `unknown`
    — never invent a category the consumer has no routing rule for.
@@ -131,6 +153,14 @@ which unit you used.
 Weight bytes use the **weight** dtype (fp8 = 1 B/elem, bf16 = 2 B). Activation bytes use the activation
 dtype. Only count HBM traffic — a tensor re-read within one launch and small enough to sit in L2
 (`l2_bytes`) counts once.
+
+**Trust the memory axis over the compute axis, especially at decode.** The compute peaks in `peaks.md`
+are validated for fp8, but empirical MFMA peaks are not always right — the BF16 microbench commonly
+reads ~2× low, which makes a BF16 `compute_util` read ~2× high (and can push `roofline_pct` above 1.0,
+where §6 L3 catches it as `suspect`). A decode workload is memory-bound anyway, so prefer `hbm_util`;
+only rank on a compute-axis `roofline_pct` after the peak for that dtype has been validated (§8 rule:
+BF16 and FP16 MFMA run at the same rate, so those two peaks must be equal — if they are not, the peak
+is mis-calibrated and the compute-axis number is not usable).
 
 ### dense GEMM `[M,K]×[K,N]`
 ```
@@ -229,12 +259,21 @@ These are **priors, not constants** — §8 corrects them from observed outcomes
 
 ### Routing table (the actual point of this skill)
 
-| `headroom_class` | `pct_gpu_time` | route |
-|---|---|---|
-| underperforming | high | **kernel track, top priority** — real micro-optimization headroom |
-| **saturated** | **high** | **byte-reduction / algorithmic track — NOT dropped** (§7.1) |
-| any | low | low priority (ordinary Amdahl) |
-| unknown, or `confidence: low` | any | **fall back entirely to `pct_gpu_time` ordering** |
+| `headroom_class` | `bound_type` | `pct_gpu_time` | route |
+|---|---|---|---|
+| underperforming | memory / compute | high | **kernel track, top priority** — real micro-optimization headroom |
+| underperforming | latency | high | kernel track — but the lever is **occupancy / dependency-chain / fusion / split-K**, not byte reduction |
+| **saturated** | memory | **high** | **byte-reduction / algorithmic track — NOT dropped** (§7.1) |
+| saturated | latency | high | occupancy/access-pattern is the ceiling — fewer bytes (e.g. fp8 KV) or fusion; not more tuning |
+| any | any | low | low priority (ordinary Amdahl) |
+| unknown, or `confidence: low` | any | any | **fall back entirely to `pct_gpu_time` ordering** |
+
+**Shippability gate (applies before any of the above).** A head kernel with no editable call site —
+a monolithic hand-written assembly `.co` or a precompiled CK `.so` — cannot take an in-kernel rewrite
+no matter how much headroom it shows. Its only levers are **host-side**: dispatch/path selection, the
+tuning DB (`tuned_fmoe`, `AITER_CONFIG_*`), or a backend swap. When the profiler marks an entry
+non-editable, route it to the host-side track and say so; do not dispatch a rewrite that cannot be
+integrated. (The `editable` flag comes from the profiler's Top-N, not from this skill.)
 
 ### 7.1 Saturated + high `pct_gpu_time` → byte-reduction levers
 
@@ -261,13 +300,22 @@ make the kernel move **fewer bytes for the same work**:
 ## 8. Guarding against being wrong
 
 1. **Sanity band** — §6 L3.
-2. **Contradiction check.** If a kernel squad measures an isolated speedup **larger** than this skill's
+2. **Validate the peak before believing a `roofline_pct`.** The peaks are empirical microbench
+   results, not spec figures. The load-bearing cross-check: BF16 and FP16 MFMA run at the same rate on
+   these parts, so their peaks must be equal — when they are not, the compute-axis number is inflated
+   (a "kernel at 85%" may really be at 43%). Trivial streaming also tops out near ~0.85 of the HBM pin
+   rate, which is why the memory `target_eff` is 0.90, not 1.0.
+3. **Two noise bands, not one.** An **isolated-kernel** speedup is real only if it clears the
+   isolated repeat band (**~3.4%** on identical reruns here — much wider than people assume), while an
+   **e2e serving** delta uses the serving band (~0.5%). Do not judge an isolated kernel win against the
+   e2e band, and never call a sub-3.4% isolated speedup real.
+4. **Contradiction check.** If a kernel squad measures an isolated speedup **larger** than this skill's
    `attainable_speedup`, the model was wrong. Flag it, and prefer the measurement — always.
-3. **Self-correction across runs.** Record `predicted vs actual` (predicted `attainable_speedup` and
+5. **Self-correction across runs.** Record `predicted vs actual` (predicted `attainable_speedup` and
    `expected_e2e_gain_pct` vs measured isolated speedup and measured e2e delta) into
    `knowledge/backend_playbook.md`, which already grows every run. Systematic error in a class's
    `target_eff` or byte model shows up there and is corrected in the next run.
-4. **Never sole authority.** No candidate is ever pruned because of this skill; no result is ever
+6. **Never sole authority.** No candidate is ever pruned because of this skill; no result is ever
    accepted because of it. The e2e gate decides.
 
 ## 9. Worked example (real data — Qwen3.5-35B-A3B-FP8, gfx950, vLLM, TP1, isl/osl 1k, conc 64)

--- a/e2e_workflow/knowledge/analysis_skills/roofline/SKILL.md
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/SKILL.md
@@ -78,9 +78,14 @@ see the disagreement rather than a single blended number that hides it.
 
 ## 3. Procedure
 
+0. **Scope to the head.** Analyse ONLY entries with `pct_gpu_time >= HEAD_THRESHOLD_PCT` (default 5),
+   biggest first, capped at ~8. Below that bar the Amdahl ceiling is under the noise band no matter
+   what the roofline says, so a headroom estimate cannot change a decision — modelling those kernels
+   only adds failure modes. Skipped entries are **absent** from the artifact; they are NOT `degraded[]`
+   (a kernel too small to matter is not a modelling failure and must not read as one).
 1. Resolve peaks for `gfx` from `peaks.md`. Not found → derive from device props, set
    `peaks.confidence="low"` (§6 L1).
-2. For each Top-N entry, pick the **e2e-critical regime** — the one carrying the launches
+2. For each selected entry, pick the **e2e-critical regime** — the one carrying the launches
    (`serving.n_decode_steps` vs `n_prefill_steps`; a decode-dominated run means decode). Use that
    regime's `base_latency_ms` as `t_ms`.
 3. Classify `op_class` from `name`/`classification`/shapes.
@@ -101,6 +106,18 @@ see the disagreement rather than a single blended number that hides it.
    `roofline_pct ≥ 0.9×target_eff` → **saturated**; `≥ 0.6×target_eff` → **moderate**; else →
    **underperforming**; unmodelled or low-confidence → **unknown**.
    *88% against a 0.90 target is **saturated**, not "nearly there" — tuning has nothing left to give.*
+
+   **Two outcomes must produce NO verdict** (`headroom_class: "unknown"`), because in each the ratio
+   is not evidence about the kernel:
+   - **Dispatch-bound** — the per-launch time is within launch-overhead scale (~5 µs), so the launch is
+     timed by dispatch, not by its transfer or its math. Emit `bound_type: "latency"`; the lever is
+     fusion / graph capture, not kernel tuning. Typical of tiny high-call-count kernels.
+   - **Infeasible** — `roofline_pct` outside `(0,1]`. That is the byte/FLOP model being wrong, not the
+     kernel being at the wall. **A clamped 100% must NEVER be reported as `saturated`** — that turns a
+     modelling failure into a routing decision. See §6 L3.
+
+   `bound_type` is a CLOSED set: `memory | compute | latency | unknown`. If none fits, emit `unknown`
+   — never invent a category the consumer has no routing rule for.
 7. Sanity-check (§6 L3), emit both rankings, write the artifact.
 
 **Per-launch, not aggregate.** Compare bytes for ONE launch against ONE launch's `base_latency_ms`. If
@@ -133,6 +150,12 @@ If the implementation streams **all** `E` experts regardless of routing, use `E`
 `experts_hit` — and note that the difference between the two IS a byte-reduction lever (§7). When
 unsure which the kernel does, compute both, report the `experts_hit` figure, and put the all-expert
 figure in `notes`.
+
+**Feasibility rule (general, applies to every op class with more than one plausible byte model).**
+A byte estimate implying a rate above peak is refuted by the measurement itself. When you have
+several candidate models, pick the **largest one that stays feasible** (`bytes ≤ peak_bw × t`) and say
+which you used. If *every* candidate is infeasible, the class model is wrong: emit no verdict (§6 L3)
+rather than clamping to 100% and calling it saturated.
 
 ### attention (paged decode)
 KV traffic dominates; Q and the output are negligible at decode.
@@ -182,7 +205,7 @@ counter degrades to stage A/B (§6 L4), it does not fail the skill.
 | **L0** | `analysis_skill=none`, skill dir missing/unreadable | Emit nothing. Caller behaves exactly as before this feature existed. |
 | **L1** | `gfx` absent from `peaks.md` | Derive peaks from device props; `peaks.confidence="low"` → every entry is `confidence: low` → display-only. |
 | **L2** | an op class cannot be modelled | Degrade **that entry only**: `modeled:false`, `headroom_class:"unknown"`, add to `degraded[]`. Other entries are unaffected and the consumer falls back to the pre-skill prior for this one. |
-| **L3** | result is impossible: `roofline_pct > 1.0`, or `< 0.001`, or a negative/zero byte count | Clamp to `[0,1]`, set `suspect:true`, downgrade to display-only, and flag the entry as a **stage-C counter-measurement candidate**. Record the raw value in `notes`. |
+| **L3** | result is impossible: `roofline_pct > 1.0`, or `< 0.001`, or a negative/zero byte count | Clamp for display, set `suspect:true`, **force `headroom_class:"unknown"`** (an infeasible ratio is not a verdict), keep `roofline_pct_raw`, emit `bytes_upper_bound = peak_bw × t` (what the model violated), and flag the entry as a **stage-C counter-measurement candidate**. |
 | **L4** | counters unavailable / unstable | Keep the stage-A/B analytic result; do not raise confidence. |
 | **L5** | anything else raises | Catch it, append to `skill_errors[]`, write whatever entries succeeded, and continue. **The run never fails because of this skill.** |
 

--- a/e2e_workflow/knowledge/analysis_skills/roofline/peaks.md
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/peaks.md
@@ -6,6 +6,13 @@ Peaks are **dense, no-sparsity, sustained-achievable-ceiling** figures. HBM band
 *theoretical pin* rate — real streaming kernels top out near 0.85–0.92 of it, which is exactly what
 `target_eff` in `SKILL.md` encodes. Do not pre-derate the numbers here.
 
+**Compute peaks need validation; the memory axis is the trustworthy one.** BF16 and FP16 MFMA run at
+the same rate on these parts, so the two `flops` entries below must be **equal** — they are, and that
+equality is the check to keep. Empirical MFMA microbenchmarks (e.g. from rocprof-compute) frequently
+report a BF16 peak ~2× low, which inflates any BF16 compute-axis `roofline_pct` (sometimes above 100%,
+where `SKILL.md` §6 L3 flags it `suspect`). At decode, prefer `hbm_util` and only rank on a
+compute-axis number once its dtype peak has been validated against this equality.
+
 ## gfx950 — CDNA4, MI350X / MI355X class
 ```yaml
 gfx: gfx950

--- a/e2e_workflow/knowledge/analysis_skills/roofline/peaks.md
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/peaks.md
@@ -1,0 +1,50 @@
+# Hardware peaks — roofline denominators
+
+Pure data. One section per `gfx`. Extend by adding a section; nothing else needs to change.
+
+Peaks are **dense, no-sparsity, sustained-achievable-ceiling** figures. HBM bandwidth is the
+*theoretical pin* rate — real streaming kernels top out near 0.85–0.92 of it, which is exactly what
+`target_eff` in `SKILL.md` encodes. Do not pre-derate the numbers here.
+
+## gfx950 — CDNA4, MI350X / MI355X class
+```yaml
+gfx: gfx950
+cu: 256
+hbm_bw_bytes_s: 8.0e12        # HBM3E, ~8 TB/s
+flops:                         # dense matrix-core peaks, FLOP/s
+  fp64: 7.86e13
+  fp32: 1.57e14
+  bf16: 2.5e15
+  fp16: 2.5e15
+  fp8:  5.0e15
+  fp4:  1.0e16
+l2_bytes: 4194304
+```
+
+## gfx942 — CDNA3, MI300X class
+```yaml
+gfx: gfx942
+cu: 304
+hbm_bw_bytes_s: 5.3e12        # HBM3, ~5.3 TB/s
+flops:
+  fp64: 1.63e14
+  fp32: 1.63e14
+  bf16: 1.31e15
+  fp16: 1.31e15
+  fp8:  2.61e15
+l2_bytes: 4194304
+```
+
+## Unknown gfx — derived fallback (confidence: low)
+
+If the running `gfx` has no section above, DERIVE from `torch.cuda.get_device_properties(0)` and mark
+`peaks.source="derived"`, `peaks.confidence="low"`:
+
+```
+hbm_bw_bytes_s ≈ memory_clock_rate_hz × (memory_bus_width_bits / 8) × 2     # DDR
+flops[dtype]   ≈ multi_processor_count × clock_rate_hz × mfma_flops_per_cycle_per_cu[dtype]
+```
+
+The derived bandwidth is **frequently wrong for HBM3/3E** — the reported memory clock often understates
+the effective pin rate (on gfx950 it derives ~4.1 TB/s against a real ~8 TB/s). Treat any derived-peak
+result as `confidence: low`, which per `SKILL.md` means **display only, do not rank on it**.

--- a/e2e_workflow/knowledge/analysis_skills/roofline/roofline_tools.py
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/roofline_tools.py
@@ -51,6 +51,12 @@ DEFAULT_TOP_N = 8
 LAUNCH_OVERHEAD_S = 5e-6
 LATENCY_BOUND_FACTOR = 2.0
 
+#: A roof (memory or compute) counts as the binding limiter only when the kernel actually gets near
+#: it. Below this utilization on BOTH axes -- and above the dispatch floor -- the kernel is
+#: latency/occupancy-bound, NOT bandwidth- or compute-bound. This is the single most common mislabel:
+#: a small arithmetic intensity does not by itself make a kernel memory-bound.
+UTIL_BOUND_THRESHOLD = 0.60
+
 #: The only bound types this skill may emit. Anything else is a modelling escape and must degrade
 #: to "unknown" rather than inventing a category the consumer has no routing rule for.
 BOUND_TYPES = ("memory", "compute", "latency", "unknown")
@@ -214,21 +220,25 @@ def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_
     ai = (f / b) if b > 0 else float("inf")
     ridge = (pfl / pbw) if (pfl > 0 and pbw > 0) else None
 
+    # AI picks which roof the kernel is walking TOWARD (the ceiling it would hit if it stopped
+    # stalling); utilization tells whether it is actually near that roof. Both are needed -- a small
+    # AI does NOT by itself mean memory-bound. roofline_pct is measured on the AI-selected roof.
     compute_bound = bool(ridge is not None and pfl > 0 and ai > ridge)
-    if compute_bound:
-        raw_pct, bound = achieved_flops / pfl, "compute"
-    else:
-        raw_pct, bound = achieved_bw / pbw, "memory"
+    hbm_util = achieved_bw / pbw
+    compute_util = (achieved_flops / pfl) if pfl > 0 else 0.0
+    raw_pct = compute_util if compute_bound else hbm_util
+    roof_axis = "compute" if compute_bound else "memory"
 
     out = {
         "bytes_est": b, "flops_est": f, "t_ms": t * 1e3,
         "achieved_bw_bytes_s": achieved_bw, "achieved_flops": achieved_flops,
+        "hbm_util": hbm_util, "compute_util": compute_util,
         "arithmetic_intensity": ai, "ridge_point": ridge,
         "roofline_pct_raw": raw_pct, "target_eff": tgt, "suspect": False,
     }
 
-    # A launch timed by dispatch rather than by its own transfer/math: a roofline ratio says nothing
-    # about it. Report it as such instead of a bogus efficiency; the lever is fusion, not tuning.
+    # (1) Dispatch-bound by time: the launch is timed by scheduling overhead, not by its own transfer
+    # or math, so no roofline ratio applies. No verdict; the lever is fusion / graph capture.
     if t <= float(launch_overhead_s or 0) * LATENCY_BOUND_FACTOR:
         out.update(bound_type="latency", roofline_pct=min(max(raw_pct, 0.0), 1.0),
                    attainable_speedup=1.0, expected_e2e_gain_pct=0.0,
@@ -237,11 +247,12 @@ def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_
                         "roofline not applicable, lever is fusion / graph capture")
         return out
 
-    # L3 sanity band. An impossible ratio means the byte/FLOP model is wrong, NOT that the kernel is
-    # at the wall -- so it must not yield a verdict. Clamp for display, refuse to classify, and hand
-    # back the feasibility bound that the model violated so stage C knows what to measure.
+    # (2) Infeasible: raw_pct outside (0,1] means the byte/FLOP model is wrong, NOT that the kernel is
+    # at the wall -- so it must not yield a verdict. (A compute-axis >100% is usually an unvalidated
+    # peak, e.g. the BF16 MFMA microbench reading ~2x low.) Clamp for display, refuse to classify, and
+    # hand back the feasibility bound the model violated so stage C knows what to measure.
     if not (0.001 <= raw_pct <= 1.0):
-        out.update(bound_type=bound, roofline_pct=min(max(raw_pct, 0.0), 1.0),
+        out.update(bound_type=roof_axis, roofline_pct=min(max(raw_pct, 0.0), 1.0),
                    attainable_speedup=1.0, expected_e2e_gain_pct=0.0,
                    headroom_class="unknown", suspect=True,
                    bytes_upper_bound=pbw * t, flops_upper_bound=(pfl * t) if pfl > 0 else None,
@@ -249,6 +260,16 @@ def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_
                         "re-estimate with a tighter model or measure with counters (stage C)"
                         % raw_pct)
         return out
+
+    # (3) True limiter by utilization. If NEITHER roof is near its ceiling (and we already ruled out
+    # the dispatch floor), the kernel is latency/occupancy-bound. It still has recoverable headroom --
+    # keep the verdict, so a low-utilization head like paged attention still ranks by its headroom --
+    # but the lever is occupancy / shorter dependency chains / fusion, NOT byte reduction (which only
+    # helps a genuinely bandwidth-bound, high-util head).
+    if compute_util < UTIL_BOUND_THRESHOLD and hbm_util < UTIL_BOUND_THRESHOLD:
+        bound = "latency"
+    else:
+        bound = roof_axis
 
     attainable = max(1.0, tgt / raw_pct)
     out.update(bound_type=bound, roofline_pct=raw_pct, attainable_speedup=attainable,
@@ -373,10 +394,14 @@ def _selftest():
                             2 * B * 16 * S * hd * 2, 141.112e-6,
                             peaks["hbm_bw_bytes_s"], peak_flops_for(peaks, "bf16"),
                             TARGET_EFF["attn"], pct_gpu_time=8.86)
-    print("Attn  : %.0f%% of roofline, %s, %.2fx, +%.2f%% e2e (%s)"
-          % (100 * attn["roofline_pct"], attn["bound_type"], attn["attainable_speedup"],
-             attn["expected_e2e_gain_pct"], attn["headroom_class"]))
-    ok &= (attn["headroom_class"] == "underperforming" and attn["attainable_speedup"] > 1.4
+    print("Attn  : %.0f%% of roofline (hbm_util %.0f%%, compute_util %.1f%%), %s, %.2fx, +%.2f%% e2e (%s)"
+          % (100 * attn["roofline_pct"], 100 * attn["hbm_util"], 100 * attn["compute_util"],
+             attn["bound_type"], attn["attainable_speedup"], attn["expected_e2e_gain_pct"],
+             attn["headroom_class"]))
+    # low util on both axes above the dispatch floor -> latency/occupancy-bound, but the verdict is
+    # KEPT (real headroom) so the ranking inversion below survives.
+    ok &= (attn["bound_type"] == "latency" and attn["headroom_class"] == "underperforming"
+           and attn["attainable_speedup"] > 1.4
            and attn["expected_e2e_gain_pct"] > moe["expected_e2e_gain_pct"])
 
     # the whole point: the two rankings disagree, and roofline is the one that matched reality

--- a/e2e_workflow/knowledge/analysis_skills/roofline/roofline_tools.py
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/roofline_tools.py
@@ -38,6 +38,37 @@ TARGET_EFF = {
     "attn": 0.50,
 }
 
+#: Only kernels big enough for a headroom estimate to change a decision are worth analysing.
+#: Below this the Amdahl ceiling is under the noise band anyway, so modelling them adds failure
+#: modes without adding information. Callers should pass the run's HEAD_THRESHOLD_PCT.
+DEFAULT_MIN_PCT_GPU = 5.0
+DEFAULT_TOP_N = 8
+
+#: Kernel launch + scheduling overhead. A launch whose duration is within a small multiple of this
+#: is timed by dispatch, not by its transfer or its math, so a roofline ratio is meaningless for it
+#: (its lever is fusion / graph capture, not kernel tuning). Order-of-magnitude runtime constant,
+#: not a per-model tuning knob -- override per box if measured.
+LAUNCH_OVERHEAD_S = 5e-6
+LATENCY_BOUND_FACTOR = 2.0
+
+#: The only bound types this skill may emit. Anything else is a modelling escape and must degrade
+#: to "unknown" rather than inventing a category the consumer has no routing rule for.
+BOUND_TYPES = ("memory", "compute", "latency", "unknown")
+
+
+def select_entries(entries, min_pct_gpu=DEFAULT_MIN_PCT_GPU, top_n=DEFAULT_TOP_N):
+    """Head-scoped selection: the entries worth a roofline estimate, biggest first.
+
+    Everything below the bar is SKIPPED (absent from the artifact), not "degraded" -- a kernel too
+    small to matter is not a modelling failure and should not read as one.
+    """
+    try:
+        sel = [e for e in (entries or []) if float(e.get("pct_gpu_time") or 0) >= float(min_pct_gpu)]
+    except (TypeError, ValueError, AttributeError):
+        return []
+    sel.sort(key=lambda e: -float(e.get("pct_gpu_time") or 0))
+    return sel[:int(top_n)] if top_n else sel
+
 
 def dtype_bytes(name, default=2):
     """Element size in bytes for a dtype spelling. Unknown -> `default` (never raises)."""
@@ -161,11 +192,14 @@ def experts_hit(num_experts, pairs):
 # ---------------------------------------------------------------- the metric
 
 def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_eff,
-                     pct_gpu_time=0.0):
+                     pct_gpu_time=0.0, launch_overhead_s=LAUNCH_OVERHEAD_S):
     """Core arithmetic of SKILL.md section 3 step 5. Returns a dict, or None on unusable input.
 
-    Applies the L3 sanity band: an impossible roofline_pct is clamped and flagged `suspect`
-    (with the raw value preserved) rather than discarded.
+    Two outcomes deliberately produce NO verdict (`headroom_class="unknown"`), because in both the
+    ratio is not evidence about the kernel:
+      * dispatch-bound -- the launch is timed by overhead, not by its transfer or its math;
+      * infeasible (`raw_pct` outside (0,1]) -- the byte/FLOP model is wrong. A clamped 100% must
+        never be read as "saturated"; that would turn a modelling failure into a routing decision.
     """
     try:
         b, f, t = float(bytes_moved or 0), float(flops or 0), float(t_seconds or 0)
@@ -186,20 +220,41 @@ def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_
     else:
         raw_pct, bound = achieved_bw / pbw, "memory"
 
-    suspect = not (0.001 <= raw_pct <= 1.0)
-    pct = min(max(raw_pct, 0.0), 1.0)
-    attainable = max(1.0, tgt / pct) if pct > 0 else 1.0
-
-    return {
+    out = {
         "bytes_est": b, "flops_est": f, "t_ms": t * 1e3,
         "achieved_bw_bytes_s": achieved_bw, "achieved_flops": achieved_flops,
-        "arithmetic_intensity": ai, "ridge_point": ridge, "bound_type": bound,
-        "roofline_pct": pct, "roofline_pct_raw": raw_pct, "target_eff": tgt,
-        "attainable_speedup": attainable,
-        "expected_e2e_gain_pct": float(pct_gpu_time or 0.0) * (1.0 - 1.0 / attainable),
-        "headroom_class": classify_headroom(pct, tgt),
-        "suspect": suspect,
+        "arithmetic_intensity": ai, "ridge_point": ridge,
+        "roofline_pct_raw": raw_pct, "target_eff": tgt, "suspect": False,
     }
+
+    # A launch timed by dispatch rather than by its own transfer/math: a roofline ratio says nothing
+    # about it. Report it as such instead of a bogus efficiency; the lever is fusion, not tuning.
+    if t <= float(launch_overhead_s or 0) * LATENCY_BOUND_FACTOR:
+        out.update(bound_type="latency", roofline_pct=min(max(raw_pct, 0.0), 1.0),
+                   attainable_speedup=1.0, expected_e2e_gain_pct=0.0,
+                   headroom_class="unknown",
+                   note="per-launch time is within launch-overhead scale -> dispatch-bound; "
+                        "roofline not applicable, lever is fusion / graph capture")
+        return out
+
+    # L3 sanity band. An impossible ratio means the byte/FLOP model is wrong, NOT that the kernel is
+    # at the wall -- so it must not yield a verdict. Clamp for display, refuse to classify, and hand
+    # back the feasibility bound that the model violated so stage C knows what to measure.
+    if not (0.001 <= raw_pct <= 1.0):
+        out.update(bound_type=bound, roofline_pct=min(max(raw_pct, 0.0), 1.0),
+                   attainable_speedup=1.0, expected_e2e_gain_pct=0.0,
+                   headroom_class="unknown", suspect=True,
+                   bytes_upper_bound=pbw * t, flops_upper_bound=(pfl * t) if pfl > 0 else None,
+                   note="model infeasible (raw %.3f outside (0,1]) -> NOT a saturation verdict; "
+                        "re-estimate with a tighter model or measure with counters (stage C)"
+                        % raw_pct)
+        return out
+
+    attainable = max(1.0, tgt / raw_pct)
+    out.update(bound_type=bound, roofline_pct=raw_pct, attainable_speedup=attainable,
+               expected_e2e_gain_pct=float(pct_gpu_time or 0.0) * (1.0 - 1.0 / attainable),
+               headroom_class=classify_headroom(raw_pct, tgt))
+    return out
 
 
 def classify_headroom(roofline_pct, target_eff):

--- a/e2e_workflow/knowledge/analysis_skills/roofline/roofline_tools.py
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/roofline_tools.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Mechanical primitives for the `roofline` analysis skill.
+
+OPTIONAL helpers only. The skill is defined by SKILL.md and an agent can execute it by hand; this
+module exists so the boring parts (peak-table parsing, counter parsing, unit math) are not retyped.
+
+Design rules, per knowledge/analysis_skills/INDEX.md:
+  * no hard third-party dependency (stdlib only; torch is imported lazily and optionally)
+  * every helper is defensive and returns a value or None -- it never raises at the caller
+  * nothing here decides anything; the routing rules live in SKILL.md
+
+Self-test:  python3 roofline_tools.py --selftest
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+
+SKILL_NAME = "roofline"
+SKILL_VERSION = "1"
+
+# element size in bytes, keyed by the dtype spellings that show up in profiles/configs
+_DTYPE_BYTES = {
+    "fp4": 0.5, "float4": 0.5, "mxfp4": 0.5, "e2m1": 0.5,
+    "fp8": 1, "float8": 1, "e4m3": 1, "e5m2": 1, "mxfp8": 1, "fp8_e4m3": 1, "int8": 1, "uint8": 1,
+    "bf16": 2, "bfloat16": 2, "c10::bfloat16": 2, "fp16": 2, "float16": 2, "half": 2, "int16": 2,
+    "fp32": 4, "float32": 4, "float": 4, "int32": 4,
+    "fp64": 8, "float64": 8, "double": 8, "int64": 8, "long": 8,
+}
+
+# target_eff priors -- SKILL.md section 7 is the source of truth; keep the two in sync.
+TARGET_EFF = {
+    "gemm": 0.90,
+    "moe": 0.90,
+    "elementwise": 0.875,
+    "attn": 0.50,
+}
+
+
+def dtype_bytes(name, default=2):
+    """Element size in bytes for a dtype spelling. Unknown -> `default` (never raises)."""
+    if name is None:
+        return default
+    if isinstance(name, (int, float)):
+        return float(name)
+    key = str(name).strip().lower().lstrip("torch.")
+    if key in _DTYPE_BYTES:
+        return _DTYPE_BYTES[key]
+    for k, v in _DTYPE_BYTES.items():          # substring fallback: "c10::BFloat16", "torch.float8_e4m3fnuz"
+        if k in key:
+            return v
+    return default
+
+
+# ---------------------------------------------------------------- peaks
+
+def load_peaks(peaks_md_path, gfx):
+    """Parse the ```yaml blocks in peaks.md and return the one matching `gfx`.
+
+    Returns {"hbm_bw_bytes_s": float, "flops": {dtype: float}, "cu": int, "source": "table",
+             "confidence": "high"} or None when the file or the section is absent.
+    """
+    try:
+        with open(peaks_md_path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    for block in re.findall(r"```yaml\s*\n(.*?)```", text, re.S):
+        if not re.search(r"^\s*gfx:\s*%s\s*$" % re.escape(str(gfx)), block, re.M):
+            continue
+        out = {"flops": {}, "source": "table", "confidence": "high"}
+        in_flops = False
+        for line in block.splitlines():
+            if not line.strip() or line.strip().startswith("#"):
+                continue
+            body = line.split("#", 1)[0].rstrip()
+            if re.match(r"^\s*flops:\s*$", body):
+                in_flops = True
+                continue
+            m = re.match(r"^(\s*)([A-Za-z0-9_]+):\s*(.*)$", body)
+            if not m:
+                continue
+            indent, key, val = m.group(1), m.group(2), m.group(3).strip()
+            if in_flops and len(indent) >= 2 and val:
+                try:
+                    out["flops"][key] = float(val)
+                except ValueError:
+                    pass
+                continue
+            in_flops = False
+            if not val:
+                continue
+            try:
+                out[key] = float(val) if re.match(r"^[-+0-9.eE]+$", val) else val
+            except ValueError:
+                out[key] = val
+        if out.get("hbm_bw_bytes_s"):
+            return out
+    return None
+
+
+def derive_peaks_from_props(device=0):
+    """Fallback peaks from torch device properties. confidence='low' -- see peaks.md.
+
+    The derived HBM figure is frequently wrong for HBM3/3E (understates the pin rate), which is
+    exactly why the caller must treat this as display-only.
+    """
+    try:
+        import torch  # noqa: PLC0415 - optional, lazily imported on purpose
+        p = torch.cuda.get_device_properties(device)
+    except Exception:
+        return None
+    try:
+        bw = float(getattr(p, "memory_clock_rate", 0)) * 1e3 * (float(getattr(p, "memory_bus_width", 0)) / 8.0) * 2.0
+    except Exception:
+        bw = 0.0
+    if bw <= 0:
+        return None
+    return {
+        "hbm_bw_bytes_s": bw,
+        "flops": {},
+        "cu": int(getattr(p, "multi_processor_count", 0) or 0),
+        "source": "derived",
+        "confidence": "low",
+    }
+
+
+def peak_flops_for(peaks, dtype_name):
+    """Peak FLOP/s for a dtype, falling back to the largest tabulated value. None if unknown."""
+    if not peaks:
+        return None
+    flops = peaks.get("flops") or {}
+    if not flops:
+        return None
+    key = str(dtype_name or "").strip().lower()
+    for k, v in flops.items():
+        if k and k in key:
+            return float(v)
+    return float(max(flops.values()))
+
+
+# ---------------------------------------------------------------- op models
+
+def experts_hit(num_experts, pairs):
+    """Expected number of DISTINCT experts touched by `pairs` = M*top_k routed token-expert pairs.
+
+    E*(1-(1-1/E)^pairs). At decode this is what decides MoE weight traffic.
+    """
+    try:
+        E, n = float(num_experts), float(pairs)
+        if E <= 0 or n <= 0:
+            return 0.0
+        return E * (1.0 - math.pow(1.0 - 1.0 / E, n))
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+
+
+# ---------------------------------------------------------------- the metric
+
+def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_eff,
+                     pct_gpu_time=0.0):
+    """Core arithmetic of SKILL.md section 3 step 5. Returns a dict, or None on unusable input.
+
+    Applies the L3 sanity band: an impossible roofline_pct is clamped and flagged `suspect`
+    (with the raw value preserved) rather than discarded.
+    """
+    try:
+        b, f, t = float(bytes_moved or 0), float(flops or 0), float(t_seconds or 0)
+        pbw, pfl, tgt = float(peak_bw or 0), float(peak_flops or 0), float(target_eff or 0)
+    except (TypeError, ValueError):
+        return None
+    if t <= 0 or pbw <= 0 or tgt <= 0 or (b <= 0 and f <= 0):
+        return None
+
+    achieved_bw = b / t
+    achieved_flops = (f / t) if f > 0 else 0.0
+    ai = (f / b) if b > 0 else float("inf")
+    ridge = (pfl / pbw) if (pfl > 0 and pbw > 0) else None
+
+    compute_bound = bool(ridge is not None and pfl > 0 and ai > ridge)
+    if compute_bound:
+        raw_pct, bound = achieved_flops / pfl, "compute"
+    else:
+        raw_pct, bound = achieved_bw / pbw, "memory"
+
+    suspect = not (0.001 <= raw_pct <= 1.0)
+    pct = min(max(raw_pct, 0.0), 1.0)
+    attainable = max(1.0, tgt / pct) if pct > 0 else 1.0
+
+    return {
+        "bytes_est": b, "flops_est": f, "t_ms": t * 1e3,
+        "achieved_bw_bytes_s": achieved_bw, "achieved_flops": achieved_flops,
+        "arithmetic_intensity": ai, "ridge_point": ridge, "bound_type": bound,
+        "roofline_pct": pct, "roofline_pct_raw": raw_pct, "target_eff": tgt,
+        "attainable_speedup": attainable,
+        "expected_e2e_gain_pct": float(pct_gpu_time or 0.0) * (1.0 - 1.0 / attainable),
+        "headroom_class": classify_headroom(pct, tgt),
+        "suspect": suspect,
+    }
+
+
+def classify_headroom(roofline_pct, target_eff):
+    """SKILL.md section 3 step 6.
+
+    Banded against `target_eff`, NOT against the raw roofline: what matters is the distance to what
+    a good implementation of this class can realistically reach. Within 10% of that target means
+    tuning has nothing left to give (88% vs a 90% target is saturated, not "nearly there").
+    """
+    try:
+        p, t = float(roofline_pct), float(target_eff)
+    except (TypeError, ValueError):
+        return "unknown"
+    if p <= 0 or t <= 0:
+        return "unknown"
+    if p >= 0.9 * t:
+        return "saturated"
+    if p >= 0.6 * t:
+        return "moderate"
+    return "underperforming"
+
+
+# ---------------------------------------------------------------- counters (stage C)
+
+#: rocprofv3 counters to request. FETCH_SIZE/WRITE_SIZE are in KiB. fp8 has no MfmaFlopsF8 on
+#: current builds -- SQ_INSTS_VALU_MFMA_MOPS_F8 stands in. Availability varies by ROCm build;
+#: probe with `rocprofv3 --list-avail` and drop whatever is missing (degrades to L4, never fatal).
+COUNTERS = ["FETCH_SIZE", "WRITE_SIZE", "MfmaFlops", "MfmaFlopsBF16", "MfmaFlopsF16",
+            "SQ_INSTS_VALU_MFMA_MOPS_F8", "MemUnitStalled", "MfmaUtil", "OccupancyPercent"]
+
+
+def parse_counter_csv(path, kernel_substr=None):
+    """Sum rocprofv3 counter-collection CSV rows into {counter: value}.
+
+    Tolerates the several column spellings rocprofv3 has shipped. Returns {} on any problem.
+    """
+    import csv  # noqa: PLC0415 - stdlib, kept local so a broken import can't kill module load
+    out = {}
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for row in csv.DictReader(fh):
+                low = {(k or "").strip().lower(): (v or "") for k, v in row.items()}
+                name = low.get("kernel_name") or low.get("name") or low.get("kernel") or ""
+                if kernel_substr and kernel_substr.lower() not in name.lower():
+                    continue
+                ctr = (low.get("counter_name") or low.get("counter") or "").strip()
+                val = low.get("counter_value") or low.get("value") or ""
+                if not ctr:
+                    continue
+                try:
+                    out[ctr] = out.get(ctr, 0.0) + float(val)
+                except ValueError:
+                    continue
+    except (OSError, UnicodeDecodeError, csv.Error):
+        return {}
+    return out
+
+
+def bytes_from_counters(counters):
+    """(FETCH_SIZE + WRITE_SIZE) KiB -> bytes. None when neither counter was collected."""
+    if not counters:
+        return None
+    fetch, write = counters.get("FETCH_SIZE"), counters.get("WRITE_SIZE")
+    if fetch is None and write is None:
+        return None
+    return (float(fetch or 0.0) + float(write or 0.0)) * 1024.0
+
+
+def flops_from_counters(counters, mfma_flops_per_mop_f8=512.0):
+    """Measured FLOPs from MFMA counters. None when no usable counter is present.
+
+    `MfmaFlops*` are already FLOP counts. fp8 only exposes an MFMA *ops* count, so it needs the
+    per-instruction FLOP factor of the MFMA shape in play -- pass the right one for the kernel.
+    """
+    if not counters:
+        return None
+    for key in ("MfmaFlops", "MfmaFlopsBF16", "MfmaFlopsF16", "MfmaFlopsF32"):
+        if counters.get(key):
+            return float(counters[key])
+    mops = counters.get("SQ_INSTS_VALU_MFMA_MOPS_F8")
+    if mops:
+        return float(mops) * float(mfma_flops_per_mop_f8)
+    return None
+
+
+# ---------------------------------------------------------------- self-test
+
+def _selftest():
+    """Reproduces the SKILL.md section 9 worked example from real measured numbers."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    ok = True
+
+    peaks = load_peaks(os.path.join(here, "peaks.md"), "gfx950")
+    assert peaks and abs(peaks["hbm_bw_bytes_s"] - 8.0e12) < 1e9, peaks
+    assert abs(peak_flops_for(peaks, "fp8") - 5.0e15) < 1e12, peaks["flops"]
+    assert load_peaks(os.path.join(here, "peaks.md"), "gfxNOPE") is None      # L1 path
+    print("peaks: gfx950 %.2f TB/s, fp8 %.2f PFLOP/s; unknown gfx -> None  OK"
+          % (peaks["hbm_bw_bytes_s"] / 1e12, peak_flops_for(peaks, "fp8") / 1e15))
+
+    E, M, tk, H, I, L = 256, 64, 8, 2048, 512, 40
+    hit = experts_hit(E, M * tk)
+    assert 215 <= hit <= 225, hit
+    wbytes = hit * (2 * I * H + H * I) * dtype_bytes("fp8")
+    t_layer = 2 * 49.471e-6                                   # 80 launches/step over 40 layers
+    moe = roofline_metrics(wbytes, 2 * M * tk * (2 * I * H + H * I), t_layer,
+                           peaks["hbm_bw_bytes_s"], peak_flops_for(peaks, "fp8"),
+                           TARGET_EFF["moe"], pct_gpu_time=26.45)
+    print("MoE   : hit %.0f/%d, %.0f MB/layer -> %.0f%% of roofline, %s, %.3fx, +%.2f%% e2e (%s)"
+          % (hit, E, wbytes / 1e6, 100 * moe["roofline_pct"], moe["bound_type"],
+             moe["attainable_speedup"], moe["expected_e2e_gain_pct"], moe["headroom_class"]))
+    ok &= (moe["bound_type"] == "memory" and moe["headroom_class"] == "saturated"
+           and 0.85 <= moe["roofline_pct"] <= 0.92 and moe["expected_e2e_gain_pct"] < 1.0)
+
+    B, S, kvh, hd = 64, 1024 + 1024 // 2, 2, 256
+    attn = roofline_metrics(B * S * kvh * hd * 2 * dtype_bytes("bf16"),
+                            2 * B * 16 * S * hd * 2, 141.112e-6,
+                            peaks["hbm_bw_bytes_s"], peak_flops_for(peaks, "bf16"),
+                            TARGET_EFF["attn"], pct_gpu_time=8.86)
+    print("Attn  : %.0f%% of roofline, %s, %.2fx, +%.2f%% e2e (%s)"
+          % (100 * attn["roofline_pct"], attn["bound_type"], attn["attainable_speedup"],
+             attn["expected_e2e_gain_pct"], attn["headroom_class"]))
+    ok &= (attn["headroom_class"] == "underperforming" and attn["attainable_speedup"] > 1.4
+           and attn["expected_e2e_gain_pct"] > moe["expected_e2e_gain_pct"])
+
+    # the whole point: the two rankings disagree, and roofline is the one that matched reality
+    ok &= (26.45 > 8.86) and (attn["expected_e2e_gain_pct"] > moe["expected_e2e_gain_pct"])
+    print("Rank  : by pct -> MoE first; by expected gain -> Attn first (measured: MoE -0.064%% e2e, "
+          "Attn 1.56x isolated)  OK")
+
+    # L3 sanity band: all-expert bytes overshoot the roofline -> clamped + suspect, not discarded
+    allx = roofline_metrics(E * (2 * I * H + H * I) * 1, 1.0, t_layer, peaks["hbm_bw_bytes_s"],
+                            peak_flops_for(peaks, "fp8"), TARGET_EFF["moe"], pct_gpu_time=26.45)
+    assert allx["suspect"] and allx["roofline_pct"] <= 1.0, allx
+    print("L3    : all-expert bytes -> raw %.2f clamped to %.2f, suspect=True  OK"
+          % (allx["roofline_pct_raw"], allx["roofline_pct"]))
+
+    # degradation: unusable inputs return None instead of raising
+    for bad in [(0, 0, 1e-6, 1e12, 1e15, 0.9), (1, 1, 0, 1e12, 1e15, 0.9), (None, None, None, None, None, None)]:
+        assert roofline_metrics(*bad) is None, bad
+    assert dtype_bytes("who-knows") == 2 and parse_counter_csv("/nonexistent") == {}
+    assert bytes_from_counters({}) is None and flops_from_counters({}) is None
+    assert bytes_from_counters({"FETCH_SIZE": 1024.0, "WRITE_SIZE": 1024.0}) == 2 * 1024 * 1024
+    print("L2/L4/L5: unusable input -> None/{} without raising  OK")
+
+    print("\nSELFTEST %s" % ("PASS" if ok else "FAIL"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--selftest", action="store_true", help="reproduce the SKILL.md worked example")
+    ap.add_argument("--peaks", metavar="GFX", help="print the peak table entry for GFX as JSON")
+    a = ap.parse_args()
+    if a.peaks:
+        p = load_peaks(os.path.join(os.path.dirname(os.path.abspath(__file__)), "peaks.md"), a.peaks)
+        print(json.dumps(p or derive_peaks_from_props() or {"error": "no peaks for %s" % a.peaks}, indent=2))
+        raise SystemExit(0)
+    raise SystemExit(_selftest() if a.selftest else ap.print_help())

--- a/e2e_workflow/roles/profiler.md
+++ b/e2e_workflow/roles/profiler.md
@@ -202,6 +202,14 @@ degrade to whatever is available, and if both analysis.md and trace are unusable
    inconsistent and will under-rank the real targets. If the trace can't be sampled, degrade to a
    qualitative flag (high avg+calls collective → "likely spin-inflated, discount"; one giant first-call →
    "JIT warmup, discount"; large-M+small-M same name → "split regimes") — never fail or block the Top-N.
+6. **Analysis skill (ONLY if `ANALYSIS_SKILL_DIR` is a non-empty path that EXISTS — else skip entirely
+   and return `profile_roofline_json: ""`).** Read `ANALYSIS_SKILL_DIR/SKILL.md` and execute it against
+   the Top-N you just wrote, producing the artifact it specifies (for `roofline`:
+   `profile/round_${ROUND}/profile_roofline.{json,md}`). Report its path as `profile_roofline_json`.
+   This runs **after** the Top-N is final — it enriches, it never edits `profile_topN.json`, and it must
+   never change a `pct_gpu_time`. The skill defines its own degradation ladder: follow it, and **if the
+   skill errors out at any point, note it and return the Top-N anyway — a failed analysis skill must
+   never fail or block the profile.**
 
 Return JSON:
 ```json
@@ -209,6 +217,7 @@ Return JSON:
   "round": 0,
   "profile_topN_json": "<EVAL_DIR>/profile/round_0/profile_topN.json",
   "profile_topN_md": "<EVAL_DIR>/profile/round_0/profile_topN.md",
+  "profile_roofline_json": "<EVAL_DIR>/profile/round_0/profile_roofline.json  (\"\" if no analysis skill ran)",
   "source": "torch-trace|merged|tracelens|tracelens+trace",
   "total_gpu_time_ms": 0.0,
   "top_kernels": [

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -42,6 +42,14 @@ e2e is **Amdahl-dominated**: rank every candidate by `pct_gpu_time × achievable
 2%-of-time kernel is invisible — but a mere **1.15× on a 78% GEMM is ~+10% e2e**. So the head of the
 profile is where the budget goes, even though those kernels are library calls.
 
+**`achievable_speedup` is the half everyone guesses wrong.** A big `pct_gpu_time` is *necessary* but not
+*sufficient*: a kernel already running at the hardware's bandwidth or compute ceiling has no time left to
+recover, no matter how much of the profile it owns. When a roofline prior is available (step 1c) use it
+to ground that factor in a measured ceiling instead of a class prior — but note what it does and does not
+mean: **a saturated kernel is done with micro-tuning, NOT done being optimized.** If it is still the
+largest consumer of GPU time it remains the top target; the lever just moves from "make this kernel
+faster" to "make it move fewer bytes" (step 1d). Never let a headroom estimate drop the biggest kernel.
+
 **`edit=N` (library) does NOT mean "skip" — it means "Tier-C code rewrite is unavailable."** A
 fixed-shape GEMM is one of the most tunable things on the chip. Route by *which optimization the op
 admits*, not by the edit flag:
@@ -64,6 +72,8 @@ admits*, not by the edit flag:
 Inputs: `EVAL_DIR`, `PROFILE_TOPN` (path to profile_topN.json + inline top entries),
 `BASELINE_THROUGHPUT`, `WORKLOAD` (isl/osl/conc → tells you prefill vs decode regime mix),
 `BUDGET` (max kernel-optimization tasks), `CONFIG_TUNE_ENABLED` (bool), `SKILL_DIR`.
+OPTIONAL profile-analysis prior (empty string = not provided): `ANALYSIS_SKILL`, `ANALYSIS_SKILL_DIR`
+(+ the Profiler's `profile_roofline_json`) — see step 1c.
 OPTIONAL upstream TraceLens prior (may be empty strings — treat empty/missing as "not provided"):
 `TRACELENS_KERNEL_CANDIDATES_JSON`, `TRACELENS_REPORT_JSON`, `TRACELENS_ANALYSIS_MD`,
 `TRACELENS_TRACE_FILE`.
@@ -89,6 +99,51 @@ OPTIONAL upstream TraceLens prior (may be empty strings — treat empty/missing 
    profile is the judge; TraceLens only ADDs hints/candidates, never prunes them.** Treat any `shapes` it
    carries as a STARTING hint that the Extractor will re-verify against a live capture (they may be inaccurate).
    If the prior is absent, proceed exactly as before.
+1c. **Roofline prior (ADVISORY — only if `ANALYSIS_SKILL_DIR` is non-empty AND the Profiler returned a
+   `profile_roofline_json` that EXISTS; otherwise skip this step entirely and route exactly as before).**
+   Read the artifact. Per entry it gives `roofline_pct` (how much of the hardware ceiling the kernel
+   already reaches), `bound_type`, `attainable_speedup`, `expected_e2e_gain_pct`, `headroom_class` and a
+   `confidence`. Use it to answer the question `pct_gpu_time` alone cannot: **is the time this kernel
+   spends actually recoverable?**
+
+   **The doctrine (do not violate).** `roofline_pct` measures how well a kernel executes its *current*
+   byte/FLOP budget; it says NOTHING about whether that budget is necessary. So:
+   - **NEVER prune a candidate on roofline.** Same rule as TraceLens: the measured `pct_gpu_time` is the
+     judge; this prior only ADDs information and REORDERS. `drop_list` decisions stay Amdahl-based.
+   - **A saturated head is NOT dropped — it is REROUTED.** A kernel that is both a large `pct_gpu_time`
+     and `headroom_class: saturated` is done with *micro-tuning*, not done being optimized. It remains a
+     top target; what changes is the class of fix (see 1d).
+   - Honour `confidence`: **`low` (stage A, or derived peaks) = display and annotate ONLY, do not rank on
+     it.** `medium`/`high` may be used as a SECONDARY ranking key. `unknown`/`suspect`/`modeled:false`
+     entries fall back to the ordinary playbook prior for that entry alone.
+   - If a kernel squad later measures an isolated speedup LARGER than `attainable_speedup`, the roofline
+     model was wrong: prefer the measurement, and say so in the report.
+
+   **Routing table** (applies only at `confidence` ≥ medium; otherwise use `pct_gpu_time` order):
+
+   | `headroom_class` | `pct_gpu_time` | route |
+   |---|---|---|
+   | underperforming | high | **kernel/head track, top priority** — real headroom exists |
+   | **saturated** | **high** | **byte-reduction track (1d) — NOT dropped, NOT another tuning pass** |
+   | any | low | low priority (ordinary Amdahl) |
+   | unknown / low confidence | any | ignore roofline; order by `pct_gpu_time` |
+
+   Report BOTH orderings in `strategy.md` — the one by `pct_gpu_time` and the one by
+   `expected_e2e_gain_pct` — and state explicitly which you followed and why. When they disagree, that
+   disagreement is the most useful thing in the analysis; do not hide it behind a single blended number.
+
+1d. **Byte-reduction levers (for a `saturated` + high-`pct_gpu_time` head).** The kernel is at the
+   bandwidth/compute wall, so the only remaining win is to make it do the same work moving fewer bytes.
+   Enumerate concretely: **fuse an adjacent op away** (a separate quant/silu/norm kernel in the Top-N →
+   fusing it removes a whole activation round-trip *and* that kernel's own GPU time); **stop reading what
+   isn't used** (e.g. streaming all `E` experts when routing only touches a fraction); **layout/packing**
+   (padding waste, coalescing, L2 reuse between stages); **lower-precision weights** (fp8→fp4, lossy →
+   must pass the accuracy gate).
+   **🔴 Hard constraints — a "win" that violates these is not a win:** the **measurement contract is
+   fixed**. The user-supplied workload — `isl`, `osl`, **`conc`/batch size — must NOT be changed**, and
+   **speculative decoding (MTP or otherwise) must NOT be introduced** as an optimization. Raising
+   throughput by changing what is being measured is out of scope for this workflow.
+
 2. Partition the Top-N into FOUR routes (by what optimization the op admits, NOT by edit flag):
    - **config fast path** — service-level env/flag with no op isolation: `--attention-backend` swap,
      `--quantization fp8`, cuda-graph, torch-compile, kv-cache-dtype, scheduling/mem knobs → Config
@@ -162,7 +217,11 @@ Return JSON:
      "amdahl_priority": 0.0, "rationale": "why this is the head; what win to expect; if is_fused_kernel, WHY the chosen lever reaches live_call_seam (signature match)",
      "source_hint": "<TraceLens source_file/source_path if any, else ''>",
      "launcher_hint": "<TraceLens kernel_path/launcher_source_file if any, else ''>",
-     "bound_type": "<memory|compute|'' from TraceLens>"}
+     "bound_type": "<memory|compute|'' from TraceLens or the roofline prior>",
+     "roofline_pct": 0.0, "attainable_speedup": 0.0, "expected_e2e_gain_pct": 0.0,
+     "headroom_class": "<underperforming|moderate|saturated|unknown|'' if no roofline prior>",
+     "roofline_confidence": "<low|medium|high|'' if none>",
+     "byte_reduction_levers": ["only when headroom_class=saturated; see step 1d"]}
   ],
   "kernel_candidates": [
     {"id": "k0", "short_name": "...", "classification": "...", "pct_gpu_time": 0.0,
@@ -170,7 +229,11 @@ Return JSON:
      "amdahl_priority": 0.0, "extract_hint": "which callable to hook (module:attr) + why",
      "source_hint": "<TraceLens source_file/source_path if any, else ''>",
      "launcher_hint": "<TraceLens kernel_path/launcher_source_file if any, else ''>",
-     "bound_type": "<memory|compute|'' from TraceLens>"}
+     "bound_type": "<memory|compute|'' from TraceLens or the roofline prior>",
+     "roofline_pct": 0.0, "attainable_speedup": 0.0, "expected_e2e_gain_pct": 0.0,
+     "headroom_class": "<underperforming|moderate|saturated|unknown|'' if no roofline prior>",
+     "roofline_confidence": "<low|medium|high|'' if none>",
+     "byte_reduction_levers": ["only when headroom_class=saturated; see step 1d"]}
   ],
   "drop_list": [{"short_name": "...", "why": "below Amdahl threshold"}],
   "order_of_work": ["config fast path first", "then h0 (GEMM #1)", "then k0", "..."],
@@ -203,6 +266,12 @@ change), `HISTORY`, `SKILL_DIR`.
 4. **Amdahl stop rule:** estimate remaining headroom = Σ over untouched above-bar editable kernels of
    `(pct_gpu_time × plausible_speedup_fraction)`. If the best remaining candidate can't plausibly move
    e2e beyond the noise band, set `stop=true`.
+   **If a roofline prior is available at `confidence` ≥ medium** (`profile_roofline_json`, step 1c),
+   prefer its `expected_e2e_gain_pct` over a guessed `plausible_speedup_fraction` — it is derived from a
+   measured ceiling rather than a class prior. It still may not PRUNE a candidate: use it to ORDER the
+   remaining pool and to justify `stop`. Never stop solely because roofline says headroom is small while
+   a large `pct_gpu_time` kernel remains untouched — such a kernel routes to the byte-reduction track
+   (step 1d) instead.
 5. Issue concrete directions: exact callable to extract (`module:attr`) + candidate backends, citing the
    profile entry + pct_gpu_time. **Use HISTORY only to ORDER/diversify (deprioritize a direction that
    already showed no e2e gain THIS run, prefer a different kernel or a different mechanism) — NEVER as a
@@ -245,6 +314,15 @@ verified e2e throughput delta, verdict), `REPROFILE_SHIFT`, prior `HISTORY`, `SK
      A claim CONTRADICTED by new evidence → move its card to `_archive.md` with the refuting source.
    Mechanism facts are recorded as POSITIVE ROUTING ("optimize GEMM via aiter DB"), not "X failed".
 2. Keep the in-run hypothesis ledger (wins AND nulls, for THIS run's report) in `EVAL_DIR/insight_log.md`.
+3. **Calibrate the roofline prior (ONLY if one was used — `ANALYSIS_SKILL_DIR` non-empty and a
+   `profile_roofline_json` exists; else skip).** For each direction this milestone measured, record
+   `predicted vs actual` in `knowledge/backend_playbook.md`: predicted `attainable_speedup` /
+   `expected_e2e_gain_pct` against the measured isolated speedup and measured e2e delta. This is how the
+   `target_eff` priors and byte models in the skill's `SKILL.md` self-correct across runs, so state the
+   *direction* of any error ("attention decode: predicted 1.7×, measured 1.56× — prior slightly
+   optimistic"). **A measured speedup that EXCEEDS the predicted `attainable_speedup` means the byte/FLOP
+   model was wrong** — record that loudly, since it is the failure mode that would otherwise cause the
+   prior to under-rank a real opportunity in a future run. Keep it to one line per direction.
 
 Return JSON:
 ```json

--- a/e2e_workflow/scripts/test_analysis_skill_off_identical.js
+++ b/e2e_workflow/scripts/test_analysis_skill_off_identical.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Regression guard for the `analysis_skill` toggle (no GPU, no model needed).
+//
+// Invariant under test: with the skill OFF, the profile-analysis feature injects NOTHING into any role
+// prompt, so the run behaves exactly as it did before the feature existed. We prove this behaviorally by
+// extracting the ACTUAL ANALYSIS_SKILL_* block from the workflow script and asserting that
+//   (a) OFF yields empty strings for every input, and
+//   (b) the object SHAPE is identical on and off (same keys), so a spread can never add or drop a key,
+//   (c) the inputs are spread LAST at each call site and collide with no other key (no shadowing).
+//
+// Run:  node e2e_workflow/scripts/test_analysis_skill_off_identical.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');            // .../GEAK
+const FILE = path.join(ROOT, 'e2e_workflow', 'e2e_workflow.js');
+
+let failures = 0;
+const ok = (cond, msg) => { if (!cond) { console.error('  FAIL:', msg); failures++; } else console.log('  ok:', msg); };
+
+console.log(`\n# ${path.relative(ROOT, FILE)}`);
+const src = fs.readFileSync(FILE, 'utf8');
+
+// 1) Extract the real gating block and probe it with controlled module-scope deps.
+const m = src.match(/const ANALYSIS_SKILL = [\s\S]*?ANALYSIS_SKILL_DIR: '' \};/);
+ok(!!m, 'ANALYSIS_SKILL_* gating block found');
+if (m) {
+  const make = new Function('A', 'WORKFLOW_DIR',
+    m[0] + '\nreturn { ANALYSIS_SKILL, ANALYSIS_SKILL_ON, ANALYSIS_SKILL_INPUTS };');
+  const probe = (a) => make(a, '/wf');
+
+  // OFF, by every spelling a caller might use
+  for (const a of [{ analysis_skill: 'none' }, { analysis_skill: 'false' },
+                   { analysis_skill: '' }, { analysis_skill: '   ' }]) {
+    const r = probe(a);
+    ok(r.ANALYSIS_SKILL_ON === false, `OFF for ${JSON.stringify(a)}`);
+    ok(r.ANALYSIS_SKILL_INPUTS.ANALYSIS_SKILL === '' && r.ANALYSIS_SKILL_INPUTS.ANALYSIS_SKILL_DIR === '',
+      `OFF -> every input is '' for ${JSON.stringify(a)}`);
+  }
+
+  // ON: default, and explicit alternative skill (pluggability)
+  const def = probe({});
+  ok(def.ANALYSIS_SKILL === 'roofline' && def.ANALYSIS_SKILL_ON === true, "defaults to 'roofline' (ON)");
+  ok(def.ANALYSIS_SKILL_INPUTS.ANALYSIS_SKILL_DIR === '/wf/knowledge/analysis_skills/roofline',
+    'ON -> skill dir resolves under knowledge/analysis_skills/<skill>');
+  const alt = probe({ analysis_skill: 'some-other-skill' });
+  ok(alt.ANALYSIS_SKILL_INPUTS.ANALYSIS_SKILL_DIR === '/wf/knowledge/analysis_skills/some-other-skill',
+    'ON -> an arbitrary skill name is pluggable (dir swap only)');
+
+  // Shape stability: same keys on and off, so a spread never adds/removes a key.
+  const keysOn = Object.keys(def.ANALYSIS_SKILL_INPUTS).sort().join(',');
+  const keysOff = Object.keys(probe({ analysis_skill: 'none' }).ANALYSIS_SKILL_INPUTS).sort().join(',');
+  ok(keysOn === keysOff, `input object shape identical ON vs OFF (${keysOn})`);
+}
+
+// 2) The spread must be additive at every call site: the ANALYSIS_SKILL_* keys are set nowhere else,
+//    so spreading them can never shadow an existing input.
+const sites = (src.match(/\.\.\.ANALYSIS_SKILL_INPUTS/g) || []).length;
+ok(sites >= 8, `spread into every consumer call site (found ${sites})`);
+if (m) {
+  const outside = src.replace(m[0], '');
+  const stray = (outside.match(/ANALYSIS_SKILL(_DIR)?\s*:/g) || []).length;
+  ok(stray === 0,
+    `ANALYSIS_SKILL/_DIR used as an object key ONLY inside the gating block (found ${stray} elsewhere) ` +
+    `-> the spread can never shadow another input`);
+}
+
+// 3) Consumers must treat the prior as optional and advisory.
+ok(/ADVISORY|advisory/.test(src), 'gating block documents the prior as advisory');
+for (const [role, phrase] of [['profiler', 'ANALYSIS_SKILL_DIR'], ['system_architect', 'ANALYSIS_SKILL_DIR']]) {
+  const roleSrc = fs.readFileSync(path.join(ROOT, 'e2e_workflow', 'roles', `${role}.md`), 'utf8');
+  ok(roleSrc.includes(phrase), `roles/${role}.md consumes ${phrase}`);
+  ok(/non-empty|EXISTS|else skip|otherwise skip/i.test(roleSrc), `roles/${role}.md guards on the prior being present`);
+}
+
+console.log(failures === 0
+  ? '\nPASS: analysis_skill OFF injects nothing (feature is purely additive).'
+  : `\nFAILED: ${failures} assertion(s).`);
+process.exit(failures === 0 ? 0 : 1);

--- a/e2e_workflow/scripts/tests/test_roofline_skill.py
+++ b/e2e_workflow/scripts/tests/test_roofline_skill.py
@@ -126,6 +126,46 @@ class TestCalibrationAttention(unittest.TestCase):
         self.assertGreaterEqual(_attn_metrics()["attainable_speedup"], 1.56)
 
 
+class TestBoundTypeByUtilization(unittest.TestCase):
+    """bound_type is decided by measured utilization on BOTH axes, not by AI-vs-ridge alone."""
+
+    def test_attention_is_latency_bound_but_keeps_its_verdict(self):
+        """Small AI + low HBM util is NOT memory-bound — it is latency/occupancy-bound. The load-bearing
+        part: the verdict is KEPT (real headroom), so a low-utilization head still ranks by headroom
+        rather than falling back to raw %GPU. Only the *lever class* changes (occupancy/fusion)."""
+        a = _attn_metrics()
+        self.assertEqual(a["bound_type"], "latency")           # was mislabeled "memory" pre-fix
+        self.assertLess(a["hbm_util"], 0.60)
+        self.assertLess(a["compute_util"], 0.60)
+        self.assertEqual(a["headroom_class"], "underperforming")  # verdict survives
+        self.assertGreater(a["attainable_speedup"], 1.4)
+
+    def test_saturated_memory_head_stays_memory_bound(self):
+        """A genuinely bandwidth-bound head (high hbm_util) keeps bound_type='memory' so it routes to
+        the byte-reduction track, not the occupancy track."""
+        m = _moe_metrics()
+        self.assertEqual(m["bound_type"], "memory")
+        self.assertGreaterEqual(m["hbm_util"], 0.60)
+        self.assertEqual(m["headroom_class"], "saturated")
+
+    def test_latency_verdict_kept_is_distinct_from_dispatch_no_verdict(self):
+        """Two latency kinds must not collapse: a real-work low-util launch keeps a verdict; a launch
+        timed by the dispatch floor does not."""
+        p = _peaks()
+        # low util, but well above the ~5us dispatch floor -> latency WITH a verdict
+        real = rt.roofline_metrics(2e8, 1e8, 100e-6, p["hbm_bw_bytes_s"],
+                                   rt.peak_flops_for(p, "bf16"), 0.90, pct_gpu_time=10.0)
+        self.assertEqual(real["bound_type"], "latency")
+        self.assertNotEqual(real["headroom_class"], "unknown")
+        self.assertGreater(real["expected_e2e_gain_pct"], 0.0)
+        # same shape, timed at the dispatch floor -> latency with NO verdict
+        floor = rt.roofline_metrics(2e8, 1e8, 2e-6, p["hbm_bw_bytes_s"],
+                                    rt.peak_flops_for(p, "bf16"), 0.90, pct_gpu_time=10.0)
+        self.assertEqual(floor["bound_type"], "latency")
+        self.assertEqual(floor["headroom_class"], "unknown")
+        self.assertEqual(floor["expected_e2e_gain_pct"], 0.0)
+
+
 class TestRankingInversion(unittest.TestCase):
     def test_rankings_disagree(self):
         """THE point of the skill: %GPU says MoE, headroom says attention — and reality agreed

--- a/e2e_workflow/scripts/tests/test_roofline_skill.py
+++ b/e2e_workflow/scripts/tests/test_roofline_skill.py
@@ -145,6 +145,61 @@ class TestDegradation(unittest.TestCase):
         self.assertGreater(m["roofline_pct_raw"], 1.0)
         self.assertLessEqual(m["roofline_pct"], 1.0)
 
+    def test_L3_infeasible_never_yields_a_saturation_verdict(self):
+        """Regression: a clamped 100% is a MODELLING FAILURE, not evidence the kernel is at the wall.
+
+        Reading it as `saturated` would let a wrong byte model silently make a routing decision —
+        observed in a real run, where fused_moe came back roofline_pct=1.00 + suspect and would
+        otherwise have been classified saturated on the strength of the clamp alone.
+        """
+        m = _moe_metrics(all_experts=True)
+        self.assertEqual(m["headroom_class"], "unknown")
+        self.assertEqual(m["attainable_speedup"], 1.0)
+        self.assertEqual(m["expected_e2e_gain_pct"], 0.0)
+        self.assertIn("bytes_upper_bound", m)          # what the model violated, for stage C
+        self.assertLess(m["bytes_upper_bound"], m["bytes_est"])
+
+    def test_dispatch_bound_launch_gets_no_verdict(self):
+        """A launch timed by dispatch overhead (tiny, high call count) is not evidence about
+        bandwidth or math. Emit bound_type='latency' and no verdict — the lever is fusion."""
+        p = _peaks()
+        m = rt.roofline_metrics(1e5, 1e5, 2e-6, p["hbm_bw_bytes_s"],
+                                rt.peak_flops_for(p, "bf16"), 0.875, pct_gpu_time=4.9)
+        self.assertEqual(m["bound_type"], "latency")
+        self.assertEqual(m["headroom_class"], "unknown")
+        self.assertEqual(m["expected_e2e_gain_pct"], 0.0)
+        self.assertIn("fusion", m["note"])
+
+    def test_bound_type_is_a_closed_set(self):
+        """Regression: a real run emitted an invented 'dispatch' bound_type the consumer had no
+        routing rule for. Every path must land inside BOUND_TYPES."""
+        p = _peaks()
+        cases = [_moe_metrics(), _attn_metrics(), _moe_metrics(all_experts=True),
+                 rt.roofline_metrics(1e5, 1e5, 2e-6, p["hbm_bw_bytes_s"],
+                                     rt.peak_flops_for(p, "bf16"), 0.875)]
+        for m in cases:
+            self.assertIn(m["bound_type"], rt.BOUND_TYPES, m.get("note", ""))
+
+
+class TestHeadScoping(unittest.TestCase):
+    """Only kernels big enough to change a decision are analysed at all."""
+
+    ENTRIES = [{"short_name": "big", "pct_gpu_time": 26.4}, {"short_name": "mid", "pct_gpu_time": 8.9},
+               {"short_name": "bar", "pct_gpu_time": 5.0}, {"short_name": "small", "pct_gpu_time": 1.7},
+               {"short_name": "tiny", "pct_gpu_time": 0.2}]
+
+    def test_below_bar_is_skipped_not_degraded(self):
+        sel = [e["short_name"] for e in rt.select_entries(self.ENTRIES, min_pct_gpu=5.0)]
+        self.assertEqual(sel, ["big", "mid", "bar"])   # sorted desc, sub-bar absent entirely
+
+    def test_top_n_cap(self):
+        self.assertEqual(len(rt.select_entries(self.ENTRIES, min_pct_gpu=0.0, top_n=2)), 2)
+
+    def test_malformed_input_is_safe(self):
+        self.assertEqual(rt.select_entries(None), [])
+        self.assertEqual(rt.select_entries([]), [])
+        self.assertEqual(rt.select_entries([{"short_name": "no-pct"}], min_pct_gpu=5.0), [])
+
     def test_L2_unusable_input_returns_none(self):
         for bad in [(0, 0, 1e-6, 1e12, 1e15, 0.9),      # no bytes and no flops
                     (1e6, 1e6, 0, 1e12, 1e15, 0.9),     # no time

--- a/e2e_workflow/scripts/tests/test_roofline_skill.py
+++ b/e2e_workflow/scripts/tests/test_roofline_skill.py
@@ -1,0 +1,210 @@
+"""Unit tests for the `roofline` analysis skill (stdlib only; no pytest, no GPU, no model needed).
+
+Two things are locked here.
+
+1. **Calibration against a real run.** The numbers below are the measured profile of
+   Qwen3.5-35B-A3B-FP8 on gfx950 / vLLM / TP1 / isl-osl 1k / conc 64 — a run whose outcome we know.
+   The skill must reproduce the call it would have made:
+     fused_moe   26.45% GPU, ~88% of roofline -> saturated, ~1.02x attainable  (measured: 1.047x
+                 isolated, -0.064% e2e -> the budget spent there was wasted)
+     paged_attn   8.86% GPU, ~18% of roofline -> underperforming, >1.4x        (measured: 1.56x isolated)
+   The load-bearing assertion is `test_rankings_disagree`: ranking by pct_gpu_time puts MoE first,
+   ranking by roofline headroom puts attention first. That inversion is the entire point of the skill.
+
+2. **Degradation is non-fatal.** Every level of the SKILL.md ladder returns a value instead of raising,
+   so a bad peak table / unmodellable op / impossible result / missing counter cannot fail a run.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "knowledge", "analysis_skills", "roofline"))
+import roofline_tools as rt  # noqa: E402
+
+PEAKS_MD = os.path.join(os.path.dirname(os.path.abspath(rt.__file__)), "peaks.md")
+
+# --- measured profile of the reference run (see module docstring) ---------------------------------
+MOE = dict(E=256, M=64, top_k=8, hidden=2048, inter=512, layers=40,
+           t_launch_s=49.471e-6, launches_per_step=80, pct_gpu=26.45)
+ATTN = dict(batch=64, isl=1024, osl=1024, kv_heads=2, q_heads=16, head_dim=256,
+            t_launch_s=141.112e-6, pct_gpu=8.86)
+
+
+def _peaks():
+    return rt.load_peaks(PEAKS_MD, "gfx950")
+
+
+def _moe_metrics(all_experts=False):
+    p = _peaks()
+    per_expert_elems = 2 * MOE["inter"] * MOE["hidden"] + MOE["hidden"] * MOE["inter"]
+    n = MOE["E"] if all_experts else rt.experts_hit(MOE["E"], MOE["M"] * MOE["top_k"])
+    # 80 launches/step over 40 layers => 2 launches per logical layer (SKILL.md "per-launch, not aggregate")
+    t_layer = (MOE["launches_per_step"] / MOE["layers"]) * MOE["t_launch_s"]
+    return rt.roofline_metrics(
+        n * per_expert_elems * rt.dtype_bytes("fp8"),
+        2 * MOE["M"] * MOE["top_k"] * per_expert_elems,
+        t_layer, p["hbm_bw_bytes_s"], rt.peak_flops_for(p, "fp8"),
+        rt.TARGET_EFF["moe"], pct_gpu_time=MOE["pct_gpu"])
+
+
+def _attn_metrics():
+    p = _peaks()
+    seq = ATTN["isl"] + ATTN["osl"] // 2          # mid-run average context
+    kv_bytes = ATTN["batch"] * seq * ATTN["kv_heads"] * ATTN["head_dim"] * 2 * rt.dtype_bytes("bf16")
+    flops = 2 * ATTN["batch"] * ATTN["q_heads"] * seq * ATTN["head_dim"] * 2
+    return rt.roofline_metrics(kv_bytes, flops, ATTN["t_launch_s"], p["hbm_bw_bytes_s"],
+                               rt.peak_flops_for(p, "bf16"), rt.TARGET_EFF["attn"],
+                               pct_gpu_time=ATTN["pct_gpu"])
+
+
+class TestPeaks(unittest.TestCase):
+    def test_known_gfx_from_table(self):
+        p = _peaks()
+        self.assertIsNotNone(p)
+        self.assertAlmostEqual(p["hbm_bw_bytes_s"], 8.0e12, delta=1e9)
+        self.assertAlmostEqual(rt.peak_flops_for(p, "fp8"), 5.0e15, delta=1e12)
+        self.assertEqual(p["source"], "table")
+        self.assertEqual(p["confidence"], "high")
+
+    def test_gfx942_also_tabulated(self):
+        p = rt.load_peaks(PEAKS_MD, "gfx942")
+        self.assertIsNotNone(p)
+        self.assertAlmostEqual(p["hbm_bw_bytes_s"], 5.3e12, delta=1e9)
+
+    def test_L1_unknown_gfx_returns_none(self):
+        """Unknown gfx -> None, so the caller falls back to derived peaks at confidence=low."""
+        self.assertIsNone(rt.load_peaks(PEAKS_MD, "gfx-does-not-exist"))
+
+    def test_L5_missing_peaks_file_does_not_raise(self):
+        self.assertIsNone(rt.load_peaks("/nonexistent/peaks.md", "gfx950"))
+
+
+class TestCalibrationMoE(unittest.TestCase):
+    """The 26%-of-GPU head that was, in fact, already at the bandwidth wall."""
+
+    def test_memory_bound(self):
+        m = _moe_metrics()
+        self.assertEqual(m["bound_type"], "memory")
+        self.assertLess(m["arithmetic_intensity"], m["ridge_point"] / 10)
+
+    def test_near_roofline(self):
+        m = _moe_metrics()
+        self.assertGreaterEqual(m["roofline_pct"], 0.85)
+        self.assertLessEqual(m["roofline_pct"], 0.92)
+
+    def test_saturated_and_no_meaningful_headroom(self):
+        m = _moe_metrics()
+        self.assertEqual(m["headroom_class"], "saturated")
+        self.assertLess(m["attainable_speedup"], 1.10)
+        # measured e2e was -0.064%, i.e. inside the 0.5% noise band -> prediction must agree
+        self.assertLess(m["expected_e2e_gain_pct"], 1.0)
+
+    def test_88pct_against_a_90pct_target_is_saturated_not_moderate(self):
+        """Regression: banding on target_eff, not on the raw roofline.
+
+        Classifying 0.88 against a 0.90 target as `moderate` would route this head back to the
+        kernel track — exactly the wasted budget this skill exists to prevent.
+        """
+        self.assertEqual(rt.classify_headroom(0.88, 0.90), "saturated")
+        self.assertEqual(rt.classify_headroom(0.60, 0.90), "moderate")
+        self.assertEqual(rt.classify_headroom(0.20, 0.90), "underperforming")
+
+
+class TestCalibrationAttention(unittest.TestCase):
+    """The 8.86%-of-GPU kernel that actually had the headroom (measured 1.56x isolated)."""
+
+    def test_underperforming_with_real_headroom(self):
+        a = _attn_metrics()
+        self.assertEqual(a["headroom_class"], "underperforming")
+        self.assertGreater(a["attainable_speedup"], 1.4)
+
+    def test_prediction_brackets_the_measured_speedup(self):
+        """target_eff=0.50 predicts ~1.7-2.8x; the squad measured 1.56x. A prior that predicted
+        below the measured value would be the dangerous direction (it under-ranks real work)."""
+        self.assertGreaterEqual(_attn_metrics()["attainable_speedup"], 1.56)
+
+
+class TestRankingInversion(unittest.TestCase):
+    def test_rankings_disagree(self):
+        """THE point of the skill: %GPU says MoE, headroom says attention — and reality agreed
+        with headroom (MoE -0.064% e2e vs attention 1.56x isolated)."""
+        moe, attn = _moe_metrics(), _attn_metrics()
+        self.assertGreater(MOE["pct_gpu"], ATTN["pct_gpu"])                       # by %GPU: MoE first
+        self.assertGreater(attn["expected_e2e_gain_pct"],
+                           moe["expected_e2e_gain_pct"])                          # by headroom: attn first
+
+
+class TestDegradation(unittest.TestCase):
+    def test_L3_impossible_result_is_clamped_and_flagged(self):
+        """Assuming ALL experts stream overshoots the roofline. That must clamp + flag `suspect`
+        (and preserve the raw value), never be silently emitted or discarded."""
+        m = _moe_metrics(all_experts=True)
+        self.assertTrue(m["suspect"])
+        self.assertGreater(m["roofline_pct_raw"], 1.0)
+        self.assertLessEqual(m["roofline_pct"], 1.0)
+
+    def test_L2_unusable_input_returns_none(self):
+        for bad in [(0, 0, 1e-6, 1e12, 1e15, 0.9),      # no bytes and no flops
+                    (1e6, 1e6, 0, 1e12, 1e15, 0.9),     # no time
+                    (1e6, 1e6, 1e-6, 0, 1e15, 0.9),     # no peak bandwidth
+                    (None, None, None, None, None, None)]:
+            self.assertIsNone(rt.roofline_metrics(*bad), bad)
+
+    def test_L2_unknown_dtype_falls_back(self):
+        self.assertEqual(rt.dtype_bytes("some-future-dtype"), 2)
+        self.assertEqual(rt.dtype_bytes(None), 2)
+        self.assertEqual(rt.dtype_bytes("torch.float8_e4m3fnuz"), 1)
+        self.assertEqual(rt.dtype_bytes("c10::BFloat16"), 2)
+
+    def test_L4_missing_counters_return_none_not_zero(self):
+        """None (= 'not measured', keep the analytic estimate), never 0.0 (= 'measured nothing')."""
+        self.assertIsNone(rt.bytes_from_counters({}))
+        self.assertIsNone(rt.bytes_from_counters(None))
+        self.assertIsNone(rt.flops_from_counters({"MemUnitStalled": 5.0}))
+        self.assertEqual(rt.parse_counter_csv("/nonexistent/counters.csv"), {})
+
+    def test_counter_conversion(self):
+        self.assertEqual(rt.bytes_from_counters({"FETCH_SIZE": 1024.0, "WRITE_SIZE": 512.0}),
+                         1536.0 * 1024)
+        self.assertEqual(rt.flops_from_counters({"MfmaFlopsBF16": 42.0}), 42.0)
+        self.assertEqual(rt.flops_from_counters({"SQ_INSTS_VALU_MFMA_MOPS_F8": 2.0},
+                                                mfma_flops_per_mop_f8=512.0), 1024.0)
+
+    def test_classify_never_raises(self):
+        for bad in [(None, 0.9), ("x", 0.9), (0.5, None), (0, 0), (-1, 0.9)]:
+            self.assertEqual(rt.classify_headroom(*bad), "unknown", bad)
+
+    def test_experts_hit_is_bounded_and_safe(self):
+        self.assertEqual(rt.experts_hit(0, 100), 0.0)
+        self.assertEqual(rt.experts_hit(256, 0), 0.0)
+        self.assertEqual(rt.experts_hit(None, None), 0.0)
+        self.assertLessEqual(rt.experts_hit(256, 10**6), 256.0)
+        self.assertAlmostEqual(rt.experts_hit(256, 512), 221.0, delta=3.0)
+
+
+class TestSkillDocConsistency(unittest.TestCase):
+    """The helper's priors must not drift from the SKILL.md table that documents them."""
+
+    def test_target_eff_matches_skill_md(self):
+        skill_md = os.path.join(os.path.dirname(PEAKS_MD), "SKILL.md")
+        with open(skill_md, encoding="utf-8") as fh:
+            text = fh.read()
+        self.assertEqual(rt.TARGET_EFF["gemm"], 0.90)
+        self.assertEqual(rt.TARGET_EFF["moe"], 0.90)
+        self.assertEqual(rt.TARGET_EFF["attn"], 0.50)
+        for frag in ("dense GEMM | **0.90**", "MoE / grouped GEMM | **0.90**",
+                     "attention decode (paged) | **0.50**"):
+            self.assertIn(frag, text, "SKILL.md target_eff table drifted from roofline_tools.TARGET_EFF")
+
+    def test_workload_contract_is_stated(self):
+        """The hard constraint the byte-reduction track must not violate."""
+        with open(os.path.join(os.path.dirname(PEAKS_MD), "SKILL.md"), encoding="utf-8") as fh:
+            text = fh.read()
+        self.assertIn("must not be changed", text)
+        self.assertIn("speculative decoding", text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/kernel_workflow/knowledge/profiling_guide.md
+++ b/kernel_workflow/knowledge/profiling_guide.md
@@ -119,15 +119,44 @@ Shows how wavefronts spend their time.
 | Issue Wait | Stalled on instruction issue |
 | Total Wave Cycles | Total cycles alive |
 
-**Key ratios:**
+**Key ratios** (each row is an independent accumulator over the SAME `Total Wave Cycles` — divide each
+by Total, **never subtract them from one another**; subtracting produces negative "active" values,
+which is a mis-read, not a finding):
 - `Active / Total` = Kernel efficiency (< 20% = CRITICAL inefficiency)
-- `Dependency Wait / Total` = Memory stall fraction
-- `Issue Wait / Total` = Instruction scheduling stall
+- `Dependency Wait / Total` = fraction stalled on a data dependency feeding the math units
+- `Issue Wait / Total` = fraction stalled because too few waves are resident to issue from
 
-**Diagnosis:**
-- High Dependency Wait → memory-bound or cache miss
-- High Issue Wait → instruction-level parallelism needed
-- Low Active + Low Wait → occupancy too low
+These are **averages over every wave in the dispatch** (and every dispatch, if you aggregated). A
+kernel whose waves diverge — an MoE expert with uneven token counts, attention with ragged sequence
+lengths — can average into a near-even split that describes none of its waves. If the split comes out
+ambiguous, re-profile a single representative launch before trusting it.
+
+**Diagnosis — and do NOT collapse dependency-wait into "memory-bound".** A high dependency wait means
+the math units are waiting on a *serial data-dependency chain*; the fix is to shorten that chain, which
+is not the same as a bandwidth problem. See "Splitting latency-bound" below — the two latency sub-cases
+have **opposite** fixes, so resolve the sub-case before touching code.
+- High Dependency Wait → serial dependency chain (latency-bound **C1**) — shorten the chain
+- High Issue Wait → not enough resident waves (latency-bound **C2**) — raise occupancy / fill the GPU
+- Low Active + Low Wait → occupancy too low, or the launch is dominated by dispatch overhead
+
+### Splitting latency-bound before choosing a fix (the two remedies pull opposite directions)
+
+"Latency-bound" on its own does not select a fix. It covers two situations whose remedies conflict:
+C1 wants **shorter dependency chains** (often more registers per wave); C2 wants **more resident
+waves** (fewer registers per wave). Guess wrong and the kernel gets slower.
+
+**The split is a property of the configuration, not of the source.** Tile size in particular moves a
+kernel between the two, in opposite directions:
+- **Small tiles** → little math per wave, so a serial preamble (dequant, scale, address math) dominates
+  the wave lifetime → reads as **dependency wait (C1)**.
+- **Large tiles** → bigger accumulator → more registers → fewer waves fit → too few to cover latency →
+  reads as **issue wait (C2)**.
+
+We measured one kernel cross this line under nothing but a tile-size change: 72% dependency wait at the
+small tile, 42% issue wait at the large one — same source, opposite fix. Two consequences: **re-read
+the split after every change to tile size / `num_stages` / `num_warps`** instead of carrying the prior
+diagnosis forward; and recognize that an autotuner sweeping tiles is implicitly sweeping both branches
+— the winning config usually *balances* the two stalls rather than minimizing either alone.
 
 ### Section 11: Compute Pipeline
 
@@ -175,14 +204,48 @@ Shows how wavefronts spend their time.
    └─ LDS > 50% → LDS-BOUND
 
 2. Check Wavefront stats (Active / Total ratio)
-   ├─ < 20% → LATENCY-BOUND (critical inefficiency)
-   ├─ 20-50% → check Dependency vs Issue wait
-   │   ├─ Dependency dominant → MEMORY-BOUND (cache miss stalls)
-   │   └─ Issue dominant → LATENCY-BOUND (ILP needed)
+   ├─ < 20% → LATENCY-BOUND (critical inefficiency) → split C1/C2 below
+   ├─ 20-50% → check Dependency vs Issue wait (both are latency sub-cases, NOT memory-bound)
+   │   ├─ Dependency dominant → LATENCY-BOUND C1 (serial dep chain) → shorten the chain
+   │   └─ Issue dominant      → LATENCY-BOUND C2 (too few waves) → raise occupancy / GPU fill
    └─ > 50% → check cache hit rates
        ├─ L1 < 60% → MEMORY-BOUND (poor locality)
        └─ L1 > 60% → BALANCED (likely small kernel, launch overhead)
+
+   Note: a low VMEM/VALU SoL with a dependency-wait-dominant wavefront is latency-bound (C1), not
+   memory-bandwidth-bound. Only classify MEMORY-BOUND when HBM/VMEM utilization is actually high
+   (≥60% SoL, or L1 locality is the demonstrated problem) — a small arithmetic intensity alone does
+   not make a kernel memory-bound.
 ```
+
+## Cheap checks to run from the raw counters BEFORE trusting a label
+
+The report does not surface these, but each is a few counters already collected, and each has caught a
+real mislabel. Run them before forming a hypothesis.
+
+**Validate the peaks first (a wrong denominator invents or hides a bottleneck).**
+- **BF16 compute peak reads ~2× low.** BF16 and FP16 MFMA run at the same rate on these parts, so the
+  two reported peaks must be equal — the empirical BF16 peak often is not, which makes BF16 compute
+  efficiency read ~2× high (we saw 185%, 396%). Any roofline efficiency **> 100%** is a mis-calibrated
+  peak (or SFU ops folded into the perf counter on rmsnorm/rope), not a record. Prefer HBM% and F32
+  MFMA%; pass `--roofline-data-type` if the tool supports it.
+- **HBM can under-report on multi-XCD.** If SoL HBM% looks implausibly low, cross-check with
+  `TCC_EA*_RDREQ_DRAM × 64B`, or bytes/time by hand.
+- **MoE padding inflates AI.** Recompute arithmetic intensity from *effective* FLOPs (not padded rows)
+  and confirmed bytes before believing an "AI far right of ridge → compute-bound" call.
+
+**Check the GPU is actually filled (this was the real limiter in a large fraction of kernels).**
+- **Fill:** `CTAs = Grid_Size / Workgroup_Size`. If `CTAs < CU count`, the kernel physically cannot
+  occupy the GPU — no tile or register tuning helps; you must partition more (split-K, finer tiles,
+  more blocks). This is separate from occupancy: a kernel can hit its per-wave occupancy ceiling and
+  still leave most of the GPU idle because it never launched enough work.
+- **Occupancy ceiling:** `waves/SIMD ≈ min(8, 512 / (Arch_VGPR + Accum_VGPR))`; 1–2 is register-starved.
+- **Spill:** any nonzero `Scratch_Per_Workitem` comes first, before other register work.
+- **LDS bank conflict:** `SQ_LDS_BANK_CONFLICT / SQ_LDS_IDX_ACTIVE > 20%` → pad the row stride / swizzle.
+- **Coalescing:** `TD_COALESCABLE_WAVEFRONT_sum / TD_LOAD_WAVEFRONT_sum < 50%` → fix access pattern.
+
+Only tune registers/occupancy when achieved occupancy actually sits at the register ceiling; if it is
+far below the ceiling, the register footprint is not what constrains you and cutting VGPRs does nothing.
 
 ## Bottleneck Shift Analysis (for re-profiling after optimization)
 

--- a/kernel_workflow/roles/profile_engineer.md
+++ b/kernel_workflow/roles/profile_engineer.md
@@ -39,6 +39,15 @@ assumed MI300X.
    compute-bound / memory-bound / latency-bound / lds-bound / balanced. ALSO flag **overhead-bound**
    when per-case latencies are similar across very different problem sizes, or dispatch count > 1
    with small kernels — this points at host/dispatch overhead (see `geomean_levers.md`).
+   - **Do not call it memory-bound on a small AI alone** — only when HBM/VMEM utilization is actually
+     high. A small AI with low HBM util is latency-bound (`profiling_guide.md` → decision tree note).
+   - **When latency-bound, name the sub-case in your opportunities**: dependency-wait dominant (C1,
+     shorten the serial chain) vs issue-wait dominant (C2, raise occupancy / GPU fill). They have
+     opposite fixes, so the TechLead needs the sub-case, not just "latency". Re-read this split after
+     any tile / `num_stages` / `num_warps` change — it is a property of the config, not the source.
+   - **Run the cheap peak/fill sanity-checks** (`profiling_guide.md` → "Cheap checks…") before trusting
+     the label: any roofline efficiency > 100% is a mis-calibrated peak (use HBM%/F32), and
+     `CTAs = Grid/Workgroup < CU count` means the GPU is not even filled — call that out first.
 5. Write `EVAL_DIR/baseline_metrics.json` (or `round_N_metrics.json`) and
    `EVAL_DIR/profiling_summary.md` (or `round_N_shift_analysis.md`). For reprofile, include a
    BEFORE→AFTER shift section explaining why the bottleneck moved and what to target next.


### PR DESCRIPTION
## Roofline-guided kernel routing

  pct_gpu_time shows where time is spent but not whether it's recoverable — a kernel already at its hardware ceiling can't benefit from optimization budget.
  This PR adds roofline analysis so routing can account for headroom, not just cost.

## Key components

  - New skill slot — a pluggable analysis-skill slot at knowledge/analysis_skills/, with its first skill roofline, which estimates per-kernel roofline
  percentage, attainable speedup, and expected end-to-end gain. The Architect reports two orderings (by %GPU and by expected gain) rather than silently
  combining them.
  - Calibration — tested on a real run (Qwen3.5-35B-A3B-FP8, gfx950, vLLM TP1, 1k/1k, conc 64). fused_moe_kernel used 26.45% GPU at 88% of roofline (essentially
  no recoverable gain), while attention used 8.86% GPU at only 18% of roofline (a real ~1.56× win). Ranking by %GPU misdirects budget to MoE; ranking by
  headroom correctly targets attention.
  - Doctrine — a saturated kernel is rerouted, not dropped: it moves to a byte-reduction track (fusing adjacent ops, skipping unrouted experts, layout/packing,
  lower precision). The measurement contract is fixed — user-supplied isl/osl/conc/batch stays constant, and speculative decoding doesn't count as optimization.
  - Safety — advisory only: the skill never prunes a candidate or overrides measured pct_gpu_time. Staged confidence plus a five-level degradation ladder ending
  in "emit nothing, behave as before." With analysis_skill=none, behavior is byte-identical to before the feature. Analysis is head-scoped; a dispatch-bound
  launch and an infeasible byte model both yield no verdict rather than a false "saturated."
  - Tests — test_roofline_skill.py: 26 stdlib-only tests (no GPU) covering calibration, ranking inversion, and non-fatal degradation.
  test_analysis_skill_off_identical.js verifies the OFF path injects nothing.

 ## End-to-end verification
 validated end-to-end on the calibration config above (Qwen3.5-35B-A3B-FP8 / gfx950 / vLLM TP1 / 1k-1k / conc 64). The skill ran  every round, degraded non-fatally, and the predicted-vs-actual calibration confirmed the routing behaves as designed. No issues.