### PR TITLE
fix: GEAK reports misleading raw-session baseline divergence (#390)

### DIFF
--- a/ci/ONBOARDING.md
+++ b/ci/ONBOARDING.md
@@ -13,7 +13,7 @@ $WS/
   InferenceX/           # bench client (cloned separately)
   geak_runtime/         # per-model data root ($HF_LOGS)
     <model_key>/
-      handoff.json                     # REQUIRED — properties + task (schema_version 1)
+      handoff.json                     # REQUIRED — properties + task (schema_version 2)
       baseline_config.with_envs.yaml   # REQUIRED — launch recipe
       kernel-agent/**/tracelens/analysis.md            # TraceLens priors (optional but recommended)
       kernel-agent/**/kernel_candidates.json
@@ -43,14 +43,14 @@ one-off HF download instead of pre-staging, set `GEAK_ALLOW_DOWNLOAD=1` and give
 real `hf_repo` in `models.tsv` (see step 3).
 
 ### 2. Drop the per-model GEAK material under `geak_runtime/<model_key>/`
-- **`handoff.json`** (required, `schema_version: 1`) — the single source of truth
+- **`handoff.json`** (required, `schema_version: 2`) — the single source of truth
   for `framework` and `tp` (they are NOT in `models.tsv`). Required non-empty keys:
   `model_path` and `exp_root` (both are hard-asserted; `exp_root` is rewritten at
   run time so any non-empty placeholder is fine). Functional fields used by the run:
 
   ```json
   {
-    "schema_version": 1,
+    "schema_version": 2,
     "model_path": "<placeholder or real path; overridden by staged weights>",
     "framework": "vllm",                 // vllm | sglang  -> picks the image
     "gpu_type": "mi300x",
@@ -60,6 +60,7 @@ real `hf_repo` in `models.tsv` (see step 3).
     "accepted_env": "VLLM_USE_AITER=1 ...",
     "launch_recipe": "<overridden to the local baseline_config.with_envs.yaml>",
     "raw_baseline_tput": 0,
+    "orchestrator_best_tput_same_config": 0,
     "exp_root": "<placeholder; overridden to geak_runtime/<model_key>/geak>",
     "bench_client": "auto",
     "inferencex_path": "<overridden to $WS/InferenceX>",

--- a/ci/fixtures/handoff.dry.json
+++ b/ci/fixtures/handoff.dry.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "model_path": "/tmp/geak-ci/models/Qwen3-8B",
   "framework": "vllm",
   "gpu_type": "mi300x",
@@ -13,6 +13,7 @@
   "accepted_env": "VLLM_USE_AITER=1 VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MHA=1 VLLM_ROCM_USE_AITER_RMSNORM=1",
   "launch_recipe": "/tmp/geak-ci/baseline_config.with_envs.yaml",
   "raw_baseline_tput": 4458.59,
+  "orchestrator_best_tput_same_config": 4680.25,
   "exp_root": "/tmp/geak-ci/geak",
   "bench_client": "auto",
   "inferencex_path": "/tmp/geak-ci/InferenceX",

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -253,8 +253,10 @@ Env: `PROFILER_PRIORITY` (default `rocprof-compute omniperf rocprofv3 rocprof me
 
 ## External-orchestrator contract (`interface/run_e2e.py`)
 
-The only surface an external orchestrator (for example, Hyperloom) touches — wraps `e2e_workflow.js` arg names
-behind one command and two JSON files (`schema_version` 1).
+The only surface an external orchestrator (for example, Hyperloom) touches —
+wraps `e2e_workflow.js` arg names behind one command and two JSON files. The
+current result schema is version 2; handoff schema 1 remains accepted, while
+schema 2 carries same-config alignment metadata.
 
 ```bash
 python interface/run_e2e.py <handoff.json> <result.json> [--dry-run]
@@ -262,7 +264,7 @@ python interface/run_e2e.py <handoff.json> <result.json> [--dry-run]
 
 Stable `handoff.json` fields: `model_path`, `framework` (→ `backend`), `tp`, `gpu_ids`,
 `workload{isl, osl, conc}`, `accepted_flags` / `env`, `exp_root`, `bench_client`, `bench_protocol`,
-`inferencex_path`, `raw_baseline_tput`.
+`inferencex_path`, `raw_baseline_tput`, `orchestrator_best_tput_same_config`.
 
 Env knobs: `GEAK_CLAUDE_MODEL` (`claude-opus-4-8`), `GEAK_CLAUDE_EFFORT` (`ultracode`),
 `GEAK_E2E_TIMEOUT_S` (`43200` = 12h), `GEAK_ROOT`, `GEAK_EVAL_DIR`, `INFERENCEX_PATH`.

--- a/docs/reference/run-e2e-contract.md
+++ b/docs/reference/run-e2e-contract.md
@@ -11,8 +11,8 @@ myst:
 touches. Everything volatile about the e2e workflow (the `e2e_workflow.js` arg
 names, the Claude Code `Workflow` invocation, the `--effort ultracode`
 requirement, the SDK-vs-CLI choice) is hidden behind one command and two JSON
-files. As long as `schema_version` stays `1`, the caller never changes when
-the workflow evolves internally.
+files. The result schema is versioned so callers can distinguish contract
+changes while the workflow evolves internally.
 
 ## Command
 
@@ -41,7 +41,7 @@ Pass the following fields in the handoff file.
 
 ```jsonc
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "model_path": "/models/Qwen-Qwen3.5-27B",
   "framework": "sglang",                 // -> backend (sglang|vllm)
   "gpu_type": "MI300X",
@@ -51,7 +51,8 @@ Pass the following fields in the handoff file.
   "accepted_flags": "--attention-backend triton",  // best config from the caller's search
   "accepted_env": "SGLANG_USE_AITER=1",
   "launch_recipe": "/path/baseline_config.with_envs.yaml",  // optional launch script/recipe
-  "raw_baseline_tput": 1485.4,           // caller's official raw baseline (carried for reference)
+  "raw_baseline_tput": 1485.4,           // caller's pre-change session baseline (audit reference)
+  "orchestrator_best_tput_same_config": 1550.8, // caller best measured with accepted_flags/env
   "exp_root": "/work/experiment/geak",   // basename MUST be `geak`; the timestamped run dir is created here
   "bench_client": "auto",                // auto|inferencex|native
   "inferencex_path": "/opt/InferenceX",  // optional; else taken from $INFERENCEX_PATH
@@ -91,6 +92,8 @@ The mapping is owned by `run_e2e.py:map_args`.
 | `accepted_flags` | `initial_extra_server_args` | seeds the baseline from caller best config |
 | `accepted_env` | `initial_extra_env` | seeds baseline env |
 | `launch_recipe` | `launch_script` | optional |
+| `raw_baseline_tput` | result audit metadata | pre-change session baseline; never used as the measurement-alignment signal |
+| `orchestrator_best_tput_same_config` | result alignment metadata | caller throughput on the accepted config GEAK uses for its baseline |
 | `exp_root` | `exp_root` | run dir root |
 | (derived from `exp_root`) | `tracelens` | auto-discovered upstream TraceLens artifacts; only non-null paths forwarded; key omitted entirely when none found |
 | `bench_client`, `inferencex_path` | env `BENCH_CLIENT`, `INFERENCEX_PATH` | exported so every `bench_e2e.sh` call inherits it (not a JS arg) |
@@ -130,7 +133,7 @@ The workflow writes the following fields to the result file.
 
 ```jsonc
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "status": "ok | no_gain | error",
   "eval_dir": "/work/experiment/geak/e2e_<model>_<ts>",
   "baseline_throughput_tok_s": 1485.4,
@@ -149,11 +152,36 @@ The workflow writes the following fields to the result file.
   "accepted_kernels": [ /* per-kernel detail */ ],
   "accepted_heads": [ /* head GEMM/attention winners */ ],
   "accepted_config": { "flags": "...", "env": "..." },
+  "baseline_basis": {
+    "geak_measured_baseline_tok_s": 1551.4,
+    "orchestrator_baseline_tok_s": 1485.4,
+    "raw_session_baseline_divergence_pct": 4.44,
+    "orchestrator_best_tput_same_config": 1550.8,
+    "current_best_same_config_divergence_pct": 0.04,
+    "measurement_divergence_pct": 0.04
+  },
+  "baseline_alignment": {
+    "status": "aligned | warning | unavailable",
+    "primary_metric": "current_best_same_config_divergence_pct",
+    "divergence_pct": 0.04,
+    "warning_threshold_pct": 3.0,
+    "raw_session_divergence_is_measurement_signal": false
+  },
   "report_path": ".../final_report.md",
   "kernel_journey_path": ".../kernel_journey.json",
   "recovered_from_disk": true
 }
 ```
+
+Schema v2 renames `baseline_divergence_pct` to
+`raw_session_baseline_divergence_pct`. The raw-session metric is audit-only
+because it includes accepted upstream configuration gains.
+
+`current_best_same_config_divergence_pct` is the primary cross-harness
+alignment metric. `measurement_divergence_pct` remains an exact compatibility
+alias for existing callers. If `orchestrator_best_tput_same_config` is absent,
+the same-config fields are `null` and `baseline_alignment.status` is
+`unavailable`; GEAK never treats raw-session divergence as measurement drift.
 
 ## Handoff resilience
 

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -489,6 +489,14 @@ attempt, win or not. REQUIRED sections, in order:
    phase reconciles this section to `EVAL_DIR/validation/{base,final}/bench_summary.json` (its authoritative
    same-session TTFT/TPOT/throughput).
 
+   The external interface deterministically injects a **Baseline alignment**
+   section after the workflow returns. Do not invent cross-harness baseline
+   values. If existing artifacts expose them, treat the upstream current-best
+   throughput measured on the same accepted configuration as the primary
+   alignment reference. Treat the upstream raw-session baseline as audit-only:
+   it may predate accepted configuration changes, so its divergence includes
+   configuration gain and must never be described as pure measurement drift.
+
 Data sources (read the ACTUAL files, never invent): `director_e2e_validation.json`,
 `final/bench/bench_summary.json`, `config/sweep_results.json`, `overlay/cand_*/integrate_result.json`,
 `kernels/_exp/*/*/director_validation.json`, `kernels/*/opbench_result.json` (incl. its `backend_absent[]`),

--- a/interface/run_e2e.md
+++ b/interface/run_e2e.md
@@ -4,8 +4,8 @@
 touches. Everything volatile about the e2e workflow (the `e2e_workflow.js` arg
 names, the Claude Code `Workflow` invocation, the `--effort ultracode`
 requirement, the SDK-vs-CLI choice) is hidden behind one command and two JSON
-files. As long as `schema_version` stays `1`, the caller never changes when
-the workflow evolves internally.
+files. The result schema is versioned so callers can distinguish contract
+changes while the workflow evolves internally.
 
 ## Command
 
@@ -30,7 +30,7 @@ The fast-path artifacts live under `<exp_root>/geak_e2e_moe_int4/`
 
 ```jsonc
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "model_path": "/models/Qwen-Qwen3.5-27B",
   "framework": "sglang",                 // -> backend (sglang|vllm)
   "gpu_type": "MI300X",
@@ -40,7 +40,8 @@ The fast-path artifacts live under `<exp_root>/geak_e2e_moe_int4/`
   "accepted_flags": "--attention-backend triton",  // best config from the caller's search
   "accepted_env": "SGLANG_USE_AITER=1",
   "launch_recipe": "/path/baseline_config.with_envs.yaml",  // optional launch script/recipe
-  "raw_baseline_tput": 1485.4,           // caller's official raw baseline (carried for reference)
+  "raw_baseline_tput": 1485.4,           // caller's pre-change session baseline (audit reference)
+  "orchestrator_best_tput_same_config": 1550.8, // caller best measured with accepted_flags/env
   "exp_root": "/work/experiment/geak",   // basename MUST be `geak`; the timestamped run dir is created here
   "bench_client": "auto",                // auto|inferencex|native — see口径 alignment below
   "inferencex_path": "/opt/InferenceX",  // optional; else taken from $INFERENCEX_PATH
@@ -78,6 +79,8 @@ a ~10-15% 口径 gap. Both default to `0` (fixed) so the standalone and forwarde
 | `accepted_flags` | `initial_extra_server_args` | seeds the baseline = caller best config |
 | `accepted_env` | `initial_extra_env` | seeds baseline env |
 | `launch_recipe` | `launch_script` | optional |
+| `raw_baseline_tput` | result audit metadata | pre-change session baseline; never used as the measurement-alignment signal |
+| `orchestrator_best_tput_same_config` | result alignment metadata | caller throughput on the accepted config GEAK uses for its baseline |
 | `exp_root` | `exp_root` | run dir root |
 | (derived from `exp_root`) | `tracelens` | auto-discovered upstream TraceLens / kernel-agent artifacts (see below); only non-null paths forwarded; key omitted entirely when none found |
 | `bench_client` / `inferencex_path` | env `BENCH_CLIENT` + `INFERENCEX_PATH` | exported so every `bench_e2e.sh` call inherits it (not a JS arg) |
@@ -121,7 +124,7 @@ the baseline prior is stale) the workflow profiles/strategizes exactly as before
 
 ```jsonc
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "status": "ok | no_gain | error",
   "eval_dir": "/work/experiment/geak/e2e_<model>_<ts>",
   "baseline_throughput_tok_s": 1485.4,   // baseline (= caller best config)
@@ -140,11 +143,37 @@ the baseline prior is stale) the workflow profiles/strategizes exactly as before
   "accepted_kernels": [ /* what was optimized + how (per-kernel) */ ],
   "accepted_heads": [ /* head GEMM/attn winners */ ],
   "accepted_config": { "flags": "...", "env": "..." },
+  "baseline_basis": {
+    "geak_measured_baseline_tok_s": 1551.4,
+    "orchestrator_baseline_tok_s": 1485.4,
+    "raw_session_baseline_divergence_pct": 4.44, // audit only; includes accepted config gain
+    "orchestrator_best_tput_same_config": 1550.8,
+    "current_best_same_config_divergence_pct": 0.04, // primary alignment metric
+    "measurement_divergence_pct": 0.04 // backward-compatible alias
+  },
+  "baseline_alignment": {
+    "status": "aligned | warning | unavailable",
+    "primary_metric": "current_best_same_config_divergence_pct",
+    "divergence_pct": 0.04,
+    "warning_threshold_pct": 3.0,
+    "raw_session_divergence_is_measurement_signal": false
+  },
   "report_path": ".../final_report.md",  // human report: per-kernel optimizations, changed params, TTFT/TPOT
   "kernel_journey_path": ".../kernel_journey.json",  // per-kernel journey contract (see below); absent if nothing accepted
   "recovered_from_disk": true             // present+true only when the handoff was rebuilt from on-disk artifacts
 }
 ```
+
+`raw_session_baseline_divergence_pct` compares GEAK's accepted-config baseline
+with the caller's pre-change session baseline. It is audit-only because it
+includes configuration gains accepted before GEAK started.
+
+`current_best_same_config_divergence_pct` compares the same accepted
+configuration in both harnesses and is the primary alignment metric.
+`measurement_divergence_pct` remains an exact compatibility alias for existing
+callers. If the handoff omits `orchestrator_best_tput_same_config`, both
+same-config fields are `null` and `baseline_alignment.status` is `unavailable`;
+GEAK never falls back to the raw-session divergence as a drift signal.
 
 ## Handoff resilience (the workflow return is never the single point of failure)
 

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import atexit
 import glob
 import json
+import math
 import os
 import shlex
 import shutil
@@ -38,7 +39,23 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+KERNEL_JOURNEY_SCHEMA_VERSION = 1
+
+try:
+    SAME_CONFIG_DIVERGENCE_WARN_PCT = float(
+        os.environ.get("GEAK_SAME_CONFIG_DIVERGENCE_WARN_PCT", "3.0")
+    )
+    if (
+        not math.isfinite(SAME_CONFIG_DIVERGENCE_WARN_PCT)
+        or SAME_CONFIG_DIVERGENCE_WARN_PCT < 0.0
+    ):
+        raise ValueError("warning threshold must be finite and non-negative")
+except (TypeError, ValueError):
+    SAME_CONFIG_DIVERGENCE_WARN_PCT = 3.0
+
+BASELINE_ALIGNMENT_BEGIN = "<!-- GEAK_BASELINE_ALIGNMENT_BEGIN -->"
+BASELINE_ALIGNMENT_END = "<!-- GEAK_BASELINE_ALIGNMENT_END -->"
 
 # interface/ is a sibling of e2e_workflow/ under the repo root.
 INTERFACE_DIR = Path(__file__).resolve().parent
@@ -1022,6 +1039,56 @@ def _state_op_names(wf: dict, queue: str) -> set[str]:
     return names
 
 
+def _divergence_pct(measured: Any, reference: Any) -> float | None:
+    """Return percentage divergence from a positive reference."""
+    try:
+        measured_value = float(measured)
+        reference_value = float(reference)
+    except (TypeError, ValueError):
+        return None
+    if (
+        not math.isfinite(measured_value)
+        or not math.isfinite(reference_value)
+        or measured_value <= 0.0
+        or reference_value <= 0.0
+    ):
+        return None
+    return round(
+        100.0 * (measured_value - reference_value) / reference_value,
+        2,
+    )
+
+
+def _positive_finite_float(value: Any) -> float:
+    """Normalize external numeric input for strict JSON serialization."""
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(normalized) or normalized <= 0.0:
+        return 0.0
+    return normalized
+
+
+def _build_baseline_alignment(
+    same_config_divergence_pct: float | None,
+) -> dict[str, Any]:
+    """Classify cross-harness alignment using only the same-config metric."""
+    if same_config_divergence_pct is None:
+        status = "unavailable"
+    elif abs(same_config_divergence_pct) > SAME_CONFIG_DIVERGENCE_WARN_PCT:
+        status = "warning"
+    else:
+        status = "aligned"
+    return {
+        "status": status,
+        "primary_metric": "current_best_same_config_divergence_pct",
+        "divergence_pct": same_config_divergence_pct,
+        "warning_threshold_pct": SAME_CONFIG_DIVERGENCE_WARN_PCT,
+        "raw_session_divergence_is_measurement_signal": False,
+    }
+
+
 def normalize_result(h: dict, wf: dict) -> dict:
     eval_dir = Path(wf["eval_dir"])
     validation = _read_json(eval_dir / "director_e2e_validation.json")
@@ -1128,56 +1195,47 @@ def normalize_result(h: dict, wf: dict) -> dict:
                 wf["accepted_heads"] = [_entry]
             wf["attribution_backfilled"] = True
 
-    # baseline measurement-protocol cross-check (GEAK-E2E vs Hyperloom-E2E divergence).
-    # GEAK's measured baseline is already seeded with Hyperloom's accepted config (map_args forwards
-    # accepted_flags/accepted_env), so it should match Hyperloom's own baseline. Surface BOTH numbers
-    # plus their divergence so the caller can tell a real win from a measurement mismatch (different
-    # client/protocol/warm-vs-cold) instead of trusting a gain measured against a different baseline.
-    geak_baseline = float(
+    # Cross-harness measurement-protocol check. GEAK's measured baseline is
+    # seeded with the upstream orchestrator's accepted config, so compare it
+    # separately with the raw session baseline and the same-config current best.
+    geak_baseline = _positive_finite_float(
         wf.get("baseline_throughput_tok_s")
         or validation.get("baseline_throughput_tok_s")
         or 0.0
     )
-    geak_final = float(
+    geak_final = _positive_finite_float(
         wf.get("final_throughput_tok_s")
         or validation.get("director_verified_throughput_tok_s")
         or 0.0
     )
-    try:
-        orch_baseline = float(h.get("raw_baseline_tput") or 0.0)
-    except (TypeError, ValueError):
-        orch_baseline = 0.0
+    orch_baseline = _positive_finite_float(h.get("raw_baseline_tput"))
     # Orchestrator throughput measured on the SAME config GEAK seeds with
-    # (== Hyperloom current_best config). When present it isolates the PURE
+    # (the upstream orchestrator's current-best config). When present it isolates
+    # the PURE
     # cross-harness measurement residue (identical config, both harnesses) from
     # the explore/framework config gain that is baked into the raw-baseline
-    # comparison. Falls back to raw baseline when absent (older handoffs).
-    try:
-        orch_same_cfg = float(h.get("orchestrator_best_tput_same_config") or 0.0)
-    except (TypeError, ValueError):
-        orch_same_cfg = 0.0
+    # comparison. It remains unavailable when absent from older handoffs.
+    orch_same_cfg = _positive_finite_float(
+        h.get("orchestrator_best_tput_same_config")
+    )
+    raw_session_divergence_pct = _divergence_pct(geak_baseline, orch_baseline)
+    same_config_divergence_pct = _divergence_pct(geak_baseline, orch_same_cfg)
+    baseline_alignment = _build_baseline_alignment(same_config_divergence_pct)
     baseline_basis = {
         # GEAK's own measured baseline (Hyperloom-accepted config = fair engagement baseline; gating uses this).
         "geak_measured_baseline_tok_s": geak_baseline or None,
         # Hyperloom's own measured baseline forwarded in the handoff (the orchestrator reference).
         "orchestrator_baseline_tok_s": orch_baseline or None,
-        # How far GEAK's baseline drifted from Hyperloom's RAW baseline. NOTE:
-        # this conflates the explore/framework CONFIG gain (GEAK seeds with the
-        # accepted config, raw baseline does not) with measurement residue, so it
-        # is NOT a clean measurement-mismatch signal. Kept for continuity.
-        "baseline_divergence_pct": (
-            round(100.0 * (geak_baseline - orch_baseline) / orch_baseline, 2)
-            if (geak_baseline > 0 and orch_baseline > 0) else None
-        ),
+        # Audit-only comparison with the RAW session baseline. This includes
+        # accepted upstream config gain and is not a measurement-drift signal.
+        "raw_session_baseline_divergence_pct": raw_session_divergence_pct,
         # PURE cross-harness measurement residue: GEAK baseline vs the
         # orchestrator's throughput on the SAME (accepted) config. Both sides
         # run the identical config, so this isolates client/protocol/warm-cold
-        # differences from the config gain. This is the value promote-side gating
-        # should use. None when the same-config baseline was not forwarded.
-        "measurement_divergence_pct": (
-            round(100.0 * (geak_baseline - orch_same_cfg) / orch_same_cfg, 2)
-            if (geak_baseline > 0 and orch_same_cfg > 0) else None
-        ),
+        # differences from the config gain. This is the primary alignment metric.
+        "current_best_same_config_divergence_pct": same_config_divergence_pct,
+        # Backward-compatible alias consumed by existing orchestrators.
+        "measurement_divergence_pct": same_config_divergence_pct,
         "orchestrator_best_tput_same_config": orch_same_cfg or None,
         # Gain measured against the ORCHESTRATOR baseline (what Hyperloom sees end-to-end).
         "gain_vs_orchestrator_baseline": (
@@ -1261,11 +1319,7 @@ def normalize_result(h: dict, wf: dict) -> dict:
         "status": status,
         "result_source": result_source,
         "eval_dir": str(eval_dir),
-        "baseline_throughput_tok_s": float(
-            wf.get("baseline_throughput_tok_s")
-            or validation.get("baseline_throughput_tok_s")
-            or 0.0
-        ),
+        "baseline_throughput_tok_s": geak_baseline,
         # Promoted final: the COLD final when it is a real cold win, else the HOT
         # median (see the final-basis selection above). final_throughput_basis says
         # which one this is, so a consumer can tell cold-to-cold from hot-to-cold.
@@ -1311,11 +1365,158 @@ def normalize_result(h: dict, wf: dict) -> dict:
         "accepted_config": wf.get("accepted_config") or {},
         # Self-describing baseline measurement-protocol + Hyperloom cross-check (see baseline_basis above).
         "baseline_basis": baseline_basis,
+        # Reliability classification is independent of the optimization status.
+        "baseline_alignment": baseline_alignment,
         # Cold/hot speedup cross-checks (double-check only; see alignment_metrics above).
         # Does NOT change the promoted final_throughput_tok_s / throughput_speedup.
         "alignment_metrics": alignment_metrics,
         "report_path": wf.get("report_path") or str(eval_dir / "final_report.md"),
     }
+
+
+def _format_optional_number(
+    value: Any,
+    *,
+    digits: int = 2,
+    suffix: str = "",
+) -> str:
+    try:
+        return f"{float(value):.{digits}f}{suffix}"
+    except (TypeError, ValueError):
+        return "unavailable"
+
+
+def _render_baseline_alignment_section(result: dict[str, Any]) -> str:
+    """Render a deterministic, same-config-first report section."""
+    basis = result.get("baseline_basis") or {}
+    alignment = result.get("baseline_alignment") or {}
+    geak_baseline = _format_optional_number(
+        basis.get("geak_measured_baseline_tok_s"), digits=3, suffix=" tok/s"
+    )
+    same_config_baseline = _format_optional_number(
+        basis.get("orchestrator_best_tput_same_config"),
+        digits=3,
+        suffix=" tok/s",
+    )
+    same_config_divergence = _format_optional_number(
+        basis.get("current_best_same_config_divergence_pct"),
+        digits=2,
+        suffix="%",
+    )
+    raw_baseline = _format_optional_number(
+        basis.get("orchestrator_baseline_tok_s"), digits=3, suffix=" tok/s"
+    )
+    raw_divergence = _format_optional_number(
+        basis.get("raw_session_baseline_divergence_pct"),
+        digits=2,
+        suffix="%",
+    )
+    threshold = _format_optional_number(
+        alignment.get("warning_threshold_pct"), digits=1, suffix="%"
+    )
+    status = str(alignment.get("status") or "unavailable")
+    return "\n".join(
+        [
+            BASELINE_ALIGNMENT_BEGIN,
+            "## Baseline alignment",
+            "",
+            "Primary same-config comparison:",
+            "",
+            f"- GEAK measured baseline: {geak_baseline}",
+            (
+                "- Upstream current-best baseline on the same config: "
+                f"{same_config_baseline}"
+            ),
+            f"- Same-config divergence: {same_config_divergence}",
+            f"- Alignment status: `{status}` (warning threshold: ±{threshold})",
+            "",
+            "Raw-session audit comparison:",
+            "",
+            f"- Upstream raw-session baseline: {raw_baseline}",
+            f"- Raw-session baseline divergence: {raw_divergence}",
+            "",
+            (
+                "The raw-session baseline predates accepted upstream configuration "
+                "changes and is not expected to match the GEAK baseline. Its "
+                "divergence includes previously accepted configuration gains and "
+                "is not a pure measurement-drift signal."
+            ),
+            BASELINE_ALIGNMENT_END,
+        ]
+    )
+
+
+def _upsert_marked_markdown_section(
+    text: str,
+    section: str,
+    *,
+    begin_marker: str,
+    end_marker: str,
+) -> str:
+    """Replace a generated section or insert it after the first H1."""
+    begin = text.find(begin_marker)
+    end = text.find(end_marker)
+    if begin >= 0 and end >= begin:
+        end += len(end_marker)
+        return text[:begin] + section + text[end:]
+
+    lines = text.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if line.startswith("# "):
+            return (
+                "".join(lines[: index + 1])
+                + "\n"
+                + section
+                + "\n\n"
+                + "".join(lines[index + 1 :])
+            )
+    return section + "\n\n" + text
+
+
+def _update_baseline_alignment_reports(result: dict[str, Any]) -> list[str]:
+    """Idempotently add baseline alignment to every existing primary report."""
+    section = _render_baseline_alignment_section(result)
+    eval_dir = str(result.get("eval_dir") or "").strip()
+    if not eval_dir:
+        return []
+    eval_root = Path(eval_dir).resolve(strict=False)
+
+    candidates: list[Path] = []
+    report_path = str(result.get("report_path") or "").strip()
+    if report_path:
+        report_candidate = Path(report_path)
+        if not report_candidate.is_absolute():
+            report_candidate = eval_root / report_candidate
+        candidates.append(report_candidate)
+    candidates.append(eval_root / "final_report.md")
+
+    updated: list[str] = []
+    seen: set[str] = set()
+    for path in candidates:
+        resolved_path = path.resolve(strict=False)
+        try:
+            resolved_path.relative_to(eval_root)
+        except ValueError:
+            continue
+        key = str(resolved_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not resolved_path.is_file():
+            continue
+        original = resolved_path.read_text(encoding="utf-8")
+        rendered = _upsert_marked_markdown_section(
+            original,
+            section,
+            begin_marker=BASELINE_ALIGNMENT_BEGIN,
+            end_marker=BASELINE_ALIGNMENT_END,
+        )
+        if rendered != original:
+            tmp = resolved_path.with_name(resolved_path.name + ".tmp")
+            tmp.write_text(rendered, encoding="utf-8")
+            os.replace(tmp, resolved_path)
+        updated.append(str(resolved_path))
+    return updated
 
 
 # ---------------------------------------------------------------------------
@@ -2101,7 +2302,7 @@ def build_kernel_journey(wf: dict, normalized: dict) -> dict:
         }]
 
     return {
-        "schema_version": SCHEMA_VERSION,
+        "schema_version": KERNEL_JOURNEY_SCHEMA_VERSION,
         "producer": "kernel-agent",
         "eval_dir": eval_dir_str,
         "versions": _geak_versions(),
@@ -2130,7 +2331,7 @@ def _empty_journey(eval_dir: Path, normalized: dict) -> dict:
     finds a parseable file and can see WHY nothing landed — used on an error/
     timeout/no-recovery run, or as the fallback when the full build raises."""
     return {
-        "schema_version": SCHEMA_VERSION,
+        "schema_version": KERNEL_JOURNEY_SCHEMA_VERSION,
         "producer": "kernel-agent",
         "eval_dir": str(eval_dir),
         "versions": _geak_versions(),
@@ -2275,6 +2476,15 @@ def main(argv: list[str]) -> int:
                 out["kernel_journey_path"] = _write_kernel_journey(eval_dir, wf, out)
             except Exception as kj_exc:
                 out["kernel_journey_error"] = f"{type(kj_exc).__name__}: {kj_exc}"
+        if out.get("baseline_basis"):
+            try:
+                updated_reports = _update_baseline_alignment_reports(out)
+                if updated_reports:
+                    out["baseline_alignment_report_paths"] = updated_reports
+            except Exception as report_exc:
+                out["baseline_alignment_report_error"] = (
+                    f"{type(report_exc).__name__}: {report_exc}"
+                )
         try:
             result_path.parent.mkdir(parents=True, exist_ok=True)
             tmp = result_path.with_name(result_path.name + ".tmp")

--- a/interface/test_run_e2e_alignment.py
+++ b/interface/test_run_e2e_alignment.py
@@ -11,12 +11,12 @@ two failure modes that inflate the leaderboard:
 The contract under test (see run_e2e normalize_result / baseline_basis +
 alignment_metrics):
 
-  * ``measurement_divergence_pct`` = GEAK baseline vs the orchestrator's tput on
-    the SAME accepted config (identical config both sides) — the clean residue,
-    populated only when the handoff forwards
-    ``orchestrator_best_tput_same_config``.
-  * ``baseline_divergence_pct`` = GEAK baseline vs the orchestrator RAW baseline
-    (conflates config gain + residue) — kept for continuity.
+  * ``current_best_same_config_divergence_pct`` = GEAK baseline vs the
+    orchestrator's tput on the SAME accepted config — the primary clean residue.
+  * ``measurement_divergence_pct`` is the backward-compatible alias for that
+    same-config metric.
+  * ``raw_session_baseline_divergence_pct`` = GEAK baseline vs the orchestrator
+    RAW baseline (conflates config gain + residue) — audit only.
   * ``cold_speedup`` = GEAK cold final / orchestrator COLD baseline — the exact
     number Hyperloom promotes as its (cross-harness) PROVISIONAL gain, so it must
     equal current_best.tput / baseline_tput.
@@ -54,41 +54,85 @@ def _wf(eval_dir: Path, *, base: float, final: float, speedup: float) -> dict:
     }
 
 
-def test_measurement_divergence_uses_same_config_not_raw_baseline(tmp_path: Path) -> None:
-    """The clean residue divides GEAK baseline by the SAME-config orch tput.
-
-    A large raw-baseline divergence must NOT masquerade as a measurement
-    mismatch when the same-config numbers actually agree.
-    """
+def test_issue6_names_raw_and_same_config_divergence_explicitly(
+    tmp_path: Path,
+) -> None:
+    """Issue 6 values distinguish accepted gain from measurement residue."""
     eval_dir = tmp_path / "e2e"
     eval_dir.mkdir()
-    geak_baseline = 2974.662
-    orch_raw = 2844.209          # lower — includes the config gain GEAK seeds with
-    orch_same_cfg = 2960.0       # orchestrator on the identical accepted config
+    geak_baseline = 537.354
+    orch_raw = 498.81
+    orch_same_cfg = 537.15
     h = {
-        "workload": {"isl": 1024, "osl": 1024, "conc": 64},
+        "workload": {"isl": 16384, "osl": 512, "conc": 16},
         "raw_baseline_tput": orch_raw,
         "orchestrator_best_tput_same_config": orch_same_cfg,
     }
-    wf = _wf(eval_dir, base=geak_baseline, final=3236.489, speedup=1.088)
+    wf = _wf(eval_dir, base=geak_baseline, final=532.119, speedup=0.9903)
 
     out = rx.normalize_result(h, wf)
     bb = out["baseline_basis"]
 
-    # Pure residue: GEAK baseline vs SAME-config orchestrator tput.
-    assert bb["measurement_divergence_pct"] == pytest.approx(
-        100.0 * (geak_baseline - orch_same_cfg) / orch_same_cfg, abs=0.01
+    assert bb["raw_session_baseline_divergence_pct"] == pytest.approx(
+        7.73, abs=0.01
     )
-    # Raw-baseline divergence is the LARGER, config-conflated number.
-    assert bb["baseline_divergence_pct"] == pytest.approx(
-        100.0 * (geak_baseline - orch_raw) / orch_raw, abs=0.01
+    assert bb["current_best_same_config_divergence_pct"] == pytest.approx(
+        0.04, abs=0.01
     )
-    assert abs(bb["baseline_divergence_pct"]) > abs(bb["measurement_divergence_pct"])
+    assert (
+        bb["measurement_divergence_pct"]
+        == bb["current_best_same_config_divergence_pct"]
+    )
+    assert "baseline_divergence_pct" not in bb
     assert bb["orchestrator_best_tput_same_config"] == pytest.approx(orch_same_cfg)
+    assert out["baseline_alignment"]["status"] == "aligned"
 
 
-def test_measurement_divergence_none_when_same_config_absent(tmp_path: Path) -> None:
-    """Older handoffs (no same-config tput) leave the clean residue undefined."""
+def test_same_config_divergence_above_threshold_is_warning(tmp_path: Path) -> None:
+    """A real same-config mismatch warns without changing optimization status."""
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    h = {
+        "workload": {"isl": 1024, "osl": 1024, "conc": 64},
+        "raw_baseline_tput": 1331.7541295483402,
+        "orchestrator_best_tput_same_config": 1872.9515966860333,
+    }
+    wf = _wf(eval_dir, base=1785.741, final=2869.795, speedup=1.607)
+
+    out = rx.normalize_result(h, wf)
+
+    assert out["baseline_basis"][
+        "current_best_same_config_divergence_pct"
+    ] == pytest.approx(-4.66, abs=0.01)
+    assert out["baseline_alignment"]["status"] == "warning"
+    assert out["status"] == "ok"
+
+
+def test_large_raw_gain_does_not_trigger_alignment_warning(tmp_path: Path) -> None:
+    """Accepted config gain is audit-only when same-config measurements align."""
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    h = {
+        "workload": {"isl": 1024, "osl": 1024, "conc": 64},
+        "raw_baseline_tput": 100.0,
+        "orchestrator_best_tput_same_config": 120.0,
+    }
+    wf = _wf(eval_dir, base=120.2, final=125.0, speedup=1.04)
+
+    out = rx.normalize_result(h, wf)
+    bb = out["baseline_basis"]
+
+    assert bb["raw_session_baseline_divergence_pct"] == pytest.approx(
+        20.2, abs=0.01
+    )
+    assert bb["current_best_same_config_divergence_pct"] == pytest.approx(
+        0.17, abs=0.01
+    )
+    assert out["baseline_alignment"]["status"] == "aligned"
+
+
+def test_same_config_alignment_unavailable_without_reference(tmp_path: Path) -> None:
+    """Older handoffs never fall back to raw divergence for alignment."""
     eval_dir = tmp_path / "e2e"
     eval_dir.mkdir()
     h = {
@@ -98,9 +142,87 @@ def test_measurement_divergence_none_when_same_config_absent(tmp_path: Path) -> 
     }
     wf = _wf(eval_dir, base=2974.662, final=3236.489, speedup=1.088)
 
-    bb = rx.normalize_result(h, wf)["baseline_basis"]
+    out = rx.normalize_result(h, wf)
+    bb = out["baseline_basis"]
     assert bb["measurement_divergence_pct"] is None
-    assert bb["baseline_divergence_pct"] is not None  # raw still computable
+    assert bb["current_best_same_config_divergence_pct"] is None
+    assert bb["raw_session_baseline_divergence_pct"] is not None
+    assert out["baseline_alignment"]["status"] == "unavailable"
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_divergence_inputs_are_unavailable(
+    tmp_path: Path,
+    value: float,
+) -> None:
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    h = {
+        "workload": {"isl": 1024, "osl": 1024, "conc": 64},
+        "raw_baseline_tput": 100.0,
+        "orchestrator_best_tput_same_config": value,
+    }
+    wf = _wf(eval_dir, base=120.0, final=125.0, speedup=1.04)
+
+    out = rx.normalize_result(h, wf)
+
+    assert out["baseline_basis"]["measurement_divergence_pct"] is None
+    assert out["baseline_basis"]["orchestrator_best_tput_same_config"] is None
+    assert out["baseline_alignment"]["status"] == "unavailable"
+    json.dumps(out, allow_nan=False)
+
+
+def test_alignment_report_is_same_config_first_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    report = tmp_path / "final_report.md"
+    report.write_text("# GEAK final report\n\nExisting content.\n", encoding="utf-8")
+    result = {
+        "report_path": str(report),
+        "eval_dir": str(tmp_path),
+        "baseline_basis": {
+            "geak_measured_baseline_tok_s": 537.354,
+            "orchestrator_baseline_tok_s": 498.81,
+            "raw_session_baseline_divergence_pct": 7.73,
+            "current_best_same_config_divergence_pct": 0.04,
+            "measurement_divergence_pct": 0.04,
+            "orchestrator_best_tput_same_config": 537.15,
+        },
+        "baseline_alignment": {
+            "status": "aligned",
+            "primary_metric": "current_best_same_config_divergence_pct",
+            "divergence_pct": 0.04,
+            "warning_threshold_pct": 3.0,
+            "raw_session_divergence_is_measurement_signal": False,
+        },
+    }
+
+    rx._update_baseline_alignment_reports(result)
+    rx._update_baseline_alignment_reports(result)
+
+    rendered = report.read_text(encoding="utf-8")
+    assert rendered.count(rx.BASELINE_ALIGNMENT_BEGIN) == 1
+    assert rendered.count(rx.BASELINE_ALIGNMENT_END) == 1
+    assert rendered.index("Primary same-config comparison") < rendered.index(
+        "Raw-session audit comparison"
+    )
+    assert "not a pure measurement-drift signal" in rendered
+
+
+def test_alignment_report_refuses_path_outside_eval_dir(tmp_path: Path) -> None:
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text("# External report\n", encoding="utf-8")
+    result = {
+        "report_path": str(outside),
+        "eval_dir": str(eval_dir),
+        "baseline_basis": {},
+        "baseline_alignment": {"status": "unavailable"},
+    }
+
+    assert rx._update_baseline_alignment_reports(result) == []
+    assert outside.read_text(encoding="utf-8") == "# External report\n"
 
 
 def test_map_args_forwards_serving_fidelity_when_present(tmp_path: Path) -> None:

--- a/interface/test_run_e2e_recovery.py
+++ b/interface/test_run_e2e_recovery.py
@@ -62,7 +62,7 @@ def _make_eval_dir(tmp_path: Path, *, accepted: bool = True,
 
 def _handoff(eval_dir: Path) -> dict:
     return {
-        "schema_version": 1, "model_path": "/models/fake", "framework": "vllm",
+        "schema_version": 2, "model_path": "/models/fake", "framework": "vllm",
         "tp": 8, "workload": {"isl": 8192, "osl": 1024, "conc": 64},
         "exp_root": str(eval_dir.parent), "eval_dir": str(eval_dir),
     }
@@ -449,29 +449,51 @@ def test_result_source_live_workflow_return(tmp_path):
 
 # ── guaranteed emit in main() ───────────────────────────────────────────────
 
-def _run_main(monkeypatch, tmp_path, eval_dir, *, invoke):
+def _run_main(monkeypatch, tmp_path, eval_dir, *, invoke, handoff_extra=None):
     monkeypatch.setattr(rx, "invoke_workflow", invoke)
     monkeypatch.setattr(rx, "apply_bench_client", lambda h: "native")
     monkeypatch.setattr(rx, "apply_bench_protocol", lambda h: {})
     hp = tmp_path / "handoff.json"
     rp = tmp_path / "out" / "result.json"
-    hp.write_text(json.dumps(_handoff(eval_dir)), encoding="utf-8")
+    handoff = _handoff(eval_dir)
+    handoff.update(handoff_extra or {})
+    hp.write_text(json.dumps(handoff), encoding="utf-8")
     rc = rx.main([str(hp), str(rp)])
     return rc, rp
 
 
 def test_emit_on_success(monkeypatch, tmp_path):
     eval_dir = _make_eval_dir(tmp_path, with_validation=True)
+    report = eval_dir / "final_report.md"
+    report.write_text("# GEAK final report\n", encoding="utf-8")
 
     def ok_invoke(prompt, t, ed):
         return {"eval_dir": str(eval_dir), "throughput_speedup": 1.16,
                 "final_throughput_tok_s": 535.352,
-                "baseline_throughput_tok_s": 461.314}
+                "baseline_throughput_tok_s": 461.314,
+                "report_path": str(report)}
 
-    rc, rp = _run_main(monkeypatch, tmp_path, eval_dir, invoke=ok_invoke)
+    rc, rp = _run_main(
+        monkeypatch,
+        tmp_path,
+        eval_dir,
+        invoke=ok_invoke,
+        handoff_extra={
+            "raw_baseline_tput": 430.0,
+            "orchestrator_best_tput_same_config": 460.0,
+        },
+    )
     assert rp.is_file(), "result.json MUST exist on success"
     out = json.loads(rp.read_text())
     assert out["status"] == "ok"
+    assert out["schema_version"] == 2
+    assert out["baseline_alignment"]["status"] == "aligned"
+    assert out["baseline_basis"]["measurement_divergence_pct"] == out[
+        "baseline_basis"
+    ]["current_best_same_config_divergence_pct"]
+    assert "baseline_divergence_pct" not in out["baseline_basis"]
+    rendered = report.read_text(encoding="utf-8")
+    assert rendered.count(rx.BASELINE_ALIGNMENT_BEGIN) == 1
     assert (eval_dir / "kernel_journey.json").is_file()
 
 
@@ -479,16 +501,31 @@ def test_emit_when_workflow_raises_but_disk_has_intermediate(monkeypatch, tmp_pa
     """The killer case: workflow dies before Validate, but an accepted
     intermediate is on disk -> result.json MUST still be ok (not discarded)."""
     eval_dir = _make_eval_dir(tmp_path, accepted=True, with_validation=False)
+    report = eval_dir / "final_report.md"
+    report.write_text("# Recovered GEAK report\n", encoding="utf-8")
 
     def boom(prompt, t, ed):
         raise TimeoutError("budget expired before Validate")
 
-    rc, rp = _run_main(monkeypatch, tmp_path, eval_dir, invoke=boom)
+    rc, rp = _run_main(
+        monkeypatch,
+        tmp_path,
+        eval_dir,
+        invoke=boom,
+        handoff_extra={
+            "raw_baseline_tput": 430.0,
+            "orchestrator_best_tput_same_config": 461.0,
+        },
+    )
     assert rp.is_file(), "result.json MUST exist even when workflow raised"
     out = json.loads(rp.read_text())
     assert out["status"] == "ok"
     assert out.get("recovered_from_disk") is True
     assert out["final_throughput_tok_s"] == pytest.approx(535.352)
+    assert out["baseline_alignment"]["status"] == "aligned"
+    assert report.read_text(encoding="utf-8").count(
+        rx.BASELINE_ALIGNMENT_BEGIN
+    ) == 1
     assert (eval_dir / "kernel_journey.json").is_file()
 
 


### PR DESCRIPTION
## Background

GEAK currently compares its accepted-config baseline against both:

- the orchestrator's original raw-session baseline; and
- the orchestrator's current-best throughput on the same accepted config.

The raw-session comparison includes optimization gains accepted before GEAK
starts, so it is not a pure measurement-drift signal. The existing
`baseline_divergence_pct` name makes that distinction unclear and can cause a
large accepted configuration gain to be interpreted as cross-harness drift.

Refs #390

## Changes

- Rename `baseline_divergence_pct` to
  `raw_session_baseline_divergence_pct` to make its audit-only semantics clear.
- Add `current_best_same_config_divergence_pct` as the explicitly named primary
  cross-harness alignment metric.
- Preserve `measurement_divergence_pct` as an exact compatibility alias so
  existing Hyperloom integrations continue to work without changes.
- Add structured baseline alignment results:
  - `aligned` when same-config divergence is within tolerance;
  - `warning` when it exceeds tolerance;
  - `unavailable` when no valid same-config reference is provided.
- Keep alignment status independent from the optimization result status. A
  measurement warning does not automatically change an `ok` result.
- Add deterministic report post-processing that:
  - presents the same-config comparison first;
  - marks raw-session divergence as audit-only;
  - explains that it may include previously accepted configuration gains;
  - remains idempotent across recovery and repeated emission.
- Validate baseline inputs before serialization and treat non-finite values as
  unavailable.
- Restrict generated report updates to files inside the run's `eval_dir`.
- Update the external interface schema, documentation, CI handoff fixture, and
  workflow reporting guidance.

## Compatibility

No Hyperloom changes are required.

`measurement_divergence_pct` retains its existing same-config semantics, while
the ambiguous raw-session field is replaced with the explicit
`raw_session_baseline_divergence_pct` name.

The result schema is updated to version 2. The kernel journey schema remains
unchanged.

## Validation

- `interface/test_run_e2e_alignment.py`: 17 passed, 1 skipped.
- `interface/test_run_e2e_recovery.py`: 32 passed.
- Full `interface/` suite: 49 passed, 1 skipped.
- Updated `handoff.dry.json` completed `--dry-run` successfully.
- Repository search confirmed that the old key has no production-code
  references.

The skipped test requires a real session fixture that was not available in the
test environment. It is a pre-existing environment dependency and is unrelated
to this change.