### PR TITLE
fix(op_bench): route MoE heads to the GEMM family, not the attention bench

### DIFF
--- a/e2e_workflow/scripts/op_bench.py
+++ b/e2e_workflow/scripts/op_bench.py
@@ -10,7 +10,7 @@ plus any tuning artifact. It does NOT touch a server or measure e2e — that is 
 
 Task-dir contract (written by the Kernel Extractor PHASE=extract_op):
   <op>_task/
-    meta.json         # op_kind=gemm|attn, dtype, a_shape/b_shape/transpose_b/bias (gemm) OR captured
+    meta.json         # op_kind=attn (server-level bake-off) | gemm|moe|... (GEMM family), dtype, a_shape/b_shape/transpose_b/bias (gemm) OR captured
                       # tensor spec (attn), math_contract, reference_io_sha256, regime
     reference_io.pt   # OPTIONAL golden {inputs..., output} oracle. If absent for GEMM, this script
                       # synthesizes inputs from meta shapes+dtype and computes the oracle with the
@@ -189,7 +189,11 @@ def _is_blockscale_gemm(meta):
     qs = str(meta.get("quant_scheme", "")).lower()
     is_fp8 = ("fp8" in dt or "e4m3" in dt or "e5m2" in dt)
     has_block = bool(meta.get("weight_block_size")) or "block" in qs
-    return is_fp8 and has_block
+    # A grouped MXFP8 MoE is block-scaled AND grouped. It is not a *dense* block-scaled GEMM, and
+    # only the dense reading has a synth: `_synth_blockscale_case` builds a [N,K] weight out of
+    # `meta["b_shape"]`, which a grouped op does not carry (it describes per-expert `families`).
+    # Claiming it here sent it down that path and raised KeyError('b_shape').
+    return is_fp8 and has_block and not _is_grouped_or_quant_gemm(meta)
 
 
 def _is_grouped_or_quant_gemm(meta):
@@ -202,6 +206,14 @@ def _is_grouped_or_quant_gemm(meta):
     kc = str(meta.get("kernel_class", "")).lower()
     dt = str(meta.get("dtype", "")).lower()
     qs = str(meta.get("quant_scheme", "")).lower()
+    # The pipeline states the identity outright: the op-identity guard in e2e_workflow.js sets
+    # op_kind='moe' on every fused/grouped-expert head, and the extractor writes n_experts/top_k
+    # beside it. Keying on kernel_class alone made this function blind to its own subject -- the
+    # campaign's MoE metas carry op_kind='moe' and top_k with no kernel_class at all.
+    if str(meta.get("op_kind", "")).lower() == "moe":
+        return True
+    if meta.get("n_experts") or meta.get("num_experts") or meta.get("top_k"):
+        return True
     if any(t in kc for t in ("moe", "grouped", "experts")):
         return True
     if any(t in dt for t in ("int4", "int8", "uint4", "awq", "gptq", "w4a16", "w8a16")):
@@ -785,7 +797,12 @@ def main():
         _GRAPH_MODE = _hlib.deployment_graph_mode(meta.get("regime"))
 
     try:
-        results = bench_gemm(a, meta) if op_kind == "gemm" else bench_attn(a, meta)
+        # Attention is the one op whose bake-off lives at the server level, so it is the branch
+        # that names itself; every other op_kind is a GEMM-family op and takes bench_gemm, which
+        # classifies grouped/quantized weights out on its own. Testing for "gemm" instead made
+        # THAT the special case and swept the rest into bench_attn, so a grouped-expert GEMM was
+        # told it was missing captured q/k/v -- a diagnosis for an op that has no q/k/v.
+        results = bench_attn(a, meta) if op_kind == "attn" else bench_gemm(a, meta)
     except Exception as e:
         results = [{"backend": "ERROR", "available": False, "correct": False, "ms": None,
                     "note": f"{e!r}", "trace": traceback.format_exc()[-800:]}]

--- a/e2e_workflow/scripts/tests/test_op_bench.py
+++ b/e2e_workflow/scripts/tests/test_op_bench.py
@@ -912,6 +912,31 @@ class TestOpClassification(unittest.TestCase):
     def test_structured_moe_shape_block_is_grouped(self):
         self.assertTrue(ob._is_grouped_or_quant_gemm({"shape": {"E": 8, "N": 2048, "K": 4096}}))
 
+    def test_grouped_is_detected_from_the_op_kind_the_pipeline_writes(self):
+        # e2e_workflow.js's op-identity guard sets op_kind='moe' on every fused/grouped head. The
+        # campaign's two MoE metas carry it with NO kernel_class, so keying on kernel_class alone
+        # classified 59 of 59 logged MoE bake-offs as ungrouped.
+        self.assertTrue(ob._is_grouped_or_quant_gemm({"op_kind": "moe"}))
+        self.assertTrue(ob._is_grouped_or_quant_gemm({"op_kind": "MoE"}))
+
+    def test_grouped_is_detected_from_an_expert_count_or_topk(self):
+        self.assertTrue(ob._is_grouped_or_quant_gemm({"n_experts": 256, "top_k": 6}))
+        self.assertTrue(ob._is_grouped_or_quant_gemm({"num_experts": 128}))
+        self.assertTrue(ob._is_grouped_or_quant_gemm({"top_k": 4}))
+
+    def test_a_grouped_mxfp8_moe_is_not_a_dense_blockscale_gemm(self):
+        # Both true of it: fp8 and block-scaled, AND grouped. Only the grouped reading has a synth
+        # -- `_synth_blockscale_case` reads meta["b_shape"], which a grouped meta does not carry.
+        meta = {"op_kind": "moe", "dtype": "fp8_e4m3fn", "quant_scheme": "mxfp8_blockscale_1x32",
+                "weight_block_size": [1, 32], "top_k": 4}
+        self.assertTrue(ob._is_grouped_or_quant_gemm(meta))
+        self.assertFalse(ob._is_blockscale_gemm(meta))
+
+    def test_a_dense_blockscale_gemm_is_still_blockscale(self):
+        self.assertTrue(ob._is_blockscale_gemm(
+            {"op_kind": "gemm", "dtype": "fp8", "weight_block_size": [128, 128],
+             "b_shape": [34816, 5120]}))
+
     def test_dense_bf16_gemm_is_not_grouped(self):
         self.assertFalse(ob._is_grouped_or_quant_gemm(
             {"dtype": "bf16", "kernel_class": "linear", "b_shape": [2048, 4096],
@@ -1560,6 +1585,34 @@ class TestMainSummary(_ObStateMixin, unittest.TestCase):
         entry = {"backend": backend, "available": ms is not None, "correct": correct, "ms": ms}
         entry.update(kw)
         return entry
+
+    def _which_bench(self, op_kind):
+        """Return the name of the bench function main() actually dispatched to."""
+        d = self._task_dir({"op_kind": op_kind})
+        picked = []
+        ob.bench_gemm = lambda a, m: picked.append("gemm") or []
+        ob.bench_attn = lambda a, m: picked.append("attn") or []
+        old_argv = sys.argv
+        sys.argv = ["op_bench.py", "--task", d, "--out", os.path.join(d, "r.json")]
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                ob.main()
+        finally:
+            sys.argv = old_argv
+        return picked[0] if picked else None
+
+    def test_only_attention_takes_the_attention_bench(self):
+        # A grouped-expert GEMM has no q/k/v, so routing it to bench_attn produced a diagnosis it
+        # could never act on ("needs reference_io.pt (captured q/k/v/meta)") on 59 logged MoE
+        # bake-offs. Attention is the special case; the GEMM family is the default.
+        self.assertEqual(self._which_bench("attn"), "attn")
+        self.assertEqual(self._which_bench("gemm"), "gemm")
+        self.assertEqual(self._which_bench("moe"), "gemm")
+
+    def test_an_unknown_op_kind_takes_the_gemm_family_bench(self):
+        # bench_gemm classifies grouped/quantized weights out on its own, so an op_kind nobody has
+        # taught the harness yet gets a GEMM answer or a clean skip -- never an attention answer.
+        self.assertEqual(self._which_bench("fp8_a8w8_blockscale_gemm_bpreshuffle"), "gemm")
 
     def test_default_arguments_reach_the_bench_function(self):
         self._run_main({"op_kind": "gemm"}, results=[])


### PR DESCRIPTION
Closes #419

## The defect

`op_bench.py` dispatched with `op_kind == "gemm" ? bench_gemm : bench_attn`,
making GEMM the special case and sweeping everything else into the attention
bench. `e2e_workflow.js`'s op-identity guard sets `op_kind='moe'` on every
fused/grouped-expert head and calls it *"the grouped-GEMM branch"* — so the two
halves of the pipeline disagreed, and the Python half won.

## A/B over the whole logged corpus

Not a paraphrase of the gate and not injected rows: the changed code **is** the
bench function, so recorded `results` would only replay the old producer. This
drives the **real** `bench_gemm`/`bench_attn` from each task's **real
`meta.json`**, in both versions, over every genuine `op_bench` output in
`/shared_nfs/hyperloom-claw/` (sessions of 5 Aug: 44 rows, and 1 Aug: 15 rows).

**784 bake-offs replayed. 59 change. 725 byte-identical.**

Those 59 records belong to **three distinct MoE heads**, one per model — 56 of
the records are retry copies written under `kernels/_exp/` by the author fan-out.
The three heads are the subject; 59 is the number of records on disk that change.
Per head, with the campaign's recorded outcome:

| kernel | model | % GPU time | recorded outcome |
|---|---|---:|---|
| `_matmul_ogs_NNT_bf16xbf16xmxfp4` | DeepSeek-V4-Flash | 15.64% | `winner=None speedup=0.0 kind=none` |
| `_mxfp8_grouped_gemm_kernel` | MiniMax-M3-MXFP8 | 21.00% | `winner=None speedup=0.0 kind=none` |
| `aiter::moe_cktile2stages_gemm2_ck` | gpt-oss-120b | 11.05% | `winner=None speedup=0.0 kind=none` |

| `op_kind` | n | arm | winning row | `isolated_speedup` | `harness_suspect` |
|---|---:|---|---|---|---:|
| `attn` | 451 | before | `current` ×451 | `null` ×451 | 0 |
| | | **after** | `current` ×451 | `null` ×451 | **0** |
| `gemm` | 274 | before | *(identical)* | *(identical)* | *(identical)* |
| | | **after** | *(identical)* | *(identical)* | *(identical)* |
| `moe` | 59 | before | `current` ×59 | `null` ×59 | 0 |
| | | **after** | **`grouped_quant_gemm` ×59** | `null` ×59 | **0** |

The note handed to the agent, which is the whole point:

| arm | n | note |
|---|---:|---|
| before | 44 | `attn bake-off needs reference_io.pt (captured q/k/v/meta); none found` |
| before | 15 | `attention backend comparison is a SERVER-level flag (--attention-backend) -> delegated to the Config Tuner fast path` |
| **after** | **59** | `grouped/quantized MoE GEMM: not a dense torch-BLAS bake-off candidate; requires a Tier-C authored fused-experts grouped GEMM (GEMM1->act->GEMM2 over experts on packed weights)` |

*Replay fidelity.* The control arm runs today's `main` against the real task
directories (symlinked whole, not just `meta.json` — 15 of the 59 tasks carry a
`reference_io.pt` that `bench_attn` branches on). Control reproduces the logged
`backend` on 59/59 and the logged `note` on 44/59; the other 15 differ only in the
wording of the same branch, and `isolated_speedup` reads `null` where the logs say
`0.0`. Both of those are #415, already merged. No other difference remains, so the
control is the recorded behaviour.

*Caveat, stated because it matters:* this box has no `torch`, so the 274 `gemm`
rows raise `AttributeError` on the stand-in in **both** arms. That makes them a
valid null-change proof (control == treatment on every field) but not a proof
the dense path still works — the 162 unit tests cover that.

## What this does and does not show

Stated plainly, because I went looking for a bigger claim and the logs refused it.

**It shows** the diagnosis is wrong and unactionable. A grouped per-expert GEMM
has no q/k/v to capture and no `--attention-backend` to swap, so both notes name
work the agent cannot do. All three heads recorded `winner=None
isolated_speedup=0.0 winner_kind=none`, with `harness_suspect=false` — so nothing
downstream registers a fault — and all three sit under `HEAD_PROTECT_PCT` (30),
so none is protected as a dominant head either.

**It does not show a lost e2e win.** I checked what happened to each head after
the bake-off, and none was dropped:

| head | after the bad diagnosis |
|---|---|
| `_mxfp8_grouped_gemm_kernel` (21.00%) | still authored — `c0_triton` 1.026x, `c1_flydsl` 1.014x |
| `aiter::moe_cktile2stages_gemm2_ck` (11.05%) | still authored and smoke-tested — `UT_RESULT: PASS primary_speedup=0.997` |
| `_matmul_ogs_NNT_bf16xbf16xmxfp4` (15.64%) | session has no `result.json`; it did not finish |

I also checked the obvious comparison and it does not hold up: in the same
MiniMax session the correctly-routed `gemm` sibling `_mxfp8_linear_kernel`
(15.29%) *also* returned `winner=None` from its bake-off, and still went on to
2.39x. So the 2.39x-vs-1.03x gap between the two heads is **not** attributable
to this routing bug.

So: merge this as a correctness fix to a diagnostic, on the strength of the
replay and the unit tests. Do not merge it expecting a dashboard number to move.
The Tier-A/Tier-B bake-off never runs for a MoE head today, and after this change
it still will not produce a timing — it produces an accurate skip instead of an
impossible instruction. Making a grouped GEMM actually benchable is separate work.

## What changed

Three edits, each one line of logic.

1. **Dispatch** — attention names itself; every other `op_kind` is GEMM-family.
   `bench_gemm` classifies grouped/quantized weights out on its own, so an
   `op_kind` nobody has taught the harness yet now gets a GEMM answer or a clean
   skip, never an attention answer.
2. **`_is_grouped_or_quant_gemm`** — recognise `op_kind='moe'` and
   `n_experts`/`num_experts`/`top_k`. It keyed on `kernel_class`, which the
   campaign's MoE metas do not carry, so it matched **0 of 59** — blind to its
   own subject.
3. **`_is_blockscale_gemm`** — a grouped MXFP8 MoE is block-scaled *and*
   grouped, and only the grouped reading has a synth.
   `_synth_blockscale_case` reads `meta["b_shape"]`, which a grouped meta does
   not carry.

**Point 3 was found by the replay, not by reading.** The first draft of this PR
had only edits 1 and 2, and it turned 14 clean skips into
`KeyError('b_shape')` with `harness_suspect: True` — a regression, on the arm
that was supposed to be the fix.

## Tests

Six new tests in `TestOpClassification` and the dispatch class, keyed to the
real campaign metas rather than invented ones. `162 passed` in
`test_op_bench.py`; `1081 passed, 5 skipped` across the repo.

The 2 remaining failures in `test_bench_e2e_teardown_lookup.py` are unrelated
and pre-existing on `main` — a separate defect, filed separately.



