### PR TITLE
feat(e2e): read the Architect's "drop list" instead of discarding it

### DIFF
--- a/.github/workflows/ci-l0-checks.yml
+++ b/.github/workflows/ci-l0-checks.yml
@@ -251,13 +251,17 @@ jobs:
           /tmp/gitleaks dir . --no-banner --redact --config .gitleaks.toml
 
   node-regression:
-    name: Node regression (expert_skills, kernel canonicalization, tuning phase, time budget)
+    name: Node regression (expert_skills, kernel canonicalization, tuning phase, time budget, drop_gate)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      # Parse check first: a syntax error in the orchestrator would fail every test
+      # below with a confusing message about the test instead of about the file.
+      - name: e2e_workflow.js parses
+        run: node --check e2e_workflow/e2e_workflow.js
       # Proves the use_expert_skills=OFF path injects nothing (byte-identical).
       # Pure node (fs/path only) — no npm install needed.
       - name: expert_skills OFF-identical regression
@@ -277,6 +281,10 @@ jobs:
       # exercise the JS half, and the clock is pure time arithmetic — no GPU, no model.
       - name: wall-clock budget / final reserve regression
         run: node e2e_workflow/scripts/test_time_budget_reserve.js
+      # Proves drop_gate=off is inert, dryrun records but drops nothing, and a
+      # candidate at or above HEAD_PROTECT_PCT is never dropped in any mode.
+      - name: drop_gate relevance-gate regression
+        run: node e2e_workflow/scripts/test_drop_gate.js
 
   tuning-skillset-integrity:
     name: Vendored tuning skillset matches its manifest
@@ -292,6 +300,10 @@ jobs:
       # Stdlib only; no GPU, no network.
       - name: verify vendored tree against manifest
         run: python3 e2e_workflow/scripts/tuning_skillset_sync.py --verify
+      # Proves drop_gate=off is inert, dryrun records but drops nothing, and a
+      # candidate at or above HEAD_PROTECT_PCT is never dropped in any mode.
+      - name: drop_gate relevance-gate regression
+        run: node e2e_workflow/scripts/test_drop_gate.js
 
   dry-run:
     name: run_e2e dry-run mapping

--- a/.github/workflows/ci-l0-checks.yml
+++ b/.github/workflows/ci-l0-checks.yml
@@ -281,8 +281,9 @@ jobs:
       # exercise the JS half, and the clock is pure time arithmetic — no GPU, no model.
       - name: wall-clock budget / final reserve regression
         run: node e2e_workflow/scripts/test_time_budget_reserve.js
-      # Proves drop_gate=off is inert, dryrun records but drops nothing, and a
-      # candidate at or above HEAD_PROTECT_PCT is never dropped in any mode.
+      # Proves drop_gate ships as 'on', that 'off' is inert, and that a drop is refused
+      # unless it resolves to exactly one candidate of a KNOWN size below HEAD_PROTECT_PCT
+      # from a list that is not taking out more than DROP_MAX_FRACTION of the queue.
       - name: drop_gate relevance-gate regression
         run: node e2e_workflow/scripts/test_drop_gate.js
 
@@ -300,10 +301,6 @@ jobs:
       # Stdlib only; no GPU, no network.
       - name: verify vendored tree against manifest
         run: python3 e2e_workflow/scripts/tuning_skillset_sync.py --verify
-      # Proves drop_gate=off is inert, dryrun records but drops nothing, and a
-      # candidate at or above HEAD_PROTECT_PCT is never dropped in any mode.
-      - name: drop_gate relevance-gate regression
-        run: node e2e_workflow/scripts/test_drop_gate.js
 
   dry-run:
     name: run_e2e dry-run mapping

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -3433,9 +3433,22 @@ if (want('tune') && TUNING_SKILLSET_ENABLED) {
         ...ANALYSIS_SKILL_INPUTS,
       }),
       { phase: 'Strategize', label: 'architect:post-tuning-strategize', schema: STRATEGY_SCHEMA });
-    if (retune && retune.kernel_candidates) kernelQueue = retune.kernel_candidates.slice();
-    if (retune && retune.head_candidates)
-      headQueue = applyOpIdentityGuard(retune.head_candidates.slice(), 'post-tuning re-strategize');
+    // Identity -> op-identity guard (+ admission) -> relevance drop. See normalizeQueues.
+    // This is the FOURTH queue-assignment site and the last one to route through the shared function.
+    // It used to assign the two queues separately: applyOpIdentityGuard on the heads, a bare .slice()
+    // on the kernels. That left this site as the one place a drop_list was still ignored, so an
+    // Architect that re-ranked after tuning could hand back a list of kernels not worth the remaining
+    // budget and be overruled by the site alone. The .slice() was also a shallow copy — it duplicated
+    // the array but not the objects, so downstream mutations wrote through into the Architect's own
+    // candidates and then into carried state. normalizeQueues deep-copies, which closes both.
+    if (retune && (retune.head_candidates || retune.kernel_candidates)) {
+      ({ head: headQueue, kernel: kernelQueue } = normalizeQueues({
+        head: retune.head_candidates || headQueue,
+        kernel: retune.kernel_candidates || kernelQueue,
+        dropList: retune.drop_list || [],
+        origin: 'post-tuning re-strategize',
+      }));
+    }
     if (retune) await ensureFlydslGate();
   } else if (tuned) {
     // Claimed accepted but failed a hard bar. Do NOT bank it — an unproven artifact silently poisons

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -243,6 +243,16 @@ const HEAD_AUTHOR_MAX = parseInt(A.head_author_max != null ? A.head_author_max :
 // hits a harness fault / no-win / extraction failure, the orchestrator LOUDLY flags it (and still tries
 // the author route when a plan exists) instead of dropping the biggest lever on the floor. Default 30%.
 const HEAD_PROTECT_PCT = parseFloat(A.head_protect_pct != null ? A.head_protect_pct : 30);
+// Relevance gate: consume the Architect's drop_list (the candidates it judged not worth the time).
+// Until now drop_list was written by the Architect on every run and read by NOTHING — not code, not a
+// log, not a report, not another role's prompt. Modes:
+//   off    ignore drop_list completely; the queues are exactly what the Architect returned
+//   dryrun match entries and LOG what WOULD be dropped, but drop nothing            (default)
+//   on     actually drop
+// Default is dryrun because this list has never been acted on before: the first runs prove the matching
+// is sound before it is allowed to remove work. A candidate at or above HEAD_PROTECT_PCT is refused as a
+// drop in EVERY mode — the Amdahl-dominant op is never dropped on an LLM's say-so.
+const DROP_GATE = String(A.drop_gate != null ? A.drop_gate : 'dryrun').toLowerCase();
 // Corrective re-author: when a verified-isolated head winner is REJECTED at the e2e gate for a FIXABLE
 // integration reason (it ENGAGED live + beat the isolated oracle, only the integration POSTURE is wrong —
 // e.g. a JIT/DSL kernel lazily compiling in the TP>1 warmup -> NO_BINARY_FOR_GPU / cuda_graph_capture_unsafe,
@@ -1169,6 +1179,108 @@ function stripFlydslFromQueues(...queues) {
   }
   return n;
 }
+
+// --- Candidate queue normalization ---------------------------------------------------------------
+// EVERY site that (re)assigns headQueue/kernelQueue goes through this: the first strategize, the
+// carried-state reload, and the post-config re-strategize. Three ordered steps:
+//   (1) IDENTITY   — give every candidate a stable id and a matchable short_name, so a later stage can
+//                    refer to THIS candidate. Anything we have to invent is marked as invented.
+//   (2) OP-IDENTITY GUARD — the fused-MoE rule. It used to sit inline after the FIRST strategize only, so
+//                    a post-config re-strategize replaced the queue with fresh untagged candidates and
+//                    silently lost the protection the rule's own comment promises ("never SKIPPED").
+//   (3) RELEVANCE DROP — consume the Architect's drop_list (see DROP_GATE).
+// Order matters: (3) can match on the live seam, and (2) is what fills that in.
+// Inputs are DEEP-copied. These queues used to be shallow .slice()s, so steps (2)/(3) and the flydsl
+// strip wrote straight through into the Architect's own candidate objects and into carried state.
+const dropDecisions = (ST.drop_decisions || []).slice();   // audit trail: every drop_list entry and its outcome
+const _clone = (o) => JSON.parse(JSON.stringify(o == null ? {} : o));
+const _norm = (s) => String(s == null ? '' : s).trim().toLowerCase();
+// A seam is "module:attr(sig)"; the signature is advisory, so compare on "module:attr" only.
+const _seamKey = (c) => _norm(String((c && (c.live_call_seam || c.target_callable)) || '').split('(')[0]);
+
+function normalizeQueues({ head, kernel, dropList, origin }) {
+  let H = (head || []).map(_clone);
+  const K = (kernel || []).map(_clone);
+
+  // (1) IDENTITY. Give every candidate an id so a later stage can refer to THIS candidate. When the
+  // Architect omitted one we invent a positional stand-in AND record that we invented it: an invented id
+  // names nothing the Architect could have written down, so step (3) must never let one satisfy a
+  // drop_list entry.
+  // short_name is deliberately NOT filled in here. The head track and the milestone track each synthesize
+  // their own name downstream (`${op_kind}${i}` and `k${milestone}_${i}`), those names reach reports and
+  // task directories, and pre-empting them would silently rename kernels. A candidate with no short_name
+  // simply has no name for a drop_list entry to match on, which is the correct outcome.
+  const ident = (q, prefix) => q.forEach((c, i) => {
+    if (!_norm(c.id)) { c.id = `${prefix}${i}`; c.id_synthesized = true; }
+  });
+  ident(H, 'h'); ident(K, 'k');
+
+  // (2) OP-IDENTITY GUARD + ADMISSION.
+  // Seam-bind FIRST, then hand off to applyOpIdentityGuard (fused tagging + admitHeads). Two reasons the
+  // binding cannot move into that function: it must happen before admission, because admitHeads calls
+  // prepareHeadSelection on what it admits; and it is a superset of the fused-only rule, covering EVERY
+  // head that has a seam. That last part is bug 7 — the binding used to sit inside the fused-only branch,
+  // so a standalone head whose Architect-supplied seam was its only binding hint reached the extractor
+  // with target_callable=''. It is a fallback either way: consumers read ext.target_callable first and
+  // only fall back to the candidate's.
+  let seamBound = 0;
+  for (const c of H) {
+    if (!_norm(c.target_callable) && _norm(c.live_call_seam)) { c.target_callable = c.live_call_seam; seamBound++; }
+  }
+  // applyOpIdentityGuard is main's module-scoped fused-MoE rule; it also runs admitHeads, so a call site
+  // cannot tag identity and then forget to admit. Calling it here rather than re-implementing it keeps
+  // ONE definition of the rule, and it is what makes the drop filter below see the admitted queue.
+  H = applyOpIdentityGuard(H, origin);
+  if (seamBound) log(`[op-identity] (${origin}) ${seamBound} head(s) bound to their Architect-supplied live call seam.`);
+
+  // (3) RELEVANCE DROP.
+  const drops = (dropList || []).map(_clone);
+  if (DROP_GATE === 'off' || !drops.length) {
+    if (drops.length) log(`[drop-gate] (${origin}) OFF — ignoring ${drops.length} drop_list entr(ies).`);
+    return { head: H, kernel: K };
+  }
+  const doomed = new Set();
+  let wouldDrop = 0, dropped = 0, protectedN = 0, unmatched = 0;
+  for (const d of drops) {
+    // Match strictly, most specific first. Never match on a field we invented in step (1).
+    const matches = [...H, ...K].filter((c) => {
+      if (_norm(d.id) && !c.id_synthesized && _norm(d.id) === _norm(c.id)) return true;
+      if (_norm(d.short_name) && _norm(d.short_name) === _norm(c.short_name)) return true;
+      const dk = _norm(String(d.live_call_seam || d.target_callable || '').split('(')[0]);
+      return !!dk && dk === _seamKey(c);
+    });
+    const label = d.id || d.short_name || JSON.stringify(d);
+    if (!matches.length) {
+      // Loud on purpose: a silent no-match is indistinguishable from a working filter.
+      unmatched++;
+      log(`  [drop-gate] (${origin}) NO MATCH for drop_list entry "${label}" — nothing dropped for it.`);
+      dropDecisions.push({ origin, entry: label, why: d.why || '', outcome: 'no_match' });
+      continue;
+    }
+    for (const c of matches) {
+      const pct = Number(c.pct_gpu_time) || 0;
+      if (pct >= HEAD_PROTECT_PCT) {
+        protectedN++;
+        log(`  ⚠️ [drop-gate] (${origin}) REFUSING to drop "${c.short_name}" (${pct.toFixed(1)}% GPU >= HEAD_PROTECT_PCT ${HEAD_PROTECT_PCT}%) — Architect said "${d.why || 'no reason given'}". Keeping it in the queue.`);
+        dropDecisions.push({ origin, entry: label, matched: c.short_name, pct_gpu_time: pct, why: d.why || '', outcome: 'protected' });
+        continue;
+      }
+      if (DROP_GATE === 'dryrun') {
+        wouldDrop++;
+        log(`  [drop-gate] (${origin}) DRY RUN — would drop "${c.short_name}" (${pct.toFixed(1)}% GPU): ${d.why || 'no reason given'}`);
+        dropDecisions.push({ origin, entry: label, matched: c.short_name, pct_gpu_time: pct, why: d.why || '', outcome: 'would_drop' });
+        continue;
+      }
+      doomed.add(c);
+      dropped++;
+      log(`  [drop-gate] (${origin}) DROP "${c.short_name}" (${pct.toFixed(1)}% GPU): ${d.why || 'no reason given'}`);
+      dropDecisions.push({ origin, entry: label, matched: c.short_name, pct_gpu_time: pct, why: d.why || '', outcome: 'dropped' });
+    }
+  }
+  log(`[drop-gate] (${origin}) mode=${DROP_GATE}: ${drops.length} drop_list entr(ies) -> ${dropped} dropped, ${wouldDrop} would-drop, ${protectedN} protected, ${unmatched} unmatched.`);
+  return { head: H.filter((c) => !doomed.has(c)), kernel: K.filter((c) => !doomed.has(c)) };
+}
+
 async function ensureFlydslGate() {
   if (flydslProvisioned) return;                      // already provisioned this run
   if (!flydslRouted(headQueue, kernelQueue)) return;  // strategize did not route flydsl -> nothing to do
@@ -2899,9 +3011,13 @@ if (want('setup')) {
       ...TRACELENS_INPUTS, ...ANALYSIS_SKILL_INPUTS, ...KB_REF_INPUTS,
     }),
     { phase: 'Strategize', label: 'architect:strategize', schema: STRATEGY_SCHEMA });
-  kernelQueue = (strategy && strategy.kernel_candidates) ? strategy.kernel_candidates.slice() : [];
-  headQueue = (strategy && strategy.head_candidates) ? strategy.head_candidates.slice() : [];
-  headQueue = applyOpIdentityGuard(headQueue, 'strategize');
+  // Identity -> op-identity guard (+ admission) -> relevance drop. See normalizeQueues.
+  ({ head: headQueue, kernel: kernelQueue } = normalizeQueues({
+    head: (strategy && strategy.head_candidates) || [],
+    kernel: (strategy && strategy.kernel_candidates) || [],
+    dropList: (strategy && strategy.drop_list) || [],
+    origin: 'strategize',
+  }));
   log(`Strategy: ${headQueue.length} head candidates, ${kernelQueue.length} kernel candidates, ${(strategy && strategy.config_directions || []).length} config directions.`);
   // strategize decided the backends -> if any candidate routed flydsl, provision it now (blocking).
   await ensureFlydslGate();
@@ -2917,8 +3033,13 @@ if (want('setup')) {
   curOverlay = ST.overlay || INIT_BASE_OVERLAY;
   profile = { profile_topN_json: ST.profile_topn_json || '' };
   strategy = { config_directions: ST.config_directions || [] };
-  kernelQueue = ST.kernelQueue || [];
-  headQueue = admitHeads(ST.headQueue || [], 'resume');
+  // Carried state was already filtered when it was first planned (and those decisions came back in
+  // ST.drop_decisions), so no drop_list here — but re-run identity + the op-identity guard, which are
+  // idempotent, so a resumed run holds exactly the same invariants as a fresh one. normalizeQueues runs
+  // admitHeads for us via applyOpIdentityGuard, so this still admits exactly as the plain resume did.
+  ({ head: headQueue, kernel: kernelQueue } = normalizeQueues({
+    head: ST.headQueue || [], kernel: ST.kernelQueue || [], dropList: [], origin: 'carried-state',
+  }));
   log(`Loaded carried state: EVAL_DIR=${EVAL_DIR}, baseline ${BASELINE_TPUT}, flags='${curFlags}', env='${curEnv}', ${headQueue.length} head + ${kernelQueue.length} kernel candidates.`);
 }
 
@@ -2960,9 +3081,16 @@ if (want('config') && CONFIG_TUNE_ENABLED && strategy && (strategy.config_direct
         ...ANALYSIS_SKILL_INPUTS,
       }),
       { phase: 'Strategize', label: 'architect:re-strategize', schema: STRATEGY_SCHEMA });
-    if (restrat && restrat.kernel_candidates) kernelQueue = restrat.kernel_candidates.slice();
-    if (restrat && restrat.head_candidates)
-      headQueue = applyOpIdentityGuard(restrat.head_candidates.slice(), 're-strategize');
+    // Replace only the queue the re-plan actually returned (unchanged), but run BOTH through
+    // normalizeQueues so the re-plan's fresh drop_list is looked at at all — it never was before.
+    if (restrat && (restrat.kernel_candidates || restrat.head_candidates)) {
+      ({ head: headQueue, kernel: kernelQueue } = normalizeQueues({
+        head: restrat.head_candidates || headQueue,
+        kernel: restrat.kernel_candidates || kernelQueue,
+        dropList: restrat.drop_list || [],
+        origin: 're-strategize',
+      }));
+    }
     // re-strategize may have (re)routed flydsl -> provision it (idempotent; no-op if already done).
     await ensureFlydslGate();
   } else {
@@ -4637,6 +4765,15 @@ if (want('final')) {
 }
 
 // State to carry into the NEXT phase invocation (args.state) when driving phase-by-phase.
+// Drop-gate summary. Unconditional: drops apply to the milestone queue as well as the head queue, so
+// this must still print on a run where the head track never opened.
+if (dropDecisions.length) {
+  const tally = dropDecisions.reduce((m, d) => (m[d.outcome] = (m[d.outcome] || 0) + 1, m), {});
+  log(`[drop-gate] mode=${DROP_GATE}; ${dropDecisions.length} drop_list decision(s): ` +
+    Object.keys(tally).map((k) => `${k}=${tally[k]}`).join(', ') +
+    (DROP_GATE === 'dryrun' ? '. DRY RUN — nothing was actually dropped; re-run with drop_gate=on once the matching looks right.' : '.'));
+}
+
 const carryState = {
   backend: BACKEND,
   eval_dir: EVAL_DIR, model_name: MODEL_NAME, baseline_throughput_tok_s: BASELINE_TPUT,
@@ -4647,6 +4784,7 @@ const carryState = {
   // Full tuning-phase result, so a phase-by-phase resume does not re-run the tuning loop and the Report
   // phase still has the attribution numbers when it runs in a later invocation.
   ...(tuning ? { tuning } : {}),
+  drop_decisions: dropDecisions,   // every drop_list entry and what became of it (dropped/protected/unverified/ambiguous/no_match)
   // Carry pending (verified-isolated, A/B-incomplete) wins WITH their inputs so a
   // resumed phase run can finish their A/B instead of re-discovering them.
   pending_integrations: pendingIntegrations,
@@ -4760,6 +4898,8 @@ const wfReturn = {
     pct_gpu_time: p.pct_gpu_time, partial: p.partial || null,
   })),
   flagged_heads: flaggedHeads,   // dominant heads surfaced but not optimized (harness/extract/no-candidate) — never silently dropped
+  drop_gate: DROP_GATE,
+  drop_decisions: dropDecisions, // the Architect's drop_list, matched against the real queues, with the outcome of each
   config_tune_enabled: CONFIG_TUNE_ENABLED,
   head_budget: HEAD_BUDGET,
   head_used: headDispatched,

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -245,14 +245,20 @@ const HEAD_AUTHOR_MAX = parseInt(A.head_author_max != null ? A.head_author_max :
 const HEAD_PROTECT_PCT = parseFloat(A.head_protect_pct != null ? A.head_protect_pct : 30);
 // Relevance gate: consume the Architect's drop_list (the candidates it judged not worth the time).
 // Until now drop_list was written by the Architect on every run and read by NOTHING — not code, not a
-// log, not a report, not another role's prompt. Modes:
-//   off    ignore drop_list completely; the queues are exactly what the Architect returned
-//   dryrun match entries and LOG what WOULD be dropped, but drop nothing            (default)
-//   on     actually drop
-// Default is dryrun because this list has never been acted on before: the first runs prove the matching
-// is sound before it is allowed to remove work. A candidate at or above HEAD_PROTECT_PCT is refused as a
-// drop in EVERY mode — the Amdahl-dominant op is never dropped on an LLM's say-so.
-const DROP_GATE = String(A.drop_gate != null ? A.drop_gate : 'dryrun').toLowerCase();
+// log, not a report, not another role's prompt. Two settings, on by default:
+//   on   drop the candidates the Architect rejected                                 (default)
+//   off  ignore drop_list completely; the queues are exactly what the Architect returned
+// `off` is a kill switch, not a workflow: every decision is logged either way, so there is no
+// observe-only mode to graduate from. What makes `on` safe to default is that a drop is REFUSED
+// unless it clears all four checks in normalizeQueues step (3): the entry resolves to exactly one
+// candidate, that candidate's GPU-time share is actually known, the share is below
+// HEAD_PROTECT_PCT, and the list as a whole is not trying to remove most of the queue.
+const DROP_GATE = String(A.drop_gate != null ? A.drop_gate : 'on').toLowerCase();
+// Bulk-drop circuit breaker. A drop_list that would remove more than this fraction of the combined
+// queue is a planning or matching failure, not a profile in which most work is worthless — so the
+// WHOLE list is refused and logged rather than partially applied in arbitrary order. Deliberately a
+// constant and not an arg: it is a sanity backstop, not a tuning knob.
+const DROP_MAX_FRACTION = 0.5;
 // Corrective re-author: when a verified-isolated head winner is REJECTED at the e2e gate for a FIXABLE
 // integration reason (it ENGAGED live + beat the isolated oracle, only the integration POSTURE is wrong —
 // e.g. a JIT/DSL kernel lazily compiling in the TP>1 warmup -> NO_BINARY_FOR_GPU / cuda_graph_capture_unsafe,
@@ -1188,7 +1194,10 @@ function stripFlydslFromQueues(...queues) {
 //   (2) OP-IDENTITY GUARD — the fused-MoE rule. It used to sit inline after the FIRST strategize only, so
 //                    a post-config re-strategize replaced the queue with fresh untagged candidates and
 //                    silently lost the protection the rule's own comment promises ("never SKIPPED").
-//   (3) RELEVANCE DROP — consume the Architect's drop_list (see DROP_GATE).
+//   (3) RELEVANCE DROP — consume the Architect's drop_list (see DROP_GATE). A drop is refused unless
+//                    the entry resolves to exactly ONE candidate, that candidate's GPU-time share is
+//                    KNOWN, the share is below HEAD_PROTECT_PCT, and the list is not trying to take out
+//                    more than DROP_MAX_FRACTION of the queue. Every refusal is logged and recorded.
 // Order matters: (3) can match on the live seam, and (2) is what fills that in.
 // Inputs are DEEP-copied. These queues used to be shallow .slice()s, so steps (2)/(3) and the flydsl
 // strip wrote straight through into the Architect's own candidate objects and into carried state.
@@ -1197,6 +1206,18 @@ const _clone = (o) => JSON.parse(JSON.stringify(o == null ? {} : o));
 const _norm = (s) => String(s == null ? '' : s).trim().toLowerCase();
 // A seam is "module:attr(sig)"; the signature is advisory, so compare on "module:attr" only.
 const _seamKey = (c) => _norm(String((c && (c.live_call_seam || c.target_callable)) || '').split('(')[0]);
+// GPU-time share, or null when it is genuinely unknown. `Number(x) || 0` will not do here: it maps a
+// missing field to 0, i.e. to "vanishingly small", which is exactly the reading that makes a candidate
+// look safe to drop. An explicit 0 is a statement and is kept as 0; absent/blank/NaN becomes null.
+const _pct = (o) => {
+  const v = o == null ? undefined : o.pct_gpu_time;
+  if (v == null || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+// NOTE: _isFusedOp is NOT redeclared here. main grew its own module-scoped copy alongside
+// applyOpIdentityGuard; a second `const` of the same name at module scope is a hard SyntaxError, and
+// step (2) above delegates to that function rather than re-implementing the rule.
 
 function normalizeQueues({ head, kernel, dropList, origin }) {
   let H = (head || []).map(_clone);
@@ -1239,45 +1260,85 @@ function normalizeQueues({ head, kernel, dropList, origin }) {
     if (drops.length) log(`[drop-gate] (${origin}) OFF — ignoring ${drops.length} drop_list entr(ies).`);
     return { head: H, kernel: K };
   }
-  const doomed = new Set();
-  let wouldDrop = 0, dropped = 0, protectedN = 0, unmatched = 0;
+  // Resolve every entry FIRST and commit nothing, so the bulk-drop breaker below can weigh the whole
+  // list before any of it takes effect.
+  const pool = [...H, ...K];
+  const planned = [];                       // entries that cleared every check
+  let protectedN = 0, unmatched = 0, ambiguous = 0, unverified = 0;
+
   for (const d of drops) {
-    // Match strictly, most specific first. Never match on a field we invented in step (1).
-    const matches = [...H, ...K].filter((c) => {
-      if (_norm(d.id) && !c.id_synthesized && _norm(d.id) === _norm(c.id)) return true;
-      if (_norm(d.short_name) && _norm(d.short_name) === _norm(c.short_name)) return true;
-      const dk = _norm(String(d.live_call_seam || d.target_callable || '').split('(')[0]);
-      return !!dk && dk === _seamKey(c);
-    });
     const label = d.id || d.short_name || JSON.stringify(d);
+    const note = d.why || 'no reason given';
+
+    // An id is the Architect's own handle on a candidate, so when it supplies one we match on THAT
+    // ALONE. Falling back to the name after an id miss would let a stale or hallucinated id quietly
+    // land on some other candidate. An id we invented in step (1) is never matchable.
+    const byId = _norm(d.id);
+    const matches = byId
+      ? pool.filter((c) => !c.id_synthesized && _norm(c.id) === byId)
+      : pool.filter((c) => {
+        if (_norm(d.short_name) && _norm(d.short_name) === _norm(c.short_name)) return true;
+        const dk = _norm(String(d.live_call_seam || d.target_callable || '').split('(')[0]);
+        return !!dk && dk === _seamKey(c);
+      });
+
     if (!matches.length) {
       // Loud on purpose: a silent no-match is indistinguishable from a working filter.
       unmatched++;
       log(`  [drop-gate] (${origin}) NO MATCH for drop_list entry "${label}" — nothing dropped for it.`);
-      dropDecisions.push({ origin, entry: label, why: d.why || '', outcome: 'no_match' });
+      dropDecisions.push({ origin, entry: label, why: note, outcome: 'no_match' });
       continue;
     }
-    for (const c of matches) {
-      const pct = Number(c.pct_gpu_time) || 0;
-      if (pct >= HEAD_PROTECT_PCT) {
-        protectedN++;
-        log(`  ⚠️ [drop-gate] (${origin}) REFUSING to drop "${c.short_name}" (${pct.toFixed(1)}% GPU >= HEAD_PROTECT_PCT ${HEAD_PROTECT_PCT}%) — Architect said "${d.why || 'no reason given'}". Keeping it in the queue.`);
-        dropDecisions.push({ origin, entry: label, matched: c.short_name, pct_gpu_time: pct, why: d.why || '', outcome: 'protected' });
-        continue;
-      }
-      if (DROP_GATE === 'dryrun') {
-        wouldDrop++;
-        log(`  [drop-gate] (${origin}) DRY RUN — would drop "${c.short_name}" (${pct.toFixed(1)}% GPU): ${d.why || 'no reason given'}`);
-        dropDecisions.push({ origin, entry: label, matched: c.short_name, pct_gpu_time: pct, why: d.why || '', outcome: 'would_drop' });
-        continue;
-      }
-      doomed.add(c);
-      dropped++;
-      log(`  [drop-gate] (${origin}) DROP "${c.short_name}" (${pct.toFixed(1)}% GPU): ${d.why || 'no reason given'}`);
-      dropDecisions.push({ origin, entry: label, matched: c.short_name, pct_gpu_time: pct, why: d.why || '', outcome: 'dropped' });
+    if (matches.length > 1) {
+      // Two candidates answer to the same name. Which one the Architect meant is a guess, and a drop
+      // is not reversible, so refuse and say so.
+      ambiguous++;
+      log(`  ⚠️ [drop-gate] (${origin}) AMBIGUOUS drop_list entry "${label}" matches ${matches.length} candidates (${matches.map((c) => c.id).join(', ')}) — refusing to guess, dropping none of them.`);
+      dropDecisions.push({ origin, entry: label, matched: matches.map((c) => c.id).join(','), why: note, outcome: 'ambiguous' });
+      continue;
     }
+
+    const c = matches[0];
+    // The whole justification for a drop is "this is too small to be worth the time", so a candidate
+    // whose share we cannot read is one we cannot justify dropping. An explicit 0 is a statement and
+    // counts as known; a missing or unparseable field does not. Fall back to the share the Architect
+    // put on the drop entry itself before giving up.
+    const pct = _pct(c) != null ? _pct(c) : _pct(d);
+    if (pct == null) {
+      unverified++;
+      log(`  ⚠️ [drop-gate] (${origin}) REFUSING to drop "${c.short_name || c.id}" — no pct_gpu_time on either the candidate or the drop_list entry, so its size is unknown. Architect said "${note}".`);
+      dropDecisions.push({ origin, entry: label, matched: c.id, why: note, outcome: 'unverified' });
+      continue;
+    }
+    if (pct >= HEAD_PROTECT_PCT) {
+      protectedN++;
+      log(`  ⚠️ [drop-gate] (${origin}) REFUSING to drop "${c.short_name || c.id}" (${pct.toFixed(1)}% GPU >= HEAD_PROTECT_PCT ${HEAD_PROTECT_PCT}%) — Architect said "${note}". Keeping it in the queue.`);
+      dropDecisions.push({ origin, entry: label, matched: c.id, pct_gpu_time: pct, why: note, outcome: 'protected' });
+      continue;
+    }
+    planned.push({ c, label, pct, note });
   }
-  log(`[drop-gate] (${origin}) mode=${DROP_GATE}: ${drops.length} drop_list entr(ies) -> ${dropped} dropped, ${wouldDrop} would-drop, ${protectedN} protected, ${unmatched} unmatched.`);
+
+  // Bulk-drop circuit breaker. Refuse the WHOLE list rather than apply an arbitrary half of it: if the
+  // Architect wants most of the queue gone, the useful signal is "the plan is wrong", not "here are
+  // some kernels".
+  const cap = Math.floor(pool.length * DROP_MAX_FRACTION);
+  if (planned.length > cap) {
+    log(`  ⚠️ [drop-gate] (${origin}) REFUSING THE WHOLE drop_list: it resolves to ${planned.length} of ${pool.length} candidate(s), over the ${Math.round(DROP_MAX_FRACTION * 100)}% cap (${cap}). A list that large is a planning or matching failure, not a profile where most work is worthless. Nothing dropped.`);
+    for (const p of planned) {
+      dropDecisions.push({ origin, entry: p.label, matched: p.c.id, pct_gpu_time: p.pct, why: p.note, outcome: 'refused_bulk' });
+    }
+    log(`[drop-gate] (${origin}) mode=${DROP_GATE}: ${drops.length} drop_list entr(ies) -> 0 dropped (${planned.length} refused in bulk), ${protectedN} protected, ${unverified} unverified, ${ambiguous} ambiguous, ${unmatched} unmatched.`);
+    return { head: H, kernel: K };
+  }
+
+  const doomed = new Set();
+  for (const p of planned) {
+    doomed.add(p.c);
+    log(`  [drop-gate] (${origin}) DROP "${p.c.short_name || p.c.id}" (${p.pct.toFixed(1)}% GPU): ${p.note}`);
+    dropDecisions.push({ origin, entry: p.label, matched: p.c.id, pct_gpu_time: p.pct, why: p.note, outcome: 'dropped' });
+  }
+  log(`[drop-gate] (${origin}) mode=${DROP_GATE}: ${drops.length} drop_list entr(ies) -> ${doomed.size} dropped, ${protectedN} protected, ${unverified} unverified, ${ambiguous} ambiguous, ${unmatched} unmatched.`);
   return { head: H.filter((c) => !doomed.has(c)), kernel: K.filter((c) => !doomed.has(c)) };
 }
 
@@ -4770,8 +4831,7 @@ if (want('final')) {
 if (dropDecisions.length) {
   const tally = dropDecisions.reduce((m, d) => (m[d.outcome] = (m[d.outcome] || 0) + 1, m), {});
   log(`[drop-gate] mode=${DROP_GATE}; ${dropDecisions.length} drop_list decision(s): ` +
-    Object.keys(tally).map((k) => `${k}=${tally[k]}`).join(', ') +
-    (DROP_GATE === 'dryrun' ? '. DRY RUN — nothing was actually dropped; re-run with drop_gate=on once the matching looks right.' : '.'));
+    Object.keys(tally).map((k) => `${k}=${tally[k]}`).join(', ') + '.');
 }
 
 const carryState = {
@@ -4784,7 +4844,8 @@ const carryState = {
   // Full tuning-phase result, so a phase-by-phase resume does not re-run the tuning loop and the Report
   // phase still has the attribution numbers when it runs in a later invocation.
   ...(tuning ? { tuning } : {}),
-  drop_decisions: dropDecisions,   // every drop_list entry and what became of it (dropped/protected/unverified/ambiguous/no_match)
+  drop_decisions: dropDecisions,   // every drop_list entry and what became of it
+                                   // (dropped/protected/unverified/ambiguous/refused_bulk/no_match)
   // Carry pending (verified-isolated, A/B-incomplete) wins WITH their inputs so a
   // resumed phase run can finish their A/B instead of re-discovering them.
   pending_integrations: pendingIntegrations,

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -306,7 +306,8 @@ Return JSON:
      "roofline_confidence": "<low|medium|high|'' if none>",
      "byte_reduction_levers": ["only when headroom_class=saturated; see step 1d"]}
   ],
-  "drop_list": [{"short_name": "...", "why": "below Amdahl threshold"}],
+  "drop_list": [{"id": "<the SAME id you gave this candidate above, if you listed it there; else ''>",
+                 "short_name": "...", "pct_gpu_time": 0.0, "why": "below Amdahl threshold"}],
   "order_of_work": ["config fast path first", "then h0 (GEMM #1)", "then k0", "..."],
   "strategy_path": "<EVAL_DIR>/strategy.md"
 }

--- a/e2e_workflow/scripts/test_drop_gate.js
+++ b/e2e_workflow/scripts/test_drop_gate.js
@@ -1,19 +1,25 @@
 #!/usr/bin/env node
 // Regression guard for normalizeQueues + the `drop_gate` relevance gate (no GPU, no model needed).
 //
-// Invariants under test:
-//   (a) drop_gate=off leaves the queues exactly as the Architect returned them (feature is inert),
-//   (b) drop_gate=dryrun records what it WOULD drop and drops nothing,
-//   (c) drop_gate=on drops, but NEVER a candidate at or above HEAD_PROTECT_PCT, in any mode,
-//   (d) matching is strict: an id we invented ourselves can never satisfy a drop_list entry, and a
-//       drop_list entry that matches nothing is recorded rather than silently ignored,
-//   (e) the op-identity guard runs inside normalizeQueues, so it survives a re-strategize,
-//   (f) inputs are deep-copied — the Architect's own candidate objects are never mutated,
-//   (g) every queue-assignment site routes through normalizeQueues,
-//   (h) no schema gained a `required` entry (obj() emits additionalProperties:true and nothing validates
+// The gate is ON by default, so these are the checks that make that safe. A drop must clear ALL of:
+// exactly one match, a KNOWN size, a size under HEAD_PROTECT_PCT, and a list that is not eating the
+// queue. Invariants under test:
+//   (a) drop_gate=off leaves the queues exactly as the Architect returned them (kill switch works),
+//   (b) drop_gate defaults to 'on' — merging this changes behaviour, which is the point,
+//   (c) a candidate at or above HEAD_PROTECT_PCT is never dropped,
+//   (d) matching is strict: an id we invented ourselves can never satisfy a drop_list entry; an entry
+//       that carries an id matches on that id ALONE (no silent fallback to the name); an entry that
+//       matches two candidates is refused rather than guessed at; and a no-match is recorded loudly,
+//   (e) a candidate whose pct_gpu_time is missing/blank/NaN is NOT dropped — "too small to matter" is
+//       unprovable without a size, and Number(undefined)||0 would have read it as 0%,
+//   (f) a drop_list resolving to more than DROP_MAX_FRACTION of the queue is refused WHOLE,
+//   (g) the op-identity guard runs inside normalizeQueues, so it survives a re-strategize,
+//   (h) inputs are deep-copied — the Architect's own candidate objects are never mutated,
+//   (i) every queue-assignment site routes through normalizeQueues,
+//   (j) no schema gained a `required` entry (obj() emits additionalProperties:true and nothing validates
 //       locally, so a `required` entry would change LLM generation on every run regardless of the flag).
 //
-// We prove (a)-(f) behaviorally by extracting the ACTUAL normalizeQueues block from the workflow script
+// We prove (a)-(h) behaviorally by extracting the ACTUAL normalizeQueues block from the workflow script
 // and running it with controlled module-scope deps.
 //
 // Run:  node e2e_workflow/scripts/test_drop_gate.js
@@ -36,12 +42,19 @@ const src = fs.readFileSync(FILE, 'utf8');
 const m = src.match(/const dropDecisions = \(ST\.drop_decisions[\s\S]*?\n\}\n(?=\nasync function ensureFlydslGate)/);
 ok(!!m, 'normalizeQueues block found');
 
+// ---- (b) the shipped default is `on` --------------------------------------------------------------
+// A gate that defaults to inert changes nothing on merge. This pins the default so it cannot drift back.
+ok(/A\.drop_gate != null \? A\.drop_gate : 'on'/.test(src), "drop_gate defaults to 'on'");
+ok(!/dryrun/i.test(src), "'dryrun' is gone — the only two settings are 'on' and 'off'");
+ok(/const DROP_MAX_FRACTION = 0\.5;/.test(src), 'the bulk-drop circuit breaker exists and is 50%');
+
 if (m) {
-  const make = (dropGate, protectPct, st) => {
+  const make = (dropGate, protectPct, st, maxFraction) => {
     const lines = [];
-    const fn = new Function('ST', 'DROP_GATE', 'HEAD_PROTECT_PCT', 'log',
+    const fn = new Function('ST', 'DROP_GATE', 'HEAD_PROTECT_PCT', 'DROP_MAX_FRACTION', 'log',
       m[0] + '\nreturn { normalizeQueues, dropDecisions };');
-    const api = fn(st || {}, dropGate, protectPct, (s) => lines.push(String(s)));
+    const api = fn(st || {}, dropGate, protectPct,
+      maxFraction == null ? 0.5 : maxFraction, (s) => lines.push(String(s)));
     return { ...api, lines };
   };
 
@@ -77,16 +90,7 @@ if (m) {
     eq({ head: inp.head, kernel: inp.kernel }, before, 'OFF: the Architect\'s own objects are untouched');
   }
 
-  // ---- (b) DRY RUN records but does not drop ----------------------------------------------------
-  {
-    const { normalizeQueues, dropDecisions } = make('dryrun', 30);
-    const out = normalizeQueues(architect());
-    ok(out.head.length === 4 && out.kernel.length === 2, 'DRYRUN: every candidate survives');
-    const outcomes = dropDecisions.map((d) => d.outcome).sort();
-    eq(outcomes, ['would_drop', 'would_drop'], 'DRYRUN: both matches recorded as would_drop');
-  }
-
-  // ---- (c) ON drops, and protection wins in every mode ------------------------------------------
+  // ---- (c) ON drops, and the dominant head is refused -------------------------------------------
   {
     const { normalizeQueues, dropDecisions } = make('on', 30);
     const out = normalizeQueues(architect());
@@ -96,16 +100,14 @@ if (m) {
     ok(dropDecisions.filter((d) => d.outcome === 'dropped').length === 2, 'ON: two drops recorded');
   }
   {
-    // The dominant head is on the drop list: refused in EVERY mode.
-    for (const mode of ['dryrun', 'on']) {
-      const { normalizeQueues, dropDecisions } = make(mode, 30);
-      const inp = architect();
-      inp.dropList = [{ id: 'h0', short_name: 'fp8_gemm', why: 'architect changed its mind' }];
-      const out = normalizeQueues(inp);
-      ok(out.head.some((c) => c.id === 'h0'), `${mode}: 57%-GPU head is NOT dropped`);
-      ok(dropDecisions.length === 1 && dropDecisions[0].outcome === 'protected',
-        `${mode}: the refusal is recorded as 'protected'`);
-    }
+    // The dominant head is on the drop list. This is the check that makes ON-by-default defensible.
+    const { normalizeQueues, dropDecisions } = make('on', 30);
+    const inp = architect();
+    inp.dropList = [{ id: 'h0', short_name: 'fp8_gemm', why: 'architect changed its mind' }];
+    const out = normalizeQueues(inp);
+    ok(out.head.some((c) => c.id === 'h0'), 'ON: the 57%-GPU head is NOT dropped');
+    ok(dropDecisions.length === 1 && dropDecisions[0].outcome === 'protected',
+      "ON: the refusal is recorded as 'protected'");
   }
 
   // ---- (d) strict matching ----------------------------------------------------------------------
@@ -120,6 +122,29 @@ if (m) {
     ok(lines.some((l) => /NO MATCH/.test(l)), 'the miss is logged loudly, not swallowed');
   }
   {
+    // An entry that CARRIES an id is matched on that id alone. A stale id must not quietly fall
+    // through to the short_name and take out a candidate the Architect did not name.
+    const { normalizeQueues, dropDecisions } = make('on', 30);
+    const inp = architect();
+    inp.dropList = [{ id: 'h47', short_name: 'rmsnorm', why: 'stale id, real name' }];
+    const out = normalizeQueues(inp);
+    ok(out.head.some((c) => c.id === 'h2'),
+      'an entry with an id does NOT fall back to short_name when the id misses');
+    ok(dropDecisions[0].outcome === 'no_match', 'the stale-id entry is recorded as a miss');
+  }
+  {
+    // Two candidates answer to the same name: refuse rather than guess.
+    const { normalizeQueues, dropDecisions, lines } = make('on', 30);
+    const inp = architect();
+    inp.kernel.push({ id: 'k2', short_name: 'rmsnorm', classification: 'norm', pct_gpu_time: 0.4 });
+    inp.dropList = [{ short_name: 'rmsnorm', why: 'which one?' }];
+    const out = normalizeQueues(inp);
+    ok(out.head.some((c) => c.id === 'h2') && out.kernel.some((c) => c.id === 'k2'),
+      'an ambiguous entry drops NEITHER candidate');
+    ok(dropDecisions[0].outcome === 'ambiguous', "the ambiguity is recorded as 'ambiguous'");
+    ok(lines.some((l) => /AMBIGUOUS/.test(l)), 'the ambiguity is logged');
+  }
+  {
     // Seam match, ignoring the advisory signature.
     const { normalizeQueues } = make('on', 30);
     const inp = architect();
@@ -129,7 +154,71 @@ if (m) {
     ok(!out.head.some((c) => c.id === 'h1'), 'seam match ignores the signature after "("');
   }
 
-  // ---- (e) op-identity guard runs here ----------------------------------------------------------
+  // ---- (e) an unknown size is never dropped -----------------------------------------------------
+  // `Number(c.pct_gpu_time) || 0` would read a missing field as 0% — i.e. as the most droppable value
+  // possible. A candidate we cannot size is a candidate we cannot justify dropping.
+  {
+    for (const bad of [undefined, null, '', 'n/a', NaN]) {
+      const { normalizeQueues, dropDecisions } = make('on', 30);
+      const inp = architect();
+      inp.head = [{ id: 'h0', short_name: 'mystery', op_kind: 'gemm', pct_gpu_time: bad }];
+      inp.kernel = [{ id: 'k0', short_name: 'filler', pct_gpu_time: 1.0 },
+                    { id: 'k1', short_name: 'filler2', pct_gpu_time: 1.0 }];
+      inp.dropList = [{ id: 'h0', why: 'looks small to me' }];
+      const out = normalizeQueues(inp);
+      ok(out.head.length === 1, `pct_gpu_time=${JSON.stringify(bad)}: not dropped (size unknown)`);
+      ok(dropDecisions[0].outcome === 'unverified', `pct_gpu_time=${JSON.stringify(bad)}: recorded as unverified`);
+    }
+  }
+  {
+    // An explicit 0 is a statement, not a gap: it means "measured, negligible". That one IS droppable.
+    const { normalizeQueues, dropDecisions } = make('on', 30);
+    const inp = architect();
+    inp.head = [{ id: 'h0', short_name: 'genuinely_tiny', pct_gpu_time: 0 }];
+    inp.kernel = [{ id: 'k0', short_name: 'filler', pct_gpu_time: 1.0 },
+                  { id: 'k1', short_name: 'filler2', pct_gpu_time: 1.0 }];
+    inp.dropList = [{ id: 'h0', why: 'measured at 0.0%' }];
+    const out = normalizeQueues(inp);
+    ok(out.head.length === 0, 'an explicit pct_gpu_time of 0 IS droppable');
+    ok(dropDecisions[0].outcome === 'dropped', 'and is recorded as a real drop');
+  }
+  {
+    // The entry may carry the size even when the candidate does not.
+    const { normalizeQueues } = make('on', 30);
+    const inp = architect();
+    inp.head = [{ id: 'h0', short_name: 'sizeless' }];
+    inp.kernel = [{ id: 'k0', short_name: 'filler', pct_gpu_time: 1.0 },
+                  { id: 'k1', short_name: 'filler2', pct_gpu_time: 1.0 }];
+    inp.dropList = [{ id: 'h0', pct_gpu_time: 0.7, why: 'sized by the drop entry' }];
+    ok(normalizeQueues(inp).head.length === 0,
+      "the drop entry's own pct_gpu_time is accepted when the candidate has none");
+  }
+
+  // ---- (f) a drop_list that eats the queue is refused WHOLE --------------------------------------
+  {
+    const { normalizeQueues, dropDecisions, lines } = make('on', 30);
+    const inp = architect();                       // 4 heads + 2 kernels = 6, cap = floor(6*0.5) = 3
+    inp.dropList = [
+      { id: 'h1', why: 'no' }, { id: 'h2', why: 'no' },
+      { short_name: 'silu_mul', why: 'no' }, { short_name: 'rope', why: 'no' },
+    ];
+    const out = normalizeQueues(inp);
+    ok(out.head.length === 4 && out.kernel.length === 2,
+      '4 drops out of 6 candidates exceeds the 50% cap -> nothing is dropped');
+    ok(dropDecisions.every((d) => d.outcome === 'refused_bulk'),
+      "every entry is recorded as 'refused_bulk', not silently half-applied");
+    ok(lines.some((l) => /REFUSING THE WHOLE drop_list/.test(l)), 'the bulk refusal is logged');
+  }
+  {
+    // Exactly at the cap is allowed; the breaker is for runaway lists, not ordinary pruning.
+    const { normalizeQueues } = make('on', 30);
+    const inp = architect();
+    inp.dropList = [{ id: 'h1', why: 'ok' }, { id: 'h2', why: 'ok' }, { short_name: 'silu_mul', why: 'ok' }];
+    const out = normalizeQueues(inp);
+    ok(out.head.length + out.kernel.length === 3, 'a list exactly at the cap (3 of 6) still applies');
+  }
+
+  // ---- (g) op-identity guard runs here ----------------------------------------------------------
   {
     const { normalizeQueues } = make('off', 30);
     const out = normalizeQueues(architect());
@@ -150,7 +239,7 @@ if (m) {
     eq(twice, once, 'normalizeQueues is idempotent (safe at the re-strategize and resume sites)');
   }
 
-  // ---- (f) short_name is never invented ----------------------------------------------------------
+  // ---- (h) short_name is never invented; an invented id is marked ----------------------------------
   {
     const { normalizeQueues } = make('off', 30);
     const out = normalizeQueues({ head: [{ op_kind: 'gemm', pct_gpu_time: 3 }], kernel: [], dropList: [], origin: 't' });
@@ -160,7 +249,7 @@ if (m) {
   }
 }
 
-// ---- (g) every queue-assignment site routes through normalizeQueues -------------------------------
+// ---- (i) every queue-assignment site routes through normalizeQueues -------------------------------
 // `= normalizeQueues({`, so the function's own declaration is not counted as a call.
 const callSites = (src.match(/= normalizeQueues\(\{/g) || []).length;
 ok(callSites === 3, `all three queue-assignment sites call normalizeQueues (found ${callSites})`);
@@ -170,7 +259,7 @@ for (const origin of ['strategize', 'carried-state', 're-strategize']) {
 ok(!/(kernelQueue|headQueue) = \(?(strategy|restrat|ST)\b/.test(src),
   'no queue-assignment site bypasses normalizeQueues');
 
-// ---- (h) no schema gained a `required` entry ------------------------------------------------------
+// ---- (j) no schema gained a `required` entry ------------------------------------------------------
 // obj() emits additionalProperties:true and nothing validates locally, so `required` only shapes LLM
 // generation — it would fire on every run regardless of drop_gate, breaking "off behaves like today".
 ok(/drop_list: arrObj[\s\S]{0,200}?\}, \['kernel_candidates'\]\);/.test(src),
@@ -183,6 +272,6 @@ ok(/"drop_list": \[\{"id":/.test(arch), 'roles/system_architect.md asks for an i
 ok(/drop_list[\s\S]{0,300}pct_gpu_time/.test(arch), 'roles/system_architect.md asks for pct_gpu_time on each drop_list entry');
 
 console.log(failures === 0
-  ? '\nPASS: drop_gate is inert when off, auditable when on, and never drops a dominant head.'
+  ? '\nPASS: drop_gate is on by default and refuses any drop it cannot fully justify; off is inert.'
   : `\nFAILED: ${failures} assertion(s).`);
 process.exit(failures === 0 ? 0 : 1);

--- a/e2e_workflow/scripts/test_drop_gate.js
+++ b/e2e_workflow/scripts/test_drop_gate.js
@@ -48,13 +48,24 @@ ok(/A\.drop_gate != null \? A\.drop_gate : 'on'/.test(src), "drop_gate defaults 
 ok(!/dryrun/i.test(src), "'dryrun' is gone — the only two settings are 'on' and 'off'");
 ok(/const DROP_MAX_FRACTION = 0\.5;/.test(src), 'the bulk-drop circuit breaker exists and is 50%');
 
-if (m) {
+// normalizeQueues delegates its op-identity step to applyOpIdentityGuard, which lives at module scope
+// and is main's, not ours. Extract that block too rather than re-implementing the fused rule here: a
+// hand-written double would be free to drift from the rule the orchestrator actually applies, which is
+// exactly what invariant (g) is supposed to catch.
+const g = src.match(/const _isFusedOp = [\s\S]*?\nfunction applyOpIdentityGuard\(queue, stage\) \{[\s\S]*?\n\}\n/);
+ok(!!g, 'applyOpIdentityGuard block found (normalizeQueues delegates the fused rule to it)');
+
+if (m && g) {
   const make = (dropGate, protectPct, st, maxFraction) => {
     const lines = [];
-    const fn = new Function('ST', 'DROP_GATE', 'HEAD_PROTECT_PCT', 'DROP_MAX_FRACTION', 'log',
-      m[0] + '\nreturn { normalizeQueues, dropDecisions };');
+    // admitHeads is injected as identity on purpose. It is main's SEPARATE gate — it requires
+    // entity_kind='gpu_kernel' plus a device-kernel identity, neither of which these Architect-shaped
+    // fixtures carry, so the real one would reject all four heads and leave nothing for the drop
+    // filter to act on. Admission is out of scope here; the drop gate is what is under test.
+    const fn = new Function('ST', 'DROP_GATE', 'HEAD_PROTECT_PCT', 'DROP_MAX_FRACTION', 'log', 'admitHeads',
+      g[0] + m[0] + '\nreturn { normalizeQueues, dropDecisions };');
     const api = fn(st || {}, dropGate, protectPct,
-      maxFraction == null ? 0.5 : maxFraction, (s) => lines.push(String(s)));
+      maxFraction == null ? 0.5 : maxFraction, (s) => lines.push(String(s)), (q) => q);
     return { ...api, lines };
   };
 
@@ -252,12 +263,17 @@ if (m) {
 // ---- (i) every queue-assignment site routes through normalizeQueues -------------------------------
 // `= normalizeQueues({`, so the function's own declaration is not counted as a call.
 const callSites = (src.match(/= normalizeQueues\(\{/g) || []).length;
-ok(callSites === 3, `all three queue-assignment sites call normalizeQueues (found ${callSites})`);
-for (const origin of ['strategize', 'carried-state', 're-strategize']) {
+ok(callSites === 4, `all four queue-assignment sites call normalizeQueues (found ${callSites})`);
+for (const origin of ['strategize', 'carried-state', 're-strategize', 'post-tuning re-strategize']) {
   ok(src.includes(`origin: '${origin}'`), `call site tagged origin='${origin}'`);
 }
-ok(!/(kernelQueue|headQueue) = \(?(strategy|restrat|ST)\b/.test(src),
+ok(!/(kernelQueue|headQueue) = \(?(strategy|restrat|retune|ST)\b/.test(src),
   'no queue-assignment site bypasses normalizeQueues');
+// The post-tuning site used to assign the queues separately — the guard on the heads, a bare .slice()
+// on the kernels. Pin that it cannot come back: a .slice() there is both a bypassed drop gate and the
+// shallow copy of bug 6.
+ok(!/(headQueue|kernelQueue) = .*\.slice\(\)/.test(src),
+  'no queue is assigned from a shallow .slice() of an Architect response');
 
 // ---- (j) no schema gained a `required` entry ------------------------------------------------------
 // obj() emits additionalProperties:true and nothing validates locally, so `required` only shapes LLM

--- a/e2e_workflow/scripts/test_drop_gate.js
+++ b/e2e_workflow/scripts/test_drop_gate.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Regression guard for normalizeQueues + the `drop_gate` relevance gate (no GPU, no model needed).
+//
+// Invariants under test:
+//   (a) drop_gate=off leaves the queues exactly as the Architect returned them (feature is inert),
+//   (b) drop_gate=dryrun records what it WOULD drop and drops nothing,
+//   (c) drop_gate=on drops, but NEVER a candidate at or above HEAD_PROTECT_PCT, in any mode,
+//   (d) matching is strict: an id we invented ourselves can never satisfy a drop_list entry, and a
+//       drop_list entry that matches nothing is recorded rather than silently ignored,
+//   (e) the op-identity guard runs inside normalizeQueues, so it survives a re-strategize,
+//   (f) inputs are deep-copied — the Architect's own candidate objects are never mutated,
+//   (g) every queue-assignment site routes through normalizeQueues,
+//   (h) no schema gained a `required` entry (obj() emits additionalProperties:true and nothing validates
+//       locally, so a `required` entry would change LLM generation on every run regardless of the flag).
+//
+// We prove (a)-(f) behaviorally by extracting the ACTUAL normalizeQueues block from the workflow script
+// and running it with controlled module-scope deps.
+//
+// Run:  node e2e_workflow/scripts/test_drop_gate.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const ROOT = path.resolve(__dirname, '..', '..');            // .../GEAK
+const FILE = path.join(ROOT, 'e2e_workflow', 'e2e_workflow.js');
+
+let failures = 0;
+const ok = (cond, msg) => { if (!cond) { console.error('  FAIL:', msg); failures++; } else console.log('  ok:', msg); };
+const eq = (a, b, msg) => { try { assert.deepStrictEqual(a, b); ok(true, msg); } catch (e) { ok(false, `${msg} -> ${e.message.split('\n')[0]}`); } };
+
+console.log(`\n# ${path.relative(ROOT, FILE)}`);
+const src = fs.readFileSync(FILE, 'utf8');
+
+// Extract the real block: from `const dropDecisions` through the close of normalizeQueues.
+const m = src.match(/const dropDecisions = \(ST\.drop_decisions[\s\S]*?\n\}\n(?=\nasync function ensureFlydslGate)/);
+ok(!!m, 'normalizeQueues block found');
+
+if (m) {
+  const make = (dropGate, protectPct, st) => {
+    const lines = [];
+    const fn = new Function('ST', 'DROP_GATE', 'HEAD_PROTECT_PCT', 'log',
+      m[0] + '\nreturn { normalizeQueues, dropDecisions };');
+    const api = fn(st || {}, dropGate, protectPct, (s) => lines.push(String(s)));
+    return { ...api, lines };
+  };
+
+  // A queue the Architect might plausibly return.
+  const architect = () => ({
+    head: [
+      { id: 'h0', short_name: 'fp8_gemm', op_kind: 'gemm', pct_gpu_time: 57.0,
+        live_call_seam: 'sglang.srt.layers.quantization.fp8:Fp8LinearMethod.apply(x,w,bias)' },
+      { id: 'h1', short_name: 'moe_gemm', op_kind: 'gemm', pct_gpu_time: 8.0, is_fused_kernel: true,
+        live_call_seam: 'aiter.fused_moe_bf16_asm:asm_moe_tkw1(h,w1,w2,tw,ti)' },
+      { id: 'h2', short_name: 'rmsnorm', op_kind: 'norm', pct_gpu_time: 2.0 },
+      { short_name: 'nameless_head', op_kind: 'attn', pct_gpu_time: 1.5 },   // Architect omitted the id
+    ],
+    kernel: [
+      { id: 'k0', short_name: 'silu_mul', classification: 'elementwise', pct_gpu_time: 1.2 },
+      { id: 'k1', short_name: 'rope', classification: 'elementwise', pct_gpu_time: 0.9 },
+    ],
+    dropList: [
+      { id: 'h2', short_name: 'rmsnorm', pct_gpu_time: 2.0, why: 'below Amdahl threshold' },
+      { short_name: 'silu_mul', why: 'too small to move e2e' },
+    ],
+    origin: 'strategize',
+  });
+
+  // ---- (a) OFF is inert -------------------------------------------------------------------------
+  {
+    const { normalizeQueues, dropDecisions } = make('off', 30);
+    const inp = architect();
+    const before = JSON.parse(JSON.stringify({ head: inp.head, kernel: inp.kernel }));
+    const out = normalizeQueues(inp);
+    ok(out.head.length === 4 && out.kernel.length === 2, 'OFF: every candidate survives');
+    ok(dropDecisions.length === 0, 'OFF: no drop decisions recorded');
+    eq({ head: inp.head, kernel: inp.kernel }, before, 'OFF: the Architect\'s own objects are untouched');
+  }
+
+  // ---- (b) DRY RUN records but does not drop ----------------------------------------------------
+  {
+    const { normalizeQueues, dropDecisions } = make('dryrun', 30);
+    const out = normalizeQueues(architect());
+    ok(out.head.length === 4 && out.kernel.length === 2, 'DRYRUN: every candidate survives');
+    const outcomes = dropDecisions.map((d) => d.outcome).sort();
+    eq(outcomes, ['would_drop', 'would_drop'], 'DRYRUN: both matches recorded as would_drop');
+  }
+
+  // ---- (c) ON drops, and protection wins in every mode ------------------------------------------
+  {
+    const { normalizeQueues, dropDecisions } = make('on', 30);
+    const out = normalizeQueues(architect());
+    eq(out.head.map((c) => c.id), ['h0', 'h1', 'h3'],
+      'ON: h2 dropped, the id-less head keeps its invented id');
+    ok(out.kernel.map((c) => c.id).join(',') === 'k1', 'ON: silu_mul dropped by short_name');
+    ok(dropDecisions.filter((d) => d.outcome === 'dropped').length === 2, 'ON: two drops recorded');
+  }
+  {
+    // The dominant head is on the drop list: refused in EVERY mode.
+    for (const mode of ['dryrun', 'on']) {
+      const { normalizeQueues, dropDecisions } = make(mode, 30);
+      const inp = architect();
+      inp.dropList = [{ id: 'h0', short_name: 'fp8_gemm', why: 'architect changed its mind' }];
+      const out = normalizeQueues(inp);
+      ok(out.head.some((c) => c.id === 'h0'), `${mode}: 57%-GPU head is NOT dropped`);
+      ok(dropDecisions.length === 1 && dropDecisions[0].outcome === 'protected',
+        `${mode}: the refusal is recorded as 'protected'`);
+    }
+  }
+
+  // ---- (d) strict matching ----------------------------------------------------------------------
+  {
+    // 'h3' is the id WE invented for the nameless head. It must not match.
+    const { normalizeQueues, dropDecisions, lines } = make('on', 30);
+    const inp = architect();
+    inp.dropList = [{ id: 'h3', why: 'referring to an id the Architect never issued' }];
+    const out = normalizeQueues(inp);
+    ok(out.head.length === 4, 'an invented id cannot satisfy a drop_list entry');
+    ok(dropDecisions.length === 1 && dropDecisions[0].outcome === 'no_match', 'the miss is recorded');
+    ok(lines.some((l) => /NO MATCH/.test(l)), 'the miss is logged loudly, not swallowed');
+  }
+  {
+    // Seam match, ignoring the advisory signature.
+    const { normalizeQueues } = make('on', 30);
+    const inp = architect();
+    inp.dropList = [{ live_call_seam: 'aiter.fused_moe_bf16_asm:asm_moe_tkw1(totally, different, args)',
+                      why: 'matched on module:attr, signature ignored' }];
+    const out = normalizeQueues(inp);
+    ok(!out.head.some((c) => c.id === 'h1'), 'seam match ignores the signature after "("');
+  }
+
+  // ---- (e) op-identity guard runs here ----------------------------------------------------------
+  {
+    const { normalizeQueues } = make('off', 30);
+    const out = normalizeQueues(architect());
+    const fused = out.head.find((c) => c.id === 'h1');
+    ok(fused.op_kind === 'moe', 'fused head forced to op_kind=moe');
+    ok(fused.target_callable === 'aiter.fused_moe_bf16_asm:asm_moe_tkw1(h,w1,w2,tw,ti)',
+      'fused head bound to its live call seam');
+    const standalone = out.head.find((c) => c.id === 'h0');
+    ok(standalone.target_callable === 'sglang.srt.layers.quantization.fp8:Fp8LinearMethod.apply(x,w,bias)',
+      'a NON-fused head with a live seam is bound too (used to be fused-only)');
+    ok(standalone.op_kind === 'gemm', 'a non-fused head keeps its op_kind');
+  }
+  {
+    // Idempotent: a re-strategize re-runs this over an already-normalized queue.
+    const { normalizeQueues } = make('off', 30);
+    const once = normalizeQueues(architect());
+    const twice = normalizeQueues({ head: once.head, kernel: once.kernel, dropList: [], origin: 're-strategize' });
+    eq(twice, once, 'normalizeQueues is idempotent (safe at the re-strategize and resume sites)');
+  }
+
+  // ---- (f) short_name is never invented ----------------------------------------------------------
+  {
+    const { normalizeQueues } = make('off', 30);
+    const out = normalizeQueues({ head: [{ op_kind: 'gemm', pct_gpu_time: 3 }], kernel: [], dropList: [], origin: 't' });
+    ok(out.head[0].short_name === undefined,
+      'short_name is left alone — the head/milestone tracks name their own kernels downstream');
+    ok(out.head[0].id === 'h0' && out.head[0].id_synthesized === true, 'an invented id is marked as invented');
+  }
+}
+
+// ---- (g) every queue-assignment site routes through normalizeQueues -------------------------------
+// `= normalizeQueues({`, so the function's own declaration is not counted as a call.
+const callSites = (src.match(/= normalizeQueues\(\{/g) || []).length;
+ok(callSites === 3, `all three queue-assignment sites call normalizeQueues (found ${callSites})`);
+for (const origin of ['strategize', 'carried-state', 're-strategize']) {
+  ok(src.includes(`origin: '${origin}'`), `call site tagged origin='${origin}'`);
+}
+ok(!/(kernelQueue|headQueue) = \(?(strategy|restrat|ST)\b/.test(src),
+  'no queue-assignment site bypasses normalizeQueues');
+
+// ---- (h) no schema gained a `required` entry ------------------------------------------------------
+// obj() emits additionalProperties:true and nothing validates locally, so `required` only shapes LLM
+// generation — it would fire on every run regardless of drop_gate, breaking "off behaves like today".
+ok(/drop_list: arrObj[\s\S]{0,200}?\}, \['kernel_candidates'\]\);/.test(src),
+  "STRATEGY_SCHEMA still requires only ['kernel_candidates']");
+ok(!/drop_list: obj\(/.test(src), 'drop_list is still the permissive arrObj (no new required fields)');
+
+// The Architect must be ASKED for the matching keys (properties/prompt only, never `required`).
+const arch = fs.readFileSync(path.join(ROOT, 'e2e_workflow', 'roles', 'system_architect.md'), 'utf8');
+ok(/"drop_list": \[\{"id":/.test(arch), 'roles/system_architect.md asks for an id on each drop_list entry');
+ok(/drop_list[\s\S]{0,300}pct_gpu_time/.test(arch), 'roles/system_architect.md asks for pct_gpu_time on each drop_list entry');
+
+console.log(failures === 0
+  ? '\nPASS: drop_gate is inert when off, auditable when on, and never drops a dominant head.'
+  : `\nFAILED: ${failures} assertion(s).`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## The problem

When GEAK starts a run, one of its agents — the **System Architect** — reads the GPU profile and
decides what to work on. It produces two things:

1. a **work list**: the kernels worth optimizing, and
2. a **drop list**: kernels it looked at and rejected, each with a reason
   (`"below Amdahl threshold"`, `"too small to move e2e"`, and so on).

GEAK has always acted on the first list and **thrown the second one away**. Nothing reads
it — not the orchestrator, not a log line, not a report, not another
agent's prompt, not the saved state that survives a resume.

So the planner identifies the wasted work, says so out loud, and then the run goes and does it
anyway. In the 15-hour Qwen3-14B-FP8 baseline the string `drop_list` appears **zero times** in the
entire run tree. It was written and immediately discarded.

## What this PR changes

GEAK now reads that list.

Concretely: there are three points in a run where the work list gets set — when the Architect first
plans, when a run resumes from saved state, and again after the config sweep, when the Architect
re-plans with fresh information. Each of those three places used to just take the agent's output
as-is.

This PR puts a single shared cleanup step in front of all three, a function `normalizeQueues`.
The cleanup step does three things, in this order:

### First, make sure every kernel can be referred to

A drop entry says "skip *this* one", which only works if both lists agree on which one. The
Architect returns each candidate as a free-form JSON object and the schema requires no fields at
all, so a candidate can arrive as just `{"short_name": "rmsnorm", "pct_gpu_time": 2.0}` — with no
identifier. For those we fill in a positional stand-in (`h0`, `h1`, `k0`, …) so every candidate has
a handle for the rest of the run.

We also record that we invented it. An id GEAK assigned is not something the Architect could
ever have written down, so a drop entry naming `h3` must never match a candidate whose `h3` we
made up.

### Second, re-apply the fused-kernel protection

A Mixture-of-Experts layer routes each token to a few of many small expert matrices. A *fused* MoE
kernel does all of that in one GPU launch. GEAK has a rule that one of those must never be treated
as an ordinary dense matrix multiply. In code the rule does two things: it tags the candidate as
`moe`, which stops GEAK generating a dense matrix-multiply benchmark for it, and it holds onto the
Python function where the fused kernel is actually called, which is the only place a replacement
can be installed. A dense matrix multiply has no such call site — so a fused kernel mistaken for a
dense one ends the run with a result that cannot be installed anywhere.

**Why it needs to survive a re-plan.** Of the three points where the work list is set, this rule
used to run at only the first. After the config sweep the Architect re-plans, and the code
*replaced* the whole work list with brand-new candidate objects that had never been through the
rule — tag gone, call site gone, nothing to re-apply them. Moving the rule into the shared step
means all three points get it: first plan, resume, and re-plan. That is bug 1 below.

### Third, apply the drop list

Match each rejected entry against the work list and remove it — but only when the match is
unambiguous and the drop is justified, which is the next section. If the entry carries the
Architect's own identifier we match on that and nothing else. If it does not, we fall back to the
kernel's short name, or to the Python function GEAK would have to swap out to replace it (written
as `module:function`) — whichever the agent gave us.

## The `drop_gate` setting

**The default is `on`. Merging this changes what runs do.**

| setting | what happens |
|---|---|
| `on` | Kernels the Architect rejected are removed from the work list, provided the drop passes all four checks below. **Default.** |
| `off` | The drop list is ignored entirely. |

The first two steps above — filling in identifiers and the fused-kernel protection — run in
**both** settings. They are bug fixes, not part of the gate.

### What makes `on` safe as a default

A drop is **refused** unless all four of these hold. Every refusal is logged with the Architect's
own stated reason, saved into the state that survives a resume, and counted in a one-line summary
at the end of the run.

1. **Exactly one match.** If the entry carries an identifier, it is matched on that identifier
   alone — no falling back to the name. Otherwise a stale or hallucinated identifier would miss,
   then quietly land on some *other* kernel by name. An entry that matches two kernels is refused
   rather than guessed at; a drop is not reversible.

2. **A known size.** The entire argument for a drop is "too small to be worth the time", so a
   kernel whose GPU-time share we cannot read is one we cannot justify dropping. This is worth
   spelling out because the obvious code is wrong here: `Number(x) || 0` turns a missing field into
   `0%` — the single most droppable value there is — and would walk straight past check 3. Missing,
   blank or unparseable is refused. An explicit `0` is a real measurement and is allowed.

3. **Under 30% of GPU time** (`HEAD_PROTECT_PCT`). The dominant kernel in the profile is never
   dropped on an agent's say-so.

4. **The list is not eating the queue.** A drop list resolving to more than half the work list
   (`DROP_MAX_FRACTION`) is refused *whole* — not half-applied in arbitrary order. At that size the
   useful signal is "the plan is wrong", not "here are some kernels".

A drop entry that **matches nothing** is logged loudly and recorded too. A silent no-match looks
exactly like a filter that is working.

## Three bugs fixed along the way

These are independent of the setting above and are fixed in both settings.

1. **A re-plan silently dropped the fused-kernel protection.** The rule that keeps a fused
   Mixture-of-Experts kernel intact ran only after the first plan. The config sweep's re-plan
   replaced the work list with fresh, untagged candidates and the rule never ran again. Its own
   comment in the source says a fused kernel "is never SKIPPED" — after a re-plan, it could be.

2. **Only fused kernels got wired to their call site.** The same loop that applied the fused rule
   was also the only place that recorded *which Python function to swap out* for a kernel, and it
   skipped everything that was not fused. Now every candidate that has one gets it.

3. **The work list was copied shallowly.** `.slice()` copies the array but not the objects inside
   it, so later steps were writing into the Architect's own returned objects, and those edits were
   being saved into the state that survives a resume. The shared step now takes a deep copy.

## Tests

`e2e_workflow/scripts/test_drop_gate.js` pulls the real cleanup function out of the orchestrator
source and runs it against a synthetic work list. 54 assertions, covering:

- `off` is inert, and `on` is the shipped default;
- a 57%-of-GPU-time kernel on the drop list is refused;
- a kernel with a missing, blank or unparseable GPU-time share is refused, while an explicit `0`
  is allowed through;
- an entry that carries an identifier does not fall back to the name when that identifier misses;
- an identifier GEAK invented cannot satisfy a drop entry;
- an entry matching two kernels drops neither;
- a drop list covering 4 of 6 candidates is refused whole, while one covering exactly 3 of 6 applies;
- matching on the call site ignores the argument list;
- the agent's own objects are not mutated, and running the step twice gives the same answer
  (which a resume or a re-plan does);
- all three work-list assignments go through the shared step.

🤖 Generated with [Claude Code](https://claude.com/claude-code) and edited manually.

