### PR TITLE
feat(kernel_workflow): learned-knowledge cards

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -142,6 +142,7 @@ budget-controlled, each patch independently verified.
 | `target_language` | `triton` | Author-mode language: `triton` \| `flydsl` \| `hip` \| `ck`. |
 | `op_spec` | `{}` | Op specification (author mode). |
 | `perf_knowledge_dir` | sibling `perf_knowledge/` | Knowledge base. |
+| `update_experience` | `on` | Curate ONE distilled card into `kernel_workflow/knowledge/learned/` after a measured win (every lane run; once centrally per bake-off). `off` skips it. The sink is always this workflow's own `learned/` — an e2e-opened lane never writes into `e2e_workflow/knowledge/learned/`. Cards carry a skill-style discovery header (`name`/`description`/`keywords`/`kernels`/`platforms`/`kernel_class`/`regime`) and `learned/INDEX.md` is regenerated from it by `kernel_workflow/scripts/build_learned_index.js` (`--check` = fail-if-stale). Numbers on a card are relative only (ratios, % of achievable peak) — never wall-clock. |
 | `workload_spec_path` | — | Workload-alignment spec; makes the primary metric the time-weighted ratio-of-sums. |
 | `agent_timeout_ms` | `3600000` | Per-agent timeout (1h). |
 | `agent_retries` | `4` | Agent retry count (min 1). |

--- a/e2e_workflow/knowledge/learned/INDEX.md
+++ b/e2e_workflow/knowledge/learned/INDEX.md
@@ -5,14 +5,24 @@ they only ADD candidates to try, never remove any or replace measurement. The on
 is always the judge (see `README.md` philosophy). One line per card, grouped by reuse key. **Cap: ≤40 lines.**
 Confidence (a hint strength, not authority): ★ noise/unverified · ★★ single non-overlap or ≥2 consistent · ★★★ ≥2 non-overlap or verified e2e.
 
+> ⚠ **This index is hand-maintained and has drifted before** — cards have sat in this folder with no line
+> here, which makes them invisible to every reader. `ls` the folder before concluding a card does not
+> exist, and add the missing line when you find one. It becomes a **generated** file (from each card's
+> discovery header, via `node kernel_workflow/scripts/build_learned_index.js e2e_workflow/knowledge/learned`)
+> once the cards carry those headers — see `README.md`.
+
 ## dense GEMM
 - [gfx950 · vLLM MXFP8 E8M0 decode-bound] dense-linear split-K/fused decode-tile Triton rewrite ★★★ **+21.8% e2e (verified, gsm8k-clean); decode-driven (converts only at high conc); grouped-MoE GEMM resists (~1.1× ceiling)** — (mxfp8-linear-decode-rewrite-gfx950.md)
 - [gfx942 · sglang bf16] aiter per-shape DB tune ★★★ **+2.23% e2e (verified)** — (aiter-bf16-tuned-gemm-gfx942.md)
 - [gfx942 · sglang fp8 a8w8 blockscale] **MANDATED LEVER = the CK skill** `gemm_tuning/fp8_gemm_tuning_sglang_aiter.md` (capture live (M,N,K) → aiter CK tuner → fp8_utils Triton→CK switch overlay + `AITER_CONFIG_GEMM_A8W8_BLOCKSCALE`); baseline = the UNTUNED Triton default, so CK-tuned is the real win. The old per-(N,K) Triton config-JSON overlay is **DEPRECATED for this op (do NOT use it — it keeps the slow Triton seam live and bypasses the skill)** — (fp8-a8w8-blockscale-overlay-gfx942.md)
 - [gfx950 · vLLM MXFP8 E8M0] dense `tl.dot_scaled` STATIC tiles (decode BK256/prefill BM128) ★★★ part of +12.1% e2e — (mxfp8-microscale-gemm-gfx950.md)
+- [gfx950 · vLLM MXFP8 E8M0 dense linear] author/rewrite the in-tree `_mxfp8_linear_kernel`, tune BLOCK_K 128→256 ★★ iso ~1.12x geomean (all 12 cases); e2e unverified — (mxfp8-dense-linear-gemm-gfx950.md)
+- [gfx950 · vLLM MXFP8 E8M0 dense linear] ROUTING: live is editable in-tree Triton `dot_scaled`; no env/flag win exists — the author/Tier-C route IS the lever ★★ iso baseline only — (mxfp8-e8m0-dense-linear-gfx950.md)
 
 ## MoE grouped GEMM
 - [gfx950 · vLLM MXFP8 E8M0] grouped `dot_scaled` STATIC tiles (GEMM1-decode BN64+BK256) ★★★ part of +12.1% e2e — (mxfp8-microscale-gemm-gfx950.md)
+- [gfx950 · vLLM MXFP8 E8M0 grouped MoE] author/rewrite `_mxfp8_grouped_gemm_kernel`, tune BLOCK_K 128→256 ★★ iso ~1.08x geomean (all 6 buckets); e2e unverified — (mxfp8-grouped-moe-gemm-gfx950.md)
+- [gfx950 · vLLM MXFP8 E8M0 grouped MoE] ROUTING: editable in-tree Triton `dot_scaled`; aiter bf16 GEMM DB is the WRONG lever ★★ iso baseline only — (mxfp8-e8m0-grouped-moe-gfx950.md)
 - [gfx942 · vLLM int4 W4A16] per-shape fused-MoE Triton config tune via `VLLM_TUNED_CONFIG_FOLDER` (env, ZERO HBM; N=moe_int//TP) ★★★ +11-18% e2e (10 confirms, TP8 & TP4) — (moe-int4-w4a16-tune-gfx942.md)
 - [gfx942 · vLLM bf16 MoE] SAME per-shape fused-MoE config-tune lever works for DENSE bf16 (dtype=None filename, gelu_tanh); no shipped E=128/N=704 config → default fallback ★★ iso 1.06-1.25×/bucket, ZERO HBM, e2e gate pending — (moe-bf16-tune-gfx942.md)
 
@@ -20,6 +30,7 @@ Confidence (a hint strength, not authority): ★ noise/unverified · ★★ sing
 - [gfx942 · sglang hybrid prefill] `--attention-backend triton` cheap flag win ★★★ +~5% e2e — (attention-backend-triton-gfx942.md)
 - [gfx942 · vLLM decode/prefill, pow2+non-pow2 KV block, +MLA TRITON_MLA, +0.21 UNIFIED_ATTENTION] live=editable in-tree Triton → Tier-C rewrite (pow2 ROCm/CK→author); op bake-off N/A ★★★ ~+1-4% — (paged-attn-nonpow2-gfx942.md)
 - [gfx950 · vLLM block-sparse NSA GQA prefill] custom kernel, no lib swap; live = editable in-tree Triton → Tier-C rewrite ★★ ~5.6% head — (sparse-attn-nsa-triton-gfx950.md)
+- [gfx942 & gfx950 · vLLM block-sparse GQA] the concrete Triton→Triton rewrite that landed upstream (arch-specialized, constexpr-gated) ★★★ gfx950 TP8 +42% out tok/s, −50% TTFT, −30% TPOT; gsm8k unchanged — (sparse-attn-triton2triton-opt-gfx942-gfx950.md)
 
 ## linear-attention / FLA / mamba (editable Triton)
 - [gfx942 · prefill-dominated hybrid] stack-and-compound cluster; Amdahl pre-dispatch screen ★★★ — (editable-triton-cluster-amdahl.md)

--- a/e2e_workflow/knowledge/learned/README.md
+++ b/e2e_workflow/knowledge/learned/README.md
@@ -10,6 +10,20 @@ capable run worse by boxing it in or steering it down one path.** The judge is a
 measurement** (the immutable op unittest oracle + the e2e Director's independent A/B + parity) — never
 the KB. If a card and the measurement disagree, the measurement wins and the card gets corrected.
 
+## Which sink? (`e2e_workflow/` vs `kernel_workflow/` — two memories, one direction of reference)
+This folder holds **e2e-gated** lessons: an exploration that actually moved end-to-end throughput/latency
+through the Director's A/B. Kernel-level results — "this lever/backend makes the op itself faster,
+measured on the frozen-baseline isolated A/B" — belong in **`kernel_workflow/knowledge/learned/`**, and
+they are written there by that workflow's own `update_experience` step, *including* when e2e was the one
+that opened the kernel lane. The split is by the gate that produced the evidence, not by who launched
+the run.
+
+**Reference, don't duplicate.** When an e2e gain came from a kernel this pipeline optimized, your card
+records the **e2e delta and which exploration paid off** (which routing/direction was worth the budget)
+and **cites the kernel card** — `kernel_workflow/knowledge/learned/<slug>.md` — for the technique itself.
+One technique, one home. Never copy a kernel card into this folder, and never write a card into
+`kernel_workflow/knowledge/learned/` from here.
+
 **Two-tier memory — keep them separate:**
 - **Here (persistent)** = a small set of *distilled, advisory priors* with measured evidence. Bounded, curated.
 - **In the eval-dir (episodic)** = the raw per-run story (`final_report.md`, `insight_log.md`). Every
@@ -28,17 +42,66 @@ the KB. If a card and the measurement disagree, the measurement wins and the car
    The workflow must stay free to rediscover — and beat — any prior. A past winner is a starting point,
    not a ceiling; a past pitfall is a thing to double-check, not a banned move.
 
-Use the index to *find relevant cards fast*, not to decide the answer:
-- Read `INDEX.md`, open the cards whose key matches `(kernel_class, gfx, regime)`.
-- Treat their `lever`/`effect` as **priors to seed your candidate set**, and `caution` as **extra checks**.
+## Discovery — READ `INDEX.md`, then open the cards that look relevant
+Retrieval here is **semantic, done by you** — not a string match. The index is small by construction
+(≤40 cards) and every line carries the card's own `description`, the kernel symbols it was measured on,
+and its keywords. So:
 
-## Card schema (one principle per file, ~10–15 lines)
+1. **Read `INDEX.md`.**
+2. **Judge relevance by meaning**, not by exact wording. A card written for `split-k on skinny-M GEMM` is
+   worth opening for a tall-K GEMM; a `cudagraph-safe integration` card applies to any rebind seam. You
+   are better at this than a keyword query — that is why the matching happens in the reader.
+3. **Open 0–3 cards.** Nothing relevant is a legitimate outcome: plan cold, as the pipeline did before
+   any KB existed. Treat a card's `lever`/`effect` as **priors that seed your candidate set**, and
+   `caution` as **extra checks**.
+
+`grep` for an exact kernel symbol is a fine shortcut when you already know the name, but it is **not** the
+lookup mechanism — never conclude "there is no card for this" from a failed string search.
+
+Cards are **self-describing**: each opens with a discovery header, so it can be read directly and
+`INDEX.md` can be **regenerated** from the cards rather than hand-maintained:
+
+```bash
+node kernel_workflow/scripts/build_learned_index.js e2e_workflow/knowledge/learned
+```
+
+(One generator serves both `learned/` sinks — referenced in place, not copied, the same convention the
+kernel bake-off uses for this workflow's `op_benchmarker` + `harness_lib.py`. `--check` = fail if stale.)
+
+> **Migration in progress.** The cards in this folder predate the discovery header, so `INDEX.md` here is
+> still the hand-written one and is **known to drift** — cards have existed on disk that no index line
+> mentioned, i.e. invisible to every reader. Until the headers are backfilled: when you write a card, give
+> it a full discovery header (schema below); and when you read, `ls` this folder before concluding a card
+> does not exist. Once every card has a header, the index becomes generated and that failure mode is gone.
+
+### Keeping the vocabulary from drifting
+`split-k` / `split_k` / `splitk` are one concept and three index entries. Three defences: the reader is
+semantic, so a synonym costs ranking and not retrieval; the generator normalizes spelling mechanically
+(lowercase, `_`/space → `-`, dedupe); and the generated index publishes a `## keyword vocabulary`
+appendix — every term in use with its card count — that curators pick from before coining a new one,
+with surviving near-duplicates flagged for a human call rather than silently merged.
+
+## Card schema (one principle per file, ~12–20 lines)
 ```
 ---
-key: <kernel_class> · <gfx> · <regime>      # the cross-model REUSE KEY (for finding the card)
+# --- discovery header: how this card is FOUND (drives the generated INDEX.md) ---
+name: <slug>                                # == the filename without .md
+description: <ONE line, ≤160 chars: lever → on what → e2e effect. This becomes the INDEX.md line.>
+keywords: [<lowercase-hyphenated terms>]    # PICK FROM the index's keyword vocabulary before inventing
+kernels: [<kernel symbol / entry point>]    # e.g. fused_moe_kernel — a name a future run would recognise
+platforms: [<gfx>]
+kernel_class: <dense_gemm | moe_grouped_gemm | attention_decode | method | ...>
+regime: decode | prefill | both | n/a
+# --- classification + evidence ---
+key: <one line of plain English identifying WHAT this card is about — the op, the arch, and whatever
+     else distinguishes it: framework, dtype/quant format, shape regime. e.g.
+     "bf16 fused-MoE grouped GEMM · gfx942/MI300X · vLLM". NOT a bare "dense_gemm · gfx942 · decode"
+     triple: that collapses different cards onto one key and invites a wrong merge. The machine-readable
+     slots are the header fields above; `key` is the human identity + merge target.>
 type: routing | lever | method
 confidence: ★ | ★★ | ★★★                    # how often it REPRODUCED (a hint strength, not authority)
 effect: <iso x range; AND the e2e-transfer note — did it actually move e2e, or only isolated?>
+lifecycle: active                           # `archived` leaves the index but keeps the file
 last_seen: YYYY-MM-DD
 ---
 # <short title>
@@ -57,11 +120,19 @@ last_seen: YYYY-MM-DD
 
 ## How to UPDATE it after a run (write path) — CURATE, never blind-append
 Owners: System Architect (routing/method cards) and Op Benchmarker (head GEMM/attn cards). One transaction:
-1. **Read INDEX.md.** Find the card whose `key` matches your finding.
+1. **Read INDEX.md — and `ls` the folder** (the index can be missing a card; see the migration note).
+   Find the card whose `key` matches your finding, judging **by meaning, not wording**: a
+   differently-worded card for the same lever on the same op/arch IS a match.
 2. **MERGE if it exists** — bump `confidence` if it reproduced, widen/correct `effect` (esp. the
-   e2e-transfer note), append a `source`, update `last_seen`. Update its INDEX line. Don't create a
-   second card for the same key, and never add a new `## Learned — <date>` header.
-3. **INSERT only if novel AND effective (≥★★).** New card + ONE INDEX line.
+   e2e-transfer note), append a `source`, update `last_seen`, extend `keywords`/`kernels` with any new
+   search terms. Don't create a second card for the same key, and never add a new
+   `## Learned — <date>` header.
+3. **INSERT only if novel AND effective (≥★★).** ONE new card, opening with the full **discovery header**
+   (`name`, `description`, `keywords`, `kernels`, `platforms`, `kernel_class`, `regime`) — that header is
+   what makes it findable and what the generated index is built from.
+3a. **Publish it in the index.** Once this folder's cards all carry headers, that is
+   `node kernel_workflow/scripts/build_learned_index.js e2e_workflow/knowledge/learned` and nothing is
+   hand-edited. Until then, add the ONE index line by hand — and check no other card is missing one.
 4. **NULL / overlapping / unverified → write NOTHING here** (eval-dir report only).
 5. **A surprising negative → a CONDITIONED `caution:` line** on the relevant card (with the condition it
    held under + its source), framed as "also verify". A claim *contradicted* by new evidence → move the
@@ -69,6 +140,7 @@ Owners: System Architect (routing/method cards) and Op Benchmarker (head GEMM/at
 6. **Enforce the budget.** INDEX.md ≤ 40 card lines. Over → evict lowest `confidence × freshness` (its
    card → `_archive.md`). ★★★ is never auto-evicted.
 
-**Invariant:** a principle "exists" iff it has a line in INDEX.md (the single source of truth + size
-gate). Keep cards short: >15 lines means you're storing narrative, not a principle — distill it.
+**Invariant:** a principle "exists" iff a card file carries it with `lifecycle: active`. The card is the
+source of truth; `INDEX.md` is its projection (today hand-kept, soon generated) and the size gate. Keep
+cards short: >20 lines means you're storing narrative, not a principle — distill it.
 **Above all: a card is advice the box can overrule, not a rule that overrules the box.**

--- a/e2e_workflow/roles/op_benchmarker.md
+++ b/e2e_workflow/roles/op_benchmarker.md
@@ -28,8 +28,9 @@ Read first, every time:
 - `SKILL_DIR/knowledge/gemm_attention_backends.md` — the head-kernel ladder, per-backend tuning knobs,
   parity/accuracy gate (the priors).
 - `SKILL_DIR/knowledge/learned/INDEX.md` — distilled experience as **advisory priors** (an aid, not a
-  cage). Use the matching cards to ADD candidates to your bake-off, never to prune it or skip the e2e
-  gate — measurement is the judge. CURATE it after a run — never blind-append.
+  cage). Read it and judge relevance **by meaning, not by string match**; `ls` the folder too (the index
+  is hand-kept today and has drifted). Use the matching cards to ADD candidates to your bake-off, never
+  to prune it or skip the e2e gate — measurement is the judge. CURATE it after a run — never blind-append.
 - `SKILL_DIR/knowledge/e2e_optimization.md` — Amdahl reasoning + measurement discipline.
 - `GEAK/perf_knowledge/index/capability_index.yaml` — **REFERENCE ONLY**, to *widen* your Tier-A
   candidate set: which backends have a documented impl for this op + the gens/dtypes/regimes they support.
@@ -285,9 +286,11 @@ Inputs: `EVAL_DIR`, `OP_TASK_DIR` (from the Kernel Extractor `extract_op`), `OP_
 5. **Tier D (only if `ENABLE_FP8`)**: note fp8 as a candidate for the Integrator (server `--quantization
    fp8`); do not bake it into the op patch — it's a server flag with an accuracy gate.
 6. **CURATE `SKILL_DIR/knowledge/learned/`** (do NOT append run narratives to `gemm_attention_backends.md`).
-   Per `knowledge/learned/README.md`: read `INDEX.md`; MERGE into the card matching this op's
-   `(kernel_class, gfx, regime)` (bump `confirms`/`confidence`, widen `effect`, add `source`, update
-   `last_seen`); INSERT a new card ONLY if novel AND ≥★★; a surprising regression → a CONDITIONED
+   Per `knowledge/learned/README.md`: read `INDEX.md`; MERGE into the card matching this op — match by
+   meaning on the plain-English `key` (op · arch · framework/dtype/regime), not on a rigid triple — (bump
+   `confirms`/`confidence`, widen `effect`, add `source`, update `last_seen`, extend `keywords`/`kernels`);
+   INSERT a new card ONLY if novel AND ≥★★, opening it with the full discovery header (`name`,
+   `description`, `keywords`, `kernels`, `platforms`, `kernel_class`, `regime`); a surprising regression → a CONDITIONED
    `caution:` line ("also verify X", never a blocklist); NULL/unverified → eval-dir report only. Keep
    `INDEX.md` ≤40 lines. Record the e2e-transfer note (did it move e2e, not just isolated). Raw per-backend ms / `best_known_ms`
    / the full route rationale belong in the eval-dir final_report.md, not the persistent card.

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -20,8 +20,11 @@ You are invoked per PHASE. Read first, every time:
 - `SKILL_DIR/knowledge/learned/INDEX.md` — distilled experience as **advisory priors** (an aid, not a
   cage; the workflow performs well without it). Read it AFTER forming your own profile-driven plan, as a
   cross-check + a source of EXTRA candidates — it only ADDs options, never prunes them or skips
-  measurement; the on-box bake-off + e2e gate is the judge. CURATE it after a run (merge/insert ≥★★ /
-  archive contradicted) per `knowledge/learned/README.md` — never blind-append.
+  measurement; the on-box bake-off + e2e gate is the judge. **Read the index and judge relevance by
+  meaning, not by string match** — a card written for a neighbouring op or a different tile regime often
+  still applies; and `ls` the folder, since the index is hand-kept today and has drifted before (see
+  `knowledge/learned/README.md`). CURATE it after a run (merge/insert ≥★★ / archive contradicted) —
+  never blind-append.
 - `SKILL_DIR/knowledge/gemm_attention_backends.md` — the head-kernel ladder + per-backend priors; use
   it to build `head_candidates` (GEMM/attention) and pick their candidate backends.
 - The AMD knowledge base at `GEAK/perf_knowledge/` is **REFERENCE ONLY** — facts/how-to, not
@@ -345,11 +348,17 @@ verified e2e throughput delta, verdict), `REPROFILE_SHIFT`, prior `HISTORY`, `SK
 
 1. **CURATE `SKILL_DIR/knowledge/learned/` — do NOT blind-append.** Follow the curate transaction in
    `knowledge/learned/README.md`: read `INDEX.md`, then for each durable finding:
-   - **Match the reuse key** `kernel_class · gfx · regime`. If a card exists → **MERGE** (bump
-     `confirms`, raise `confidence` if strengthened, widen/correct `effect`, append a `source`, update
-     `last_seen`) and update its one INDEX line. Do NOT create a second card for the same key.
+   - **Match the reuse key** — one line of plain English naming the op, the arch, and whatever else
+     distinguishes it (framework, dtype/quant format, regime), e.g. `bf16 fused-MoE grouped GEMM ·
+     gfx942/MI300X · vLLM`. Match **by meaning**: a differently-worded card for the same lever on the
+     same op/arch IS the same card. If one exists → **MERGE** (bump `confirms`, raise `confidence` if
+     strengthened, widen/correct `effect`, append a `source`, update `last_seen`, extend
+     `keywords`/`kernels`) and update its one INDEX line. Do NOT create a second card for the same key.
    - **INSERT a new card ONLY if novel AND effective (≥★★** = single-run non-overlapping, or ≥2
-     consistent, or Director-verified e2e). Each card carries `lever / apply / verify / source`, stays
+     consistent, or Director-verified e2e). Open it with the full **discovery header** (`name`,
+     `description` — the one line that becomes the index entry, `keywords`, `kernels`, `platforms`,
+     `kernel_class`, `regime`): that header is what makes the card findable and is what the index will be
+     generated from once every card here has one. Each card carries `lever / apply / verify / source`, stays
      ≤~15 lines, and gets ONE INDEX line. Keep `INDEX.md` ≤40 lines (evict lowest `confidence×freshness`).
    - **NULL / overlapping / unverified → write NOTHING to `learned/`** (it goes only in the eval-dir report).
    - **A surprising negative → a CONDITIONED `caution:` line** on the relevant card (e.g. "on
@@ -358,6 +367,12 @@ verified e2e throughput delta, verdict), `REPROFILE_SHIFT`, prior `HISTORY`, `SK
      blocklist / "don't use X"** — a future run must stay free to try (and beat) it; the box judges.
      A claim CONTRADICTED by new evidence → move its card to `_archive.md` with the refuting source.
    Mechanism facts are recorded as POSITIVE ROUTING ("optimize GEMM via aiter DB"), not "X failed".
+   - **Stay in YOUR sink, and cite the other one.** Write only under `SKILL_DIR/knowledge/learned/`.
+     A gain that came from a kernel the `kernel_workflow` lane produced is recorded here as **the e2e
+     delta + which exploration was worth the budget**, with a citation to that workflow's card
+     (`kernel_workflow/knowledge/learned/<slug>.md`) for the technique itself — the lane already wrote
+     it there. Do NOT copy the kernel card in, and do NOT write into `kernel_workflow/knowledge/learned/`
+     (that sink is owned by the lane's own `update_experience` step, gated by the isolated A/B).
 2. Keep the in-run hypothesis ledger (wins AND nulls, for THIS run's report) in `EVAL_DIR/insight_log.md`.
 3. **Calibrate the roofline prior (ONLY if one was used — `ANALYSIS_SKILL_DIR` non-empty and a
    `profile_roofline_json` exists; else skip).** For each direction this milestone measured, record

--- a/kernel_workflow/README.md
+++ b/kernel_workflow/README.md
@@ -152,6 +152,46 @@ in the sibling **`kernel_lane.js` worker**:
      actually beat the frozen baseline (speedup > 1.0x); if none did, `winner=null` and the ORIGINAL kernel
      is kept. Optional `apply_to_original` (a lane winner applies its patch; an env winner records its
      `apply_env` + tuning artifact).
+  5. **UpdateExperience** (`roles/update_experience.md`): on a measured win only, the TechLead distills
+     **at most one** reusable principle into `knowledge/learned/` (curate/merge, never blind-append; see
+     `knowledge/learned/README.md`). In bake-off this runs **once, centrally** — the lanes are launched
+     with `update_experience: 'off'`, and the lesson worth keeping is the cross-language routing outcome
+     the dispatcher alone can see.
+
+### Learned knowledge (every run, not just bake-off)
+`kernel_lane.js` curates a card at the end of **every** lane run that earned a measured win — standalone,
+dispatcher passthrough (`mode=optimize|author`), or a lane opened by `e2e_workflow`. The sink is always
+`<this workflow>/knowledge/learned/`, derived from `workflow_dir`, so an e2e-driven lane writes its
+kernel-level lesson **here**, never into `e2e_workflow/knowledge/learned/` (that sink is e2e-gated and
+owned by e2e's own `system_architect`; it cites these cards instead of copying them). The cards are read
+back as **advisory priors** by `tech_lead` and `author_engineer` — ADD-only, always overruled by on-box
+measurement. Disable with `update_experience: 'off'`.
+
+Each card is **self-describing**: it opens with a skill-style discovery header (`name`, `description`,
+`keywords`, `kernels`, `platforms`, `kernel_class`, `regime`, `confidence`).
+`knowledge/learned/INDEX.md` is a **generated** projection of those headers — rebuild it with
+`node scripts/build_learned_index.js` (`--check` fails when it is stale). Nothing appends to the index by
+hand, which is also why concurrent lanes can no longer drop each other's entries.
+
+Retrieval is **semantic and done by the reading role**, not by a matcher: the index is ≤40 cards, each
+line already carries the description + kernel symbols + keywords, so the role reads it and judges
+relevance by meaning (a `split-k on skinny-M GEMM` card is worth opening for a tall-K GEMM). `grep` is a
+shortcut for an exact kernel symbol, never the lookup path. Keyword drift (`split-k`/`split_k`/`splitk`)
+is contained three ways: the reader is semantic so a synonym costs ranking not retrieval; the generator
+normalizes spelling mechanically; and the index publishes a `## keyword vocabulary` appendix (every term
+in use + counts) that curators pick from, with surviving near-duplicates flagged for a human call rather
+than auto-merged.
+
+A card's `key:` is **one line of plain English** (`MXFP8 E8M0 dense linear, decode-bound · gfx950`), not a
+rigid `class · gfx · regime` triple — the triple collapses genuinely different cards (vLLM MXFP8 vs sglang
+bf16) onto one merge target. The machine-readable slots are the discovery-header fields. `e2e_workflow`'s
+`learned/` uses the same contract; its cards predate the discovery header, so its index stays hand-kept
+until they are backfilled (see that folder's README).
+
+Card content is sanitized: **relative numbers only** (speedup ratios, percent deltas, % of achievable
+peak, roofline bound class) — never wall-clock `ms` or absolute `TFLOP/s`/`GB/s`, which vary by box and
+stay in `EVAL_DIR`. A card also records the **pitfalls actually hit** (`symptom → root cause → fix`) and,
+when several directions compounded, a `stack:` block giving the **total first, then each direction**.
 
 Available backend languages: `triton` (always) · `flydsl` (SOTA GEMM DSL) · `hip` · `ck`, plus the
 skeletons under `../perf_knowledge/languages/` — a language absent on the image is dropped with an
@@ -200,10 +240,19 @@ kernel_lane.js         single-language WORKER (the deterministic optimize/author
 kernel_workflow_bmk.js batch orchestrator (runs kernel_lane on a list of kernels, one batch per GPU)
 roles/               director, tech_lead, engineer, deep_engineer (deep_explore),
                      author_engineer, benchmark_engineer, profile_engineer,
-                     verify_engineer, integrator, oracle_freezer (bake-off freeze)
+                     verify_engineer, integrator, oracle_freezer (bake-off freeze),
+                     update_experience (learned-card curation, every run)
 knowledge/           optimization_strategies, hip/triton/wrapper, profiling_guide,
                      amd_instinct (multi-card: gfx942/gfx950), self_monitoring, geomean_levers
+knowledge/learned/   distilled experience cards (ADVISORY priors; each card self-describing via its
+                     discovery header, INDEX.md GENERATED from them; written by the
+                     TechLead update_experience step at the end of EVERY run). This sink is
+                     kernel-gated (frozen-baseline isolated A/B); e2e-gated lessons stay in
+                     e2e_workflow/knowledge/learned/ and cite these cards -- see learned/README.md
 scripts/             gpu_lock.sh, profile_kernel.sh,
+                     build_learned_index.js (regenerate a learned/INDEX.md from the cards' discovery
+                     frontmatter; sink-agnostic -- takes the dir, so it also serves
+                     e2e_workflow/knowledge/learned; `--check` for CI), test_learned_index.js (its guard),
                      test_mode_dispatch.js (regression guard: mode dispatch + bake-off lane
                      routing; stubs the runtime, no GPU/agent — `node scripts/test_mode_dispatch.js`)
 ```

--- a/kernel_workflow/kernel_lane.js
+++ b/kernel_workflow/kernel_lane.js
@@ -12,7 +12,7 @@ export const meta = {
     { title: 'Verify', detail: 'each candidate patch independently re-benchmarked' },
     { title: 'Merge', detail: 'integrator combines the round winners' },
     { title: 'Report', detail: 'tech_lead writes the final report + patch' },
-    { title: 'Validate', detail: 'director independently validates vs the true baseline' },
+    { title: 'Validate', detail: 'director independently validates vs the true baseline, then the TechLead curates ONE distilled card into knowledge/learned/ on a measured win [update_experience!=off]' },
   ],
 };
 
@@ -156,6 +156,17 @@ const EXPERT_SKILLS_DIR = String(A.expert_skills_dir ||
   (KERNEL_KNOWLEDGE_DIR ? KERNEL_KNOWLEDGE_DIR + '/expert_skills' : '')).replace(/\/+$/, '');
 // Only planning + authoring roles consult skills; every other role gets no injection.
 const EXPERT_SKILL_ROLES = new Set(['tech_lead', 'author_engineer', 'engineer', 'deep_engineer']);
+
+// ---------------------------------------------------------------------------
+// LEARNED-KNOWLEDGE SINK. Derived from WORKFLOW_DIR and nothing else, so a lane spawned by
+// e2e_workflow still curates into kernel_workflow/knowledge/learned/ — e2e's learned/ is a
+// separate memory owned by its own system_architect step.
+//   update_experience = on (default) | off | false | none
+// The bake-off dispatcher passes `off` and curates once centrally instead (N parallel lanes would
+// file N near-duplicate cards for one op).
+const LEARNED_DIR = `${WORKFLOW_DIR}/knowledge/learned`;
+const UPDATE_EXPERIENCE = String(A.update_experience != null ? A.update_experience : 'on').trim().toLowerCase() || 'on';
+const UPDATE_EXPERIENCE_ON = UPDATE_EXPERIENCE !== 'off' && UPDATE_EXPERIENCE !== 'false' && UPDATE_EXPERIENCE !== 'none';
 
 // ---------------------------------------------------------------------------
 // DEEP-MODE continuation + cross-backend / e2e-feedback hooks. ALL OPTIONAL.
@@ -345,6 +356,12 @@ const REPORT_SCHEMA = obj({
   rounds: { type: 'number' }, budget_used: { type: 'number' },
   report_path: { type: 'string' }, final_patch: { type: 'string' }, per_case: perCase,
 }, ['final_speedup_geomean', 'report_path', 'final_patch']);
+
+const UPDATE_EXPERIENCE_SCHEMA = obj({
+  action: { type: 'string' },      // created | merged | skipped
+  card_path: { type: 'string' },   // path under knowledge/learned/, or "" if nothing distilled
+  key: { type: 'string' }, note: { type: 'string' },
+}, []);
 
 const VALIDATE_SCHEMA = obj({
   kernel_name: { type: 'string' },
@@ -883,6 +900,44 @@ log(`COMPLETE. ${KERNEL_NAME}: verified ${HAS_WORKLOAD ? 'time-weighted' : 'geom
     `${HAS_WORKLOAD && Number.isFinite(finalGeomean) ? ` (unweighted geomean ${finalGeomean.toFixed(2)}x)` : ''}` +
     ` (status ${validation ? validation.validation_status : '?'}). Results in ${EVAL_DIR}`);
 
+// ===========================================================================
+// PHASE: UpdateExperience — distill ONE reusable card into this workflow's knowledge/learned/
+// (see knowledge/learned/README.md). Runs ONCE, at the very end: never per round, because only
+// the final director-verified speedup is evidence a card may cite. `validation` is required for
+// the same reason — without it `finalPrimary` falls back to the TechLead's own unverified
+// `cumulative`. ADD-only, so a skipped or failing step leaves the run byte-neutral.
+// ===========================================================================
+let learned_card = null;
+if (UPDATE_EXPERIENCE_ON && validation && Number.isFinite(finalPrimary) && finalPrimary > 1.0) {
+  const GFX = (String((profileSummary && profileSummary.device) || '').match(/gfx\d+/i) || [''])[0].toLowerCase();
+  try {
+    learned_card = await agentT(
+      roleAgent('update_experience', 'Validate',
+        'Curate one distilled learned card from this lane\'s verified win (ADD-only, measured evidence, ' +
+        'ratios not wall-clock; record the pitfalls hit; total-then-per-direction for a stacked win).', {
+          SCOPE: 'lane', LEARNED_DIR, SKILL_DIR: WORKFLOW_DIR, EVAL_DIR,
+          PERF_KNOWLEDGE_DIR: KERNEL_KNOWLEDGE_DIR,
+          WINNER: {
+            kernel: KERNEL_NAME, language: TARGET_LANGUAGE, mode: MODE, gfx: GFX,
+            kernel_class: (analysis && analysis.kernel_type) || '',
+            speedup: finalPrimary, validation_status: validation ? validation.validation_status : '',
+            bottleneck: profileSummary ? profileSummary.bottleneck : '',
+          },
+          // `rounds[]` (per-round directions + per-candidate claimed/verified/status + running
+          // `cumulative`) is what makes the card's `stack:` attribution and `pitfall:` lines derivable.
+          HISTORY: history,
+          PROFILE: profileSummary,
+          REPORT_PATH: report && report.report_path ? report.report_path : `${EVAL_DIR}/tech_lead_report.md`,
+        }),
+      { phase: 'Validate', label: 'update_experience', schema: UPDATE_EXPERIENCE_SCHEMA });
+    if (learned_card && learned_card.card_path) {
+      log(`[kb] learned card ${learned_card.action || 'written'}: ${learned_card.card_path}`);
+    }
+  } catch (e) {
+    log(`[kb] update_experience skipped: ${e && e.message ? e.message : e}`);
+  }
+}
+
 return {
   mode: MODE,
   target_language: MODE === 'author' ? TARGET_LANGUAGE : undefined,
@@ -901,4 +956,8 @@ return {
   budget_total: BUDGET,
   report_path: report ? report.report_path : `${EVAL_DIR}/tech_lead_report.md`,
   final_patch: report ? report.final_patch : `${EVAL_DIR}/final_patch.diff`,
+  // null when the step was off, or the run earned nothing worth a card.
+  learned_card: learned_card && learned_card.card_path
+    ? { action: learned_card.action || '', card_path: learned_card.card_path, key: learned_card.key || '' }
+    : null,
 };

--- a/kernel_workflow/kernel_workflow.js
+++ b/kernel_workflow/kernel_workflow.js
@@ -6,7 +6,7 @@ export const meta = {
     { title: 'Freeze',   detail: 'oracle_freezer: freeze the input kernel -> immutable oracle + baseline_src/ (the ONE denominator) [bakeoff only]' },
     { title: 'Discover', detail: 'op_benchmarker: per-language existing-impl probe + measure + OFFLINE env tune (aiter/CK, shapes from the frozen oracle) -> author_plan, best_known_ms [bakeoff only]' },
     { title: 'Bakeoff',  detail: 'one unchanged kernel_lane worker per language (optimize if an impl exists, else author), parallel over the GPU pool [bakeoff only]' },
-    { title: 'Report',   detail: 'rank ALL candidates (lanes + tuned env backend) on the SAME frozen baseline; write the comparison table + winner (+ optional apply_to_original) [bakeoff only]' },
+    { title: 'Report',   detail: 'rank ALL candidates (lanes + tuned env backend) on the SAME frozen baseline; write the comparison table + winner (+ optional apply_to_original), then curate ONE distilled card into knowledge/learned/ on a measured win [bakeoff only]' },
   ],
 };
 
@@ -123,6 +123,12 @@ const OPBENCH_SCHEMA = obj({
 const REPORT_SCHEMA = obj({
   report_path: { type: 'string' }, applied_to_original: { type: 'string' }, note: { type: 'string' },
 }, ['report_path']);
+
+const UPDATE_EXPERIENCE_SCHEMA = obj({
+  action: { type: 'string' },      // created | merged | skipped
+  card_path: { type: 'string' },   // path under knowledge/learned/, or "" if nothing distilled
+  key: { type: 'string' }, note: { type: 'string' },
+}, []);
 
 // ---------------------------------------------------------------------------
 // Prompt + agent helpers (self-contained; mirror kernel_lane.js / e2e_workflow.js).
@@ -265,7 +271,13 @@ const DISCOVER_INTRO =
   'the SAME frozen baseline the author lanes use, so it is directly comparable. If no tuned backend beats ' +
   'the baseline, set tuned_speedup=0.\n' +
   '(4) SKIP only pure server-flag levers (--attention-backend swap; serving-only fp8/MoE playbook probes ' +
-  'that need a running server). (5) DECIDE the author_plan as usual.';
+  'that need a running server). (5) DECIDE the author_plan as usual.\n' +
+  '(6) DO NOT run your step 6 (`CURATE SKILL_DIR/knowledge/learned/`). Your SKILL_DIR points at ' +
+  'e2e_workflow, but this is a kernel_workflow run: e2e`s learned/ is e2e`s own memory (owned by its ' +
+  'system_architect after an e2e A/B), and a kernel bake-off has no e2e-transfer evidence to put in it. ' +
+  'This run`s learned sink is kernel_workflow/knowledge/learned/, curated by the TechLead`s ' +
+  'update_experience step after Report. WRITE NOTHING under e2e_workflow/ — read it freely, but the ' +
+  'only files you create or modify live under EVAL_DIR (plus the tuning artifacts you were asked for).';
 const bake = await agentT(
   roleAgentFrom(E2E_WF_DIR, 'op_benchmarker', 'bakeoff', DISCOVER_INTRO, {
     EVAL_DIR, OP_TASK_DIR: oracle.task_dir, OP_KIND: oracle.op_kind,
@@ -352,6 +364,9 @@ const results = await Promise.all(lanes.map(l => sem.with(1, async ([gpu]) => {
       exp_root: `${EVAL_DIR}/bakeoff/${l.key}`,
       use_expert_skills: USE_EXPERT_SKILLS ? 'true' : 'false', expert_skills_dir: EXPERT_SKILLS_DIR,
       perf_knowledge_dir: KERNEL_KNOWLEDGE_DIR,
+      // Curation is central in bake-off mode (see the UpdateExperience step below). In optimize/author
+      // mode this dispatcher is a passthrough, so the lane keeps its default `on` and curates itself.
+      update_experience: 'off',
     });
     const speedup = primSpeedup(r);
     log(`lane ${l.key}:${l.mode} -> ${speedup ? speedup.toFixed(2) + 'x' : 'no result'} (${r ? r.validation_status : 'null'})`);
@@ -442,6 +457,31 @@ Return ONLY {report_path, applied_to_original, note} as StructuredOutput.`,
 log(winner
   ? `Bake-off COMPLETE. winner=${winner.lang}:${winner.mode} ${winner.speedup.toFixed(2)}x. Results in ${EVAL_DIR}`
   : `Bake-off COMPLETE. NO candidate beat the frozen baseline (best ${bestSpeedup.toFixed(2)}x <= 1.0x across ${cands.length} candidate(s)) — keeping the ORIGINAL kernel. Results in ${EVAL_DIR}`);
+
+// ---------------------------------------------------------------------------
+// PHASE: UpdateExperience — bake-off curates CENTRALLY here (its lanes run with
+// update_experience=off): the reusable lesson is the cross-language routing outcome, which
+// no single lane can see. Sink is THIS workflow's knowledge/learned/ (see its README.md),
+// never e2e's. Only on a measured win, and ADD-only — a failed step is byte-neutral.
+if (winner && winner.speedup > 1.0) {
+  const LEARNED_DIR = `${WORKFLOW_DIR}/knowledge/learned`;
+  try {
+    const ue = await agentT(
+      roleAgent('update_experience', 'Report',
+        'Curate one distilled learned card from this bake-off win (ADD-only, measured evidence, ' +
+        'ratios not wall-clock; record the pitfalls hit).', {
+          SCOPE: 'bakeoff', LEARNED_DIR, SKILL_DIR: WORKFLOW_DIR, EVAL_DIR,
+          PERF_KNOWLEDGE_DIR: KERNEL_KNOWLEDGE_DIR,
+          WINNER: winner, CANDIDATES: laneRows,
+          REPORT_PATH: rep ? rep.report_path : `${EVAL_DIR}/bakeoff_report.md`,
+          OP_SPEC,
+        }),
+      { phase: 'Report', label: 'update_experience', schema: UPDATE_EXPERIENCE_SCHEMA });
+    if (ue && ue.card_path) log(`[kb] learned card ${ue.action || 'written'}: ${ue.card_path}`);
+  } catch (e) {
+    log(`[kb] update_experience skipped: ${e && e.message ? e.message : e}`);
+  }
+}
 
 return {
   mode: MODE,

--- a/kernel_workflow/knowledge/learned/INDEX.md
+++ b/kernel_workflow/knowledge/learned/INDEX.md
@@ -1,0 +1,26 @@
+# Learned — index of distilled kernel_workflow experience cards
+
+<!-- GENERATED FILE — do not hand-edit. Regenerate with:
+       node kernel_workflow/scripts/build_learned_index.js
+     Every line below is derived from one card's discovery frontmatter. To change a line, edit the
+     card's `description`/`keywords`/`confidence` and regenerate. -->
+
+Open the cards matching your run as **additional, advisory priors** — they only ADD candidate levers to
+try, never remove any and never replace measurement. The frozen-baseline isolated A/B + oracle parity is
+always the judge (see `README.md`). **Cap: ≤40 card lines.** Confidence (a hint strength, not
+authority): ★ noise/unverified · ★★ single non-overlap or ≥2 consistent · ★★★ ≥2 non-overlap.
+
+Effects are **ratios or percent deltas only, never wall-clock or absolute throughput** — those vary box
+to box and stay in the run's `EVAL_DIR` (see `README.md` → "Content rules").
+
+**How to use this file: READ it, then open the 0–3 cards that look relevant.** Each line carries the
+card's own description, the kernel symbols it was measured on, and its keywords — enough to judge
+relevance without opening anything. Match on *meaning*, not on an exact string: a card written for
+`split-k on skinny-M GEMM` is worth opening for a tall-K GEMM too. If nothing matches, that is a real
+answer — plan cold, exactly as this workflow does without any KB.
+
+(Every line here is derived from a card's discovery header, so a card is still self-describing if you
+open it directly. A `grep` for an exact kernel symbol works as a shortcut, but it is not the lookup
+path — it matches strings, and the thing you are looking for is a *concept*.)
+
+## (no cards yet)

--- a/kernel_workflow/knowledge/learned/README.md
+++ b/kernel_workflow/knowledge/learned/README.md
@@ -1,0 +1,226 @@
+# `learned/` — distilled kernel_workflow experience cards (ADVISORY, read via INDEX.md)
+
+This folder is the kernel_workflow's persistent, curated optimization experience — the symmetric twin
+of `e2e_workflow/knowledge/learned/`, and it follows the same contract. It holds a small set of
+*distilled principle cards*, one idea per file, written by the TechLead's `update_experience` step and
+read by the planning/authoring roles as **advisory priors**.
+
+It is **not** a run log. The raw per-run story stays in `EVAL_DIR`.
+
+## Which sink? (`kernel_workflow/` vs `e2e_workflow/` — two memories, one direction of reference)
+The two `learned/` folders are separated by **the gate that produced the evidence**, not by who launched
+the run. A lane opened *by* e2e_workflow still writes here, because what it measured is a kernel-level
+number.
+
+| | `kernel_workflow/knowledge/learned/` (here) | `e2e_workflow/knowledge/learned/` |
+|---|---|---|
+| Evidence | frozen-baseline isolated A/B + oracle parity | e2e Director's A/B (throughput/latency) + parity |
+| Card says | *this lever/backend makes the kernel faster* | *this exploration moved e2e — and by how much* |
+| Written by | TechLead `update_experience` (every lane run; once centrally per bake-off) | System Architect / Op Benchmarker after a milestone |
+| Claims e2e? | **never** — an isolated win is not an e2e win | yes, that is the whole point |
+
+**Reference, don't duplicate.** When an e2e run gains from a kernel this workflow produced, the e2e card
+records the *e2e delta and which exploration paid off* and **cites the kernel card** (`kernel_workflow/
+knowledge/learned/<slug>.md`) for the technique itself. The technique lives here in exactly one place;
+the e2e-transfer evidence lives there. Never copy a card across, and never write a card into the other
+folder — the sink is always the `LEARNED_DIR` your orchestrator handed you.
+
+## Philosophy — the KB is an accelerant, NOT a crutch and NOT a cage
+kernel_workflow is fully capable **without** this KB; cold runs work exactly as they always did. The
+KB's only job is to help a run converge faster / go further. It must **never make a capable run worse
+by boxing it in.** The judge is always **on-box measurement** — here that means the **frozen-baseline
+isolated A/B** (the immutable oracle baseline pinned at Benchmark, every candidate re-timed against
+that same frozen dividend) plus **oracle parity** (the correctness gate in `verify_engineer`). If a
+card and the measurement disagree, the measurement wins and the card gets corrected. (Same rule as
+e2e's "bake-off + e2e gate"; only the gate identity differs.)
+
+**Two-tier memory — keep them separate:**
+- **Here (persistent)** = distilled, advisory priors with measured evidence. Bounded, curated.
+- **In `EVAL_DIR` (episodic)** = the raw per-run story (`tech_lead_report.md`, per-round metrics, the
+  per-candidate verify JSON). Every measurement, including NULL / negative results, lives there.
+  Do **not** copy run narratives here.
+
+## Discovery — READ `INDEX.md`, then open the cards that look relevant
+Retrieval here is **semantic, done by the reader** — not a string match. `INDEX.md` is small by
+construction (≤40 cards) and every line already carries the card's `description`, the kernel symbols it
+was measured on, and its keywords. So the read path is simply:
+
+1. **Read `INDEX.md`** (one file, ≤~60 lines).
+2. **Judge relevance by meaning**, not by exact wording. A card written for `split-k on skinny-M GEMM` is
+   worth opening for a tall-K GEMM; a `launch-overhead` card is worth opening for any dispatch-bound op,
+   whatever the class. You are better at this than any keyword query — that is the point of doing it in
+   the reader instead of in a matcher.
+3. **Open 0–3 cards.** Nothing relevant is a legitimate outcome: plan cold, exactly as this workflow does
+   with no KB at all.
+
+`grep` for an exact kernel symbol is a fine shortcut when you already know the name, but it is **not** the
+lookup mechanism: it matches strings, and what you are looking for is a concept. Never conclude "there is
+no card for this" from a failed grep.
+
+Each card also opens with the same **discovery header** (`name`, `description`, `keywords`, `kernels`,
+`platforms`, `kernel_class`, `regime`, `confidence`), so it stays self-describing when opened directly or
+when the index is missing.
+
+`INDEX.md` is **generated** from those headers by `kernel_workflow/scripts/build_learned_index.js`
+(grouped by `kernel_class`, ordered by confidence, plus the keyword vocabulary appendix). The generator is
+sink-agnostic — it takes the folder as an argument, so the same one serves `e2e_workflow`'s `learned/`
+(`node kernel_workflow/scripts/build_learned_index.js e2e_workflow/knowledge/learned`); one mechanism,
+referenced in place, never copied.
+**Never hand-edit it** — edit the card's `description`/`keywords`/`confidence` and regenerate. Two
+consequences worth knowing: the index can never drift from the cards, and parallel lanes cannot lose each
+other's entries (a regen republishes whatever is on disk, instead of each lane appending its own line).
+
+### Keeping the vocabulary from drifting
+`split-k` / `split_k` / `splitk` / `Split K` are one concept and four index entries — that fragmentation
+is the main way a keyword scheme rots. Three defences, in order of how much they carry:
+
+1. **The reader is semantic** (above), so a synonym costs relevance ranking, not retrieval. This is why
+   drift is a hygiene problem here and not a correctness one.
+2. **The generator normalizes** mechanically: lowercase, `_`/space → `-`, collapse repeats, dedupe. The
+   curator's spelling discipline is not load-bearing.
+3. **The vocabulary is published and reused.** `INDEX.md` ends with a generated
+   `## keyword vocabulary` line — every term currently in use, with its card count. A curator picks from
+   that list and only coins a new term when nothing fits. Synonyms that survive normalization (`split-k`
+   vs `splitk`) are **flagged** in the index with a ⚠ block; the fix is to edit the offending card and
+   regenerate. The generator never auto-merges them — collapsing `mfma`/`mfmas` behind the curator's back
+   would be a worse failure than a visible warning.
+
+The same "reuse before coining" rule applies to `kernel_class` and `lever` ids, and matters more there:
+those are what group the index.
+
+## How to USE it during a run (read path) — three hard rules
+Read `INDEX.md` (or grep the headers directly) **after** you have formed your own profile-driven plan, as
+a cross-check and a source of *extra* ideas — then:
+1. **ADD-only, never filter.** Cards may only *add* candidate levers/directions to try. They must never
+   remove a candidate, prune the direction set, or skip the author/measurement step.
+2. **Measurement is always the judge.** Run the full author + isolated A/B + oracle parity regardless of
+   what any card claims. A card is a hint about where to *look first*, not a verdict.
+3. **No card may foreclose an approach.** A `caution:` line is "**also verify X**", never "don't do Y".
+   A past winner is a starting point, not a ceiling; a past pitfall is a thing to double-check.
+
+Open the cards whose `key` matches this run's `(kernel_class, gfx, regime)`; treat their `lever`/`effect`
+as **priors that seed your candidate set**, and `caution` as **extra checks**.
+
+## Card schema (one principle per file, ~12–20 lines)
+```
+---
+# --- discovery header: how this card is FOUND (drives the generated INDEX.md; keep greppable) ---
+name: <slug>                                # == the filename without .md
+description: <ONE line, ≤160 chars: lever → on what → relative effect. This is the INDEX.md line.>
+keywords: [<lowercase-hyphenated terms>]    # PICK FROM the "keyword vocabulary" appendix at the bottom
+                                            # of INDEX.md before inventing one — reusing a term is what
+                                            # keeps sibling cards clustered. e.g. split-k, lds-tiling,
+                                            # launch-overhead, dot-scaled, aiter, decode, skinny-m
+kernels: [<kernel symbol / entry point measured>] # e.g. _gqa_sparse_fwd_kernel, fused_moe_kernel. The
+                                            # concrete name matters: greps hit it long before a class does.
+platforms: [<gfx>]                          # e.g. [gfx942] — the arch the evidence was measured on
+kernel_class: <kernel_class>                # e.g. dense_gemm | moe_grouped_gemm | attention_decode | method
+regime: decode | prefill | both | n/a       # the shape regime the evidence covers
+# --- classification + evidence ---
+key: <one line of plain English identifying WHAT this card is about>
+                                            # The human-readable identity + dedupe/merge target. Write it
+                                            # as a sentence fragment, not a rigid triple: name the op, the
+                                            # arch, and whatever else actually distinguishes this card —
+                                            # framework, dtype/quant format, shape regime.
+                                            #   good: "bf16 fused-MoE grouped GEMM · gfx942/MI300X · vLLM"
+                                            #   good: "MXFP8 E8M0 dense linear, decode-bound · gfx950"
+                                            #   bad:  "dense_gemm · gfx942 · decode"  <- collapses a vLLM
+                                            #         MXFP8 card and an sglang bf16 card into one key and
+                                            #         invites a wrong merge.
+                                            # The MACHINE-readable slots are the discovery-header fields
+                                            # above (kernel_class/platforms/regime); `key` does not need
+                                            # to repeat their job, so let it say what a person would say.
+layer: learned
+levers: [<lever id>]                        # e.g. host.launch-overhead, mem.lds-tiling — free-form but reused
+cost: L0|L1|L2|L3                           # L0 env/flag · L1 config/knob · L2 wrapper/host rewrite · L3 new kernel
+lifecycle: active
+type: routing | lever | method
+confidence: ★ | ★★ | ★★★                    # how often it REPRODUCED (a hint strength, not authority)
+effect: <RELATIVE only — e.g. "1.34x isolated (weighted), non-overlapping vs frozen baseline". No ms.>
+roofline: <bound class before → after, + % of achievable peak, e.g. "HBM-bound 41%→ compute-bound 78% of
+           achievable BW"; relative positions only, never absolute GB/s or TFLOP/s>
+verified_on: YYYY-MM-DD | null              # the date an on-box A/B actually confirmed it
+last_seen: YYYY-MM-DD
+---
+# <short title>
+- lever: <an actionable thing worth TRYING (a seed candidate), not a mandate>
+- apply: <how to deploy / the rebind seam / env var / the shape of the patch>
+- stack: <ONLY when >1 direction landed. Total first, then per-direction — see "Stacked wins" below.>
+- verify: <how to confirm it engaged + beat the frozen baseline on the isolated A/B>
+- pitfall: <symptom observed> → <root cause> → <the fix that worked>   # repeatable; one line each
+- caution: <a CONDITIONED "also verify X". NEVER a blanket prohibition.>
+- source: <EVAL_DIR path | arXiv | repo@path>   # REQUIRED — no claim without evidence
+```
+
+### Content rules — what a card may and may not record
+
+**1. Sanitize the numbers: RATIOS, never absolutes.** Wall-clock varies by box, clock/power state,
+driver, and neighbour load, so an absolute figure copied into a card is stale on arrival and misleads
+the next run into treating it as a target.
+- **Record:** speedup ratios (`1.34x`), percent deltas (`+18%`), *fractions of achievable peak*
+  (`62% of achievable HBM BW`), occupancy %, cache hit %, arithmetic intensity, the roofline **bound
+  class** and which side of the ridge point the op sits on, and workload constants that are properties
+  of the problem, not the machine (shapes, dtypes, tile sizes, `num_warps`, split-K, grid geometry).
+- **Do NOT record:** `ms`/`µs`/`ns` wall-clock (baseline or optimized), absolute `TFLOP/s`, `GB/s`,
+  bytes/s, achieved-vs-spec bandwidth in absolute units, kernel duration, power, or clocks. The raw
+  timings already live in `EVAL_DIR` — that is the right home for them.
+- If a lesson genuinely needs a magnitude, express it against something on the same box: "≈2× the
+  launch overhead of the fused path", "≈0.4 of the roofline ceiling before, ≈0.8 after".
+
+**2. Record the pitfalls, not just the win.** The traps cost the next run more time than the lever
+saves it. One `pitfall:` line per trap actually hit during this run, in `symptom → root cause → fix`
+form, and only for traps *observed here* (a hypothetical is not evidence). Typical sources: a candidate
+that failed oracle parity, an apply/build failure, a "faster but wrong" result, a config that silently
+did not engage, a win that vanished when the baseline was frozen properly. A pitfall is not a
+prohibition — it is the thing to check *while* trying the lever.
+
+**3. Stacked wins: total first, then each direction separately.** When several optimization directions
+compounded into the final number, a single blended figure is unusable — the next run cannot tell which
+lever to try first, or which one carried the win. Give the total, then attribute per direction, and say
+plainly if the attribution is approximate (directions interact; a merged patch's parts are rarely
+additive).
+```
+- stack: total 1.62x isolated (weighted, director-verified) = three directions compounded
+  - 1. mem.lds-tiling — 1.31x standalone (round 2, verified) — the bulk of the win
+  - 2. host.launch-overhead — +12% on top of (1) (round 3, verified) — only pays once (1) removed the stall
+  - 3. compute.mfma-nonkdim16 — +9% on top of (1,2) (round 4, verified)
+  - note: attribution is incremental in landing order, not independent; (2) measured ~+3% alone.
+```
+Each entry carries its own relative effect and where it was measured (round + verified/claimed). If a
+direction's individual contribution was never isolated, say so rather than inventing a split. When only
+one direction landed, omit `stack:` entirely — `effect:` already says it.
+
+### Confidence tiers (a HINT strength, not an authority level)
+- ★   = single run, isolated distributions overlapped (≈ noise / unverified) — weak hint.
+- ★★  = single-run non-overlapping isolated A/B, OR ≥2 consistent runs.
+- ★★★ = ≥2 independent runs non-overlapping on the frozen-baseline A/B.
+
+## How to UPDATE it after a run (write path) — CURATE, never blind-append
+Owner: **TechLead** (holds the global routing view; runs the `update_experience` step after Report).
+One transaction:
+1. **Read the whole index before you write** — including its keyword vocabulary appendix. Find the card
+   whose `key` matches your finding, judging by meaning (a differently-worded card for the same lever on
+   the same class/arch IS a match — merge into it rather than filing a near-twin). If the index looks
+   thinner than the folder, regenerate it first: a lane that finished seconds ago may not be projected yet.
+2. **MERGE if it exists** — raise/lower `confidence` by what reproduced, widen/correct `effect`, append a
+   `source`, refresh `last_seen`, add any new `keywords`/`kernels` the run surfaced. Never a second card
+   for the same key.
+3. **INSERT only if novel AND effective (≥★★).** ONE new card, with a complete discovery header, obeying
+   the three **Content rules** above (ratios only — no ms; the pitfalls you actually hit;
+   total-then-per-direction for a stacked win). This applies to a MERGE too: never let an absolute timing
+   in through the back door of an updated `effect:`.
+3a. **Regenerate the index — never hand-edit it.**
+   `node kernel_workflow/scripts/build_learned_index.js` (add `--check` in CI to catch a stale file).
+4. **NULL / overlapping / unverified → write NOTHING here** (the `EVAL_DIR` report is enough). A one-off
+   raw number is not a card; only a reusable `(kernel_class, gfx, regime) → lever` lesson earns one.
+5. **A surprising negative → a CONDITIONED `caution:`** on the relevant card (with the condition it held
+   under + its source), framed as "also verify". A claim *contradicted* by new evidence → move the card
+   to `_archive.md` with the refuting source. **Never write a blocklist / "never use X".**
+6. **Enforce the budget.** ≤ 40 active cards; the generator prints the count and flags the overflow in
+   the file itself. Over → set the weakest card's `lifecycle:` to `archived` and move it to
+   `_archive.md` (lowest `confidence × freshness`; ★★★ is never auto-evicted), then regenerate.
+
+**Invariant:** a principle "exists" iff a card file carries a discovery header with `lifecycle: active`.
+The card is the source of truth; `INDEX.md` is its projection. Keep cards short: >20 lines means you're
+storing narrative, not a principle — distill it.
+**Above all: a card is advice the box can overrule, not a rule that overrules the box.**

--- a/kernel_workflow/roles/author_engineer.md
+++ b/kernel_workflow/roles/author_engineer.md
@@ -39,6 +39,15 @@ never by the knowledge base. Rules (these guarantee the KB can only help, never 
   evidence* — a weak hint at most. Don't pick based on it; measure.
 - If `KERNEL_KNOWLEDGE_DIR` is empty/missing, use the canonical algorithm — no behavior change.
 
+`SKILL_DIR/knowledge/learned/INDEX.md` is the *local* twin of that contract: distilled cards from past
+runs on this box. Same three rules (`knowledge/learned/README.md`) — a card may only **ADD** a candidate
+to try, the unittest + benchmark is always the judge, and a `caution:` is "also verify X", never a ban.
+Open the cards whose key matches your `(kernel_class, gfx, regime)`; if there are none, nothing changes.
+`INDEX.md` is short (≤40 cards) and each line already carries the card's description, the kernel symbols
+it was measured on, and its keywords — **read it and judge relevance by meaning**, then open the one or
+two that look worth it. Don't string-match: a card written for a neighbouring op or a different tile
+regime often still applies.
+
 ## Load the authoring knowledge for your language + op (focused context, optional)
 Semantic dirs (resolve short names via `index/capability_index.yaml` + `index/taxonomy.md` if unsure).
 Read, as reference, before writing:

--- a/kernel_workflow/roles/tech_lead.md
+++ b/kernel_workflow/roles/tech_lead.md
@@ -15,6 +15,17 @@ Always-available references (Read what's relevant to the phase):
 - `SKILL_DIR/knowledge/hip_optimization.md` / `triton_optimization.md` — per kernel type
 - `SKILL_DIR/knowledge/wrapper_optimization.md` — host/runtime patterns
 - `SKILL_DIR/knowledge/amd_instinct.md` (the target card — detect gfx942/gfx950 on-box), `SKILL_DIR/knowledge/profiling_guide.md`
+- `SKILL_DIR/knowledge/learned/INDEX.md` — distilled experience from past runs as **advisory priors**
+  (an aid, not a rule). Read it **after** you have formed your own profile-driven plan, then open the
+  cards whose key matches this run's `(kernel_class, gfx, regime)`. Three hard rules, per
+  `knowledge/learned/README.md`: cards may only **ADD** candidate directions (never prune one, never
+  skip a measurement); the **frozen-baseline A/B + oracle parity is always the judge** — if a card and
+  the box disagree, the box wins; a `caution:` means "also verify X", never "don't do Y". The file may
+  be empty (no cards yet) — that changes nothing about how you plan.
+  **Read the index and judge relevance yourself** — each line carries the card's description, the kernel
+  symbols it was measured on, and its keywords. Match on *meaning*, not wording: a `split-k on skinny-M
+  GEMM` card is worth opening for a tall-K GEMM, a `launch-overhead` card for any dispatch-bound op. Do
+  not decide "there is no card for this" from a failed string search. Then open the 0–3 that look worth it.
 
 ### `KERNEL_KNOWLEDGE_DIR` — the AMD operator×backend SOTA base (REFERENCE ONLY)
 When `KERNEL_KNOWLEDGE_DIR` is non-empty, it points at the `perf_knowledge/` base: per-operator,

--- a/kernel_workflow/roles/update_experience.md
+++ b/kernel_workflow/roles/update_experience.md
@@ -1,0 +1,129 @@
+# Role: update_experience (TechLead — learned-card curation)
+
+You run **once, at the very end of the run** — after every optimization round, after the final report,
+and after the Director's independent re-measurement. There is no per-round curation: a single round's
+number is episodic (it belongs in `${EVAL_DIR}`), and the only figure a card may cite is the final
+verified one in `WINNER.speedup`. Your job: distill **at most one** reusable principle into the local
+`learned/` sink, following `${LEARNED_DIR}/README.md` (read it first). This is CURATION, not logging —
+most runs add nothing.
+
+## The sink is `${LEARNED_DIR}` and nothing else (hard invariant)
+`${LEARNED_DIR}` is an absolute path handed to you by the orchestrator; it always resolves inside the
+workflow that opened this run. **Never** write a card anywhere else — in particular **never** under
+`e2e_workflow/knowledge/learned/`, even if you read cards from there, and even if this lane was opened
+by e2e_workflow. That folder is a *separate memory* with a different gate (the e2e Director's A/B and
+its e2e-transfer note); a kernel-level result has no e2e evidence to put in it, and its owner is e2e's
+own `system_architect` step, which cites your card rather than copying it. Outside `${LEARNED_DIR}`, the
+only files you create or modify are under `${EVAL_DIR}`. If `${LEARNED_DIR}` does not exist, create it —
+do not "find" a nearby `learned/` folder.
+
+## SCOPE — what kind of card this run can earn
+- `SCOPE=lane` — one kernel, one language. The lesson is a **lever/method**: the technique that produced
+  the win on this `(kernel_class, gfx, regime)`, and how to confirm it engaged.
+- `SCOPE=bakeoff` — several languages competed on ONE frozen baseline. The lesson is usually **routing**:
+  which backend language actually wins for this op/arch and by how much, with the runners-up as evidence
+  (`CANDIDATES` carries every lane's measured speedup). Record a lever card instead only if the winning
+  margin came from a specific technique rather than from the language choice.
+
+## Hard rules (from README.md)
+- **ADD-only.** You may add one card + one INDEX line, or merge into an existing card. Never delete a
+  candidate concept, never rewrite a card into a prohibition. A `caution:` is "also verify X".
+- **Measurement is the judge.** Only claim what the frozen-baseline isolated A/B + oracle parity in
+  this run actually showed. Every card needs a `source:` (an `EVAL_DIR` path).
+- **One principle per card.** A one-off raw number is NOT a card — it stays in `EVAL_DIR`. Only a
+  reusable `(kernel_class, gfx, regime) → lever` lesson earns a card.
+- **Isolated evidence only.** Your `effect` is the isolated/frozen-baseline number. Do NOT claim an
+  end-to-end gain: this run never measured one. If an e2e run consumed this kernel, its own
+  `update_experience` records the e2e delta and cites your card.
+- **Keep INDEX ≤40 lines.** If it would overflow, demote the weakest ★ card to `_archive.md` first.
+
+## What goes ON the card (the three content rules — see README.md "Content rules")
+1. **Sanitize: ratios only, never absolutes.** Keep the concrete optimization direction, the speedup
+   ratio / percent delta, and the roofline picture (bound class before → after, % of *achievable* peak,
+   which side of the ridge point). **Never write a wall-clock number** — no `ms`/`µs`/`ns`, and no
+   absolute `TFLOP/s` / `GB/s` / bytes-per-second / clocks / power, for either the baseline or the
+   optimized side. Those fluctuate box to box and would mislead the next run; they already live in
+   `${EVAL_DIR}`. Shapes, dtypes, tile sizes, `num_warps`, split-K and grid geometry are properties of
+   the *problem*, not the machine — keep those.
+2. **Write the pitfalls you actually hit, with the fix.** One `pitfall:` line per trap, as
+   `symptom → root cause → fix`. Mine them from `HISTORY.ledger`/`HISTORY.insights` and the failed or
+   rejected candidates in the report: parity failures, apply/build breaks, "faster but wrong", a knob
+   that silently did not engage, a win that evaporated against the frozen baseline. Only traps this run
+   observed — no hypotheticals. A pitfall is a thing to check *while* trying the lever, never a ban.
+3. **Stacked directions: total first, then each one separately.** If more than one direction landed
+   (walk `HISTORY.rounds` — each round's `winner`, `improved`, and `cumulative`), open `stack:` with the
+   total director-verified speedup, then one sub-line per direction with its own relative contribution
+   and where it was measured (round + verified/claimed). Attribution is incremental in landing order —
+   say so, and say when a direction's standalone contribution was never isolated rather than inventing a
+   split. One direction only → omit `stack:`.
+
+## Inputs
+`SCOPE` (`lane` | `bakeoff`), `LEARNED_DIR` (the sink), `SKILL_DIR` (the owning workflow — its
+`scripts/build_learned_index.js` regenerates the index), `EVAL_DIR` (this run's episodic record),
+`REPORT_PATH` (the final report), `WINNER` (the winning candidate + its verified speedup; on a lane run
+it also carries `kernel`/`language`/`gfx`/`kernel_class`/`bottleneck`), `HISTORY` (lane only: the
+per-round ledger, insights, and each round's directions/results/winner/cumulative — this is what lets
+you decompose a stacked win and find the pitfalls), `PROFILE` (lane only: the final profile summary —
+bottleneck class and key metrics for the `roofline:` line; convert anything absolute in it into a
+fraction before it reaches the card), `CANDIDATES` (bake-off only), `OP_SPEC` (bake-off only), and
+`PERF_KNOWLEDGE_DIR` (the read-only reference base; may be empty).
+
+## Steps
+1. Read `${LEARNED_DIR}/README.md` and `${LEARNED_DIR}/INDEX.md`.
+2. Read `${REPORT_PATH}` and the `WINNER` input. Write the reuse `key` as **one line of plain English**
+   naming what this card is about — the op, the arch, and whatever else actually distinguishes it
+   (framework, dtype/quant format, shape regime): e.g. `bf16 fused-MoE grouped GEMM · gfx942/MI300X ·
+   vLLM`, or `MXFP8 E8M0 dense linear, decode-bound · gfx950`. Do **not** reduce it to a bare
+   `dense_gemm · gfx942 · decode` triple — that collapses genuinely different cards onto one key and
+   invites a wrong merge; the machine-readable slots are the separate `kernel_class`/`platforms`/`regime`
+   fields, which take their values from `WINNER` when present, else from the report.
+   Reuse a `kernel_class` / `lever` id that already appears on the existing cards when one fits —
+   consistent ids are what make the cards findable; only coin a new one when nothing matches.
+2a. **Before you call it novel, regenerate the index and read all of it** (step 7's command; a lane that
+   finished seconds ago may not be projected yet). Decide "already covered?" **by meaning, not wording** —
+   a card describing the same lever on the same `(kernel_class, gfx, regime)` in different words IS the
+   same card, and filing a near-twin next to it is the main way this folder degrades. When in doubt,
+   MERGE into the existing card rather than create.
+3. Decide the transaction:
+   - **Nothing reusable** (win was a one-off / already covered by an equal-or-stronger card): do nothing;
+     return `{"action":"skipped","card_path":"","key":"...","note":"why"}`.
+   - **Existing card matches the key**: merge — refresh `effect`/`last_seen`, adjust `confidence` by what
+     reproduced, add a `caution` only as "also verify X", and extend `keywords`/`kernels` with any new
+     search terms this run surfaced. Do NOT duplicate.
+   - **New reusable principle**: write ONE new card file `${LEARNED_DIR}/<slug>.md` using the schema in
+     README.md. It MUST open with the full **discovery header** — `name` (= the slug), `description`
+     (one line, ≤160 chars: lever → on what → relative effect; this becomes the index line), `keywords`
+     (**pick from the `## keyword vocabulary` appendix at the bottom of `INDEX.md`** — reusing an existing
+     term is what keeps sibling cards clustered; coin a new one only when nothing there fits), `kernels`
+     (the concrete kernel
+     symbol / entry point you measured), `platforms`, `kernel_class`, `regime` — followed by
+     `key, layer: learned, levers, cost, lifecycle: active, type, confidence, effect, roofline,
+     verified_on, last_seen`. Discovery lives on the card; that is what makes it findable.
+4. Confidence tier: ★ single-run overlapping isolated A/B · ★★ single non-overlap or ≥2 consistent ·
+   ★★★ ≥2 independent runs non-overlapping. Do not inflate.
+5. Set `verified_on` to today only if this run's A/B actually confirmed the effect on-box; else `null`.
+6. **Sanitation pass before you save** (applies to a merge as much as to a new card): re-read the card
+   text you are about to write and strip every absolute measurement — any `ms`/`µs`/`ns`, `TFLOP/s`,
+   `GB/s`, clock or power figure, in the frontmatter *and* the body. Restate each one as a ratio, a
+   percent delta, or a fraction of achievable peak, or drop it. The INDEX line follows the same rule.
+7. **Regenerate the index — never hand-edit `INDEX.md`.** It is a generated projection of the cards'
+   discovery headers:
+   ```bash
+   node ${SKILL_DIR}/scripts/build_learned_index.js ${LEARNED_DIR}
+   ```
+   (If `SKILL_DIR` is not in your inputs, the script sits next to the workflow that owns `${LEARNED_DIR}`:
+   `<workflow>/scripts/build_learned_index.js`.) The regen reads whatever cards are on disk, so a lane
+   running concurrently with you cannot lose its entry and you cannot lose yours — no append, no race.
+   Report a bad/edited `description` by fixing the **card** and regenerating, never by editing the index.
+   Then **read the regenerated index once**: if it now shows a ⚠ near-duplicate keyword block naming a
+   term you just used, fix your card to the established spelling and regenerate again.
+
+## Return JSON (StructuredOutput)
+```json
+{
+  "action": "created | merged | skipped",
+  "card_path": "path under knowledge/learned/, or \"\" if nothing distilled",
+  "key": "<the card's plain-English key line, e.g. 'MXFP8 E8M0 dense linear, decode-bound · gfx950'>",
+  "note": "one line: what was distilled or why nothing was"
+}
+```

--- a/kernel_workflow/scripts/build_learned_index.js
+++ b/kernel_workflow/scripts/build_learned_index.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * build_learned_index.js — regenerate knowledge/learned/INDEX.md FROM the cards.
+ *
+ * INDEX.md is a GENERATED file: every line is derived from one card's discovery frontmatter
+ * (`name`, `description`, `keywords`, `kernels`, `platforms`, `kernel_class`, `regime`, `confidence`).
+ * Nobody hand-edits it — parallel lanes used to race on an append-to-INDEX step and silently drop each
+ * other's line, whereas a regen republishes whatever cards are on disk.
+ *
+ * SINK-AGNOSTIC: the directory is an argument, so one generator serves every `learned/` folder in the
+ * repo. Referenced in place, never copied. Pure node (fs/path only) — no deps, no network, no GPU.
+ *
+ *   node build_learned_index.js                                          # this workflow's learned/
+ *   node build_learned_index.js e2e_workflow/knowledge/learned           # any other sink
+ *   node build_learned_index.js <learned_dir> --check                    # exit 1 if INDEX.md is stale
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const CAP = 40;                       // README's budget: INDEX.md holds at most this many card lines.
+const SKIP = new Set(['INDEX.md', 'README.md', '_archive.md']);
+
+// Cards that describe a cross-cutting technique rather than one op sort last — a reader scanning for
+// their own kernel_class should hit the op groups first.
+const LAST_GROUPS = ['method', 'other'];
+
+// The sink's owning workflow ("<workflow>/knowledge/learned"), so an e2e index does not tell the
+// reader to rebuild the kernel one.
+const owner = (dir) => {
+  const parts = path.resolve(dir).split(path.sep);
+  const i = parts.lastIndexOf('knowledge');
+  return i > 0 ? parts[i - 1] : parts[parts.length - 1];
+};
+const regenCmd = (dir) => 'node kernel_workflow/scripts/build_learned_index.js' +
+  (owner(dir) === 'kernel_workflow' ? '' : ` ${owner(dir)}/knowledge/learned`);
+
+const HEADER = (dir) => `# Learned — index of distilled ${owner(dir)} experience cards
+
+<!-- GENERATED FILE — do not hand-edit. Regenerate with:
+       ${regenCmd(dir)}
+     Every line below is derived from one card's discovery frontmatter. To change a line, edit the
+     card's \`description\`/\`keywords\`/\`confidence\` and regenerate. -->
+
+Open the cards matching your run as **additional, advisory priors** — they only ADD candidate levers to
+try, never remove any and never replace measurement. The frozen-baseline isolated A/B + oracle parity is
+always the judge (see \`README.md\`). **Cap: ≤${CAP} card lines.** Confidence (a hint strength, not
+authority): ★ noise/unverified · ★★ single non-overlap or ≥2 consistent · ★★★ ≥2 non-overlap.
+
+Effects are **ratios or percent deltas only, never wall-clock or absolute throughput** — those vary box
+to box and stay in the run's \`EVAL_DIR\` (see \`README.md\` → "Content rules").
+
+**How to use this file: READ it, then open the 0–3 cards that look relevant.** Each line carries the
+card's own description, the kernel symbols it was measured on, and its keywords — enough to judge
+relevance without opening anything. Match on *meaning*, not on an exact string: a card written for
+\`split-k on skinny-M GEMM\` is worth opening for a tall-K GEMM too. If nothing matches, that is a real
+answer — plan cold, exactly as this workflow does without any KB.
+
+(Every line here is derived from a card's discovery header, so a card is still self-describing if you
+open it directly. A \`grep\` for an exact kernel symbol works as a shortcut, but it is not the lookup
+path — it matches strings, and the thing you are looking for is a *concept*.)
+`;
+
+function parseFrontmatter(text) {
+  if (!text.startsWith('---')) return null;
+  const end = text.indexOf('\n---', 3);
+  if (end === -1) return null;
+  const out = {};
+  for (const raw of text.slice(3, end).split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const i = line.indexOf(':');
+    if (i === -1) continue;
+    const k = line.slice(0, i).trim();
+    let v = line.slice(i + 1).trim();
+    if (v.startsWith('[') && v.endsWith(']')) {
+      out[k] = v.slice(1, -1).split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
+    } else {
+      out[k] = v.replace(/^["']|["']$/g, '');
+    }
+  }
+  return out;
+}
+
+function stars(c) { const m = String(c || '').match(/★+/); return m ? m[0] : '★'; }
+
+// Keyword hygiene against vocabulary drift ("split-k" / "split_k" / "splitk" / "Split K"), which stops
+// sibling cards from clustering. normalize() fixes mechanical spelling; fold() is a stricter key used
+// ONLY to DETECT near-duplicates that survived it — never to auto-merge, since "gemm"/"gemms" are the
+// same word but "mfma"/"mfmas" might not be.
+const normalize = (s) => String(s).toLowerCase().trim()
+  .replace(/[\s_]+/g, '-').replace(/-{2,}/g, '-').replace(/^-|-$/g, '');
+const fold = (s) => normalize(s).replace(/-/g, '').replace(/s$/, '');
+
+function collect(dir) {
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.md') && !SKIP.has(f))
+    .sort()
+    .map((f) => {
+      const fm = parseFrontmatter(fs.readFileSync(path.join(dir, f), 'utf8'));
+      if (!fm) return null;   // no frontmatter = not indexable; skipped, not guessed at
+      const arr = (v) => (Array.isArray(v) ? v : (v ? [String(v)] : []));
+      return {
+        file: f,
+        name: fm.name || f.replace(/\.md$/, ''),
+        description: fm.description || fm.effect || '(no description)',
+        keywords: [...new Set(arr(fm.keywords).map(normalize).filter(Boolean))],
+        kernels: arr(fm.kernels),
+        platforms: arr(fm.platforms),
+        kernel_class: fm.kernel_class || 'other',
+        regime: fm.regime || '',
+        confidence: stars(fm.confidence),
+        lifecycle: fm.lifecycle || 'active',
+      };
+    })
+    .filter(Boolean)
+    // An archived/retired card keeps its file (the refuting source matters) but leaves the index.
+    .filter(c => c.lifecycle === 'active');
+}
+
+function render(cards, dir) {
+  const groups = new Map();
+  for (const c of cards) {
+    if (!groups.has(c.kernel_class)) groups.set(c.kernel_class, []);
+    groups.get(c.kernel_class).push(c);
+  }
+  const names = [...groups.keys()].sort((a, b) => {
+    const ra = LAST_GROUPS.indexOf(a), rb = LAST_GROUPS.indexOf(b);
+    if (ra !== rb) return (ra === -1 ? -1 : ra) - (rb === -1 ? -1 : rb);
+    return a.localeCompare(b);
+  });
+
+  let body = '';
+  for (const g of names) {
+    const rows = groups.get(g).sort((a, b) =>
+      (b.confidence.length - a.confidence.length) || a.name.localeCompare(b.name));
+    body += `\n## ${g}\n`;
+    for (const c of rows) {
+      const scope = [c.platforms.join('/'), c.regime].filter(Boolean).join(' · ');
+      body += `- ${scope ? `[${scope}] ` : ''}${c.description} ${c.confidence} — (${c.file})\n`;
+      const tags = [
+        c.kernels.length ? `kernels: ${c.kernels.join(', ')}` : '',
+        c.keywords.length ? `kw: ${c.keywords.join(', ')}` : '',
+      ].filter(Boolean).join(' · ');
+      if (tags) body += `  - ${tags}\n`;
+    }
+  }
+  if (!cards.length) body = '\n## (no cards yet)\n';
+
+  // Vocabulary appendix: the controlled word list a curator picks from before coining a synonym.
+  const counts = new Map();
+  for (const c of cards) for (const k of c.keywords) counts.set(k, (counts.get(k) || 0) + 1);
+  const vocab = [...counts.entries()].sort((a, b) => (b[1] - a[1]) || a[0].localeCompare(b[0]));
+
+  if (vocab.length) {
+    body += '\n## keyword vocabulary (generated — REUSE these before coining a new term)\n' +
+      vocab.map(([k, n]) => `${k}${n > 1 ? `(${n})` : ''}`).join(' · ') + '\n';
+
+    const byFold = new Map();
+    for (const [k] of vocab) {
+      const f = fold(k);
+      if (!byFold.has(f)) byFold.set(f, []);
+      byFold.get(f).push(k);
+    }
+    const dupes = [...byFold.values()].filter(v => v.length > 1);
+    if (dupes.length) {
+      body += '\n> ⚠ **Near-duplicate keywords** — same concept, different spelling. Pick one, edit the\n' +
+        '> cards, regenerate:\n' +
+        dupes.map(v => `> - ${v.join(' / ')}\n`).join('');
+    }
+  }
+
+  let footer = '';
+  if (cards.length > CAP) {
+    footer = `\n> ⚠ **Over the ${CAP}-card cap (${cards.length}).** Evict the lowest \`confidence ×\n` +
+      `> freshness\` card to \`_archive.md\` (★★★ is never auto-evicted), then regenerate.\n`;
+  }
+  return HEADER(dir) + body + footer;
+}
+
+function main(argv) {
+  const args = argv.filter(a => a !== '--check');
+  const check = argv.includes('--check');
+  const dir = path.resolve(args[0] || path.join(__dirname, '..', 'knowledge', 'learned'));
+  if (!fs.existsSync(dir)) { console.error(`no such learned dir: ${dir}`); return 2; }
+
+  const cards = collect(dir);
+  const next = render(cards, dir);
+  const out = path.join(dir, 'INDEX.md');
+  const prev = fs.existsSync(out) ? fs.readFileSync(out, 'utf8') : '';
+
+  if (check) {
+    if (prev === next) { console.log(`INDEX.md up to date (${cards.length} cards).`); return 0; }
+    console.error('INDEX.md is stale — run: node kernel_workflow/scripts/build_learned_index.js');
+    return 1;
+  }
+  if (prev !== next) fs.writeFileSync(out, next);
+  console.log(`INDEX.md ${prev === next ? 'unchanged' : 'written'} (${cards.length} cards).`);
+  return 0;
+}
+
+if (require.main === module) process.exit(main(process.argv.slice(2)));
+module.exports = { parseFrontmatter, collect, render, main };

--- a/kernel_workflow/scripts/test_learned_index.js
+++ b/kernel_workflow/scripts/test_learned_index.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * test_learned_index.js — guards the generated learned/INDEX.md contract.
+ *
+ * Pure node (fs/os/path) on a throwaway tmp dir: no GPU, no agent, no repo mutation. Asserts that the
+ * index is DERIVED from card frontmatter (so a lost/racing append can never drop a card), that grouping
+ * and ordering are deterministic, that a non-active card leaves the index, and that --check is honest.
+ */
+'use strict';
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { main, render, collect } = require('./build_learned_index.js');
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'learned-'));
+const card = (name, fm, body = '- lever: x\n') =>
+  fs.writeFileSync(path.join(dir, `${name}.md`), `---\n${fm}\n---\n# ${name}\n${body}`);
+
+card('split-k-gemm-gfx942', [
+  'name: split-k-gemm-gfx942',
+  'description: split-K + LDS re-tiling on skinny-M GEMM → 1.34x isolated',
+  'keywords: [split-k, lds-tiling, skinny-m]',
+  'kernels: [_gemm_a8w8_kernel]',
+  'platforms: [gfx942]', 'kernel_class: dense_gemm', 'regime: decode',
+  'confidence: ★★★', 'lifecycle: active',
+].join('\n'));
+card('launch-overhead-gfx942', [
+  'name: launch-overhead-gfx942',
+  'description: fuse the wrapper prologue → +12% on launch-bound decode',
+  'keywords: [host, launch-overhead]',
+  'platforms: [gfx942]', 'kernel_class: dense_gemm', 'regime: decode',
+  'confidence: ★★', 'lifecycle: active',
+].join('\n'));
+card('method-parity-first', [
+  'name: method-parity-first',
+  'description: re-run oracle parity after a hand-merged patch',
+  'keywords: [parity, integrate]',
+  'kernel_class: method', 'confidence: ★★', 'lifecycle: active',
+].join('\n'));
+card('retired-lever', [
+  'name: retired-lever', 'description: refuted', 'kernel_class: dense_gemm',
+  'confidence: ★', 'lifecycle: archived',
+].join('\n'));
+// Not a card: no frontmatter at all. Must be skipped, not guessed at.
+fs.writeFileSync(path.join(dir, 'stray-notes.md'), '# just some notes\n');
+
+assert.strictEqual(main([dir]), 0);
+const idx = fs.readFileSync(path.join(dir, 'INDEX.md'), 'utf8');
+
+assert.ok(idx.includes('GENERATED FILE'), 'index announces it is generated');
+assert.ok(idx.includes('split-K + LDS re-tiling'), 'card description reaches the index');
+assert.ok(idx.includes('kernels: _gemm_a8w8_kernel'), 'kernel names are indexed');
+assert.ok(idx.includes('kw: split-k, lds-tiling, skinny-m'), 'keywords are indexed');
+assert.ok(idx.includes('[gfx942 · decode]'), 'platform + regime scope is rendered');
+assert.ok(!idx.includes('retired-lever'), 'a non-active card leaves the index');
+assert.ok(!idx.includes('stray-notes'), 'a file without frontmatter is not indexed');
+console.log('  ok: index is derived from card discovery frontmatter');
+
+// Ordering: op groups before `method`; inside a group, higher confidence first.
+const gGemm = idx.indexOf('## dense_gemm'), gMethod = idx.indexOf('## method');
+assert.ok(gGemm !== -1 && gMethod !== -1 && gGemm < gMethod, 'method group sorts last');
+assert.ok(idx.indexOf('split-K + LDS') < idx.indexOf('fuse the wrapper prologue'),
+  '★★★ sorts above ★★ within a group');
+console.log('  ok: grouping + confidence ordering are deterministic');
+
+// The race fix: a card written by another lane appears on the next regen without anyone appending.
+assert.strictEqual(main([dir, '--check']), 0, 'freshly built index is up to date');
+card('concurrent-lane-card', [
+  'name: concurrent-lane-card', 'description: written by a parallel lane',
+  'platforms: [gfx950]', 'kernel_class: attention_decode', 'confidence: ★★', 'lifecycle: active',
+].join('\n'));
+assert.strictEqual(main([dir, '--check']), 1, '--check reports a stale index');
+assert.strictEqual(main([dir]), 0);
+assert.ok(fs.readFileSync(path.join(dir, 'INDEX.md'), 'utf8').includes('written by a parallel lane'),
+  'the other lane\'s card is published by a plain regen — no append, nothing lost');
+console.log('  ok: regen publishes every card on disk (no append race)');
+
+// Keyword hygiene: mechanical spelling differences are normalized away, and the ones that survive are
+// REPORTED so a curator merges them — never silently rewritten.
+card('drifty-card', [
+  'name: drifty-card', 'description: written with sloppy keywords',
+  'keywords: [Split_K, LDS Tiling, splitk]',
+  'platforms: [gfx942]', 'kernel_class: dense_gemm', 'confidence: ★★', 'lifecycle: active',
+].join('\n'));
+main([dir]);
+const drift = fs.readFileSync(path.join(dir, 'INDEX.md'), 'utf8');
+assert.ok(drift.includes('kw: split-k, lds-tiling, splitk'),
+  'Split_K/LDS Tiling normalize to split-k/lds-tiling (case, underscore, space)');
+assert.ok(drift.includes('## keyword vocabulary'), 'the controlled vocabulary is published');
+assert.ok(/split-k\(2\)/.test(drift), 'vocabulary counts show which term is already established');
+assert.ok(drift.includes('Near-duplicate keywords') && /split-k \/ splitk|splitk \/ split-k/.test(drift),
+  'a synonym that survives normalization is flagged, not merged behind the curator\'s back');
+console.log('  ok: keywords normalize; residual drift is reported for a human/curator call');
+fs.unlinkSync(path.join(dir, 'drifty-card.md'));
+main([dir]);
+
+// Idempotent: same cards in, byte-identical index out.
+const a = fs.readFileSync(path.join(dir, 'INDEX.md'), 'utf8');
+main([dir]);
+assert.strictEqual(fs.readFileSync(path.join(dir, 'INDEX.md'), 'utf8'), a, 'regen is idempotent');
+console.log('  ok: regen is idempotent');
+
+// The cap is reported, not silently exceeded.
+for (let i = 0; i < 45; i++) {
+  card(`bulk-${String(i).padStart(2, '0')}`, [
+    `name: bulk-${i}`, `description: bulk card ${i}`, 'kernel_class: dense_gemm',
+    'confidence: ★', 'lifecycle: active',
+  ].join('\n'));
+}
+main([dir]);
+assert.ok(fs.readFileSync(path.join(dir, 'INDEX.md'), 'utf8').includes('Over the 40-card cap'),
+  'overflow is flagged in the file itself');
+console.log('  ok: the ≤40-card cap is surfaced, not silently blown');
+
+fs.rmSync(dir, { recursive: true, force: true });
+console.log('\nPASS: learned/INDEX.md is generated from card frontmatter, ordered, capped, race-free.');


### PR DESCRIPTION
Every kernel_workflow / kernel_lane run now curates ONE distilled card into kernel_workflow/knowledge/learned/ at the very end of the run, after the Director's independent re-measurement. The sink is derived from WORKFLOW_DIR, so a lane spawned by e2e_workflow no longer writes into e2e's learned/ — the two memories stay separate and cite each other.

Cards carry a skill-style discovery header (name/description/keywords/kernels/platforms/ kernel_class/regime/lifecycle) plus a plain-English key; INDEX.md is generated from those headers by a sink-agnostic build_learned_index.js, which also removes the parallel-lane append race and publishes a keyword vocabulary to contain drift. Content is sanitized to ratios — no wall-clock — with pitfalls as symptom→cause→fix and stacked wins reported total-first, then per direction.