### PR TITLE
fix(bench_e2e): make the shared serving-GPU lock openable, and its failure loud

### DIFF
--- a/e2e_workflow/scripts/bench_e2e.sh
+++ b/e2e_workflow/scripts/bench_e2e.sh
@@ -355,8 +355,25 @@ trap server_teardown EXIT
 if [ "${SERVING_GPU_LOCK_DISABLE:-0}" != "1" ] && [ "${REUSE_SERVER:-0}" != "1" ]; then
   _gpu_key="${GPU:-0}"; _gpu_key="${_gpu_key//,/_}"
   SERVING_LOCK="${SERVING_GPU_LOCK:-/tmp/geak_serving_gpu_${_gpu_key}.lock}"
-  exec {SERVING_LOCK_FD}>"$SERVING_LOCK"
+  # The lock file is SHARED on purpose -- the GPUs are shared, so a per-user lock would hand two
+  # users the same cards and defeat the mutex. Shared means whoever creates it first must leave it
+  # openable by the next user, hence the group/other write bit. Failure to widen it is not fatal
+  # (a single-tenant box never needs it); failure to OPEN it is.
+  if [ ! -e "$SERVING_LOCK" ]; then
+    (umask 000; : > "$SERVING_LOCK") 2>/dev/null || true
+  fi
   echo ">>> Acquiring serving-GPU lock ($SERVING_LOCK) for GPU=$GPU ..."
+  # Append, never truncate: `>` on a lock another process holds gains nothing and needs the same
+  # write bit. And this open MUST be tested. A failed `exec {FD}>` does not stop the shell, so the
+  # script used to print "Acquiring ..." with no fd assigned, then die on the next line with
+  # `SERVING_LOCK_FD: unbound variable` under `set -u` -- flock never ran, and the only line naming
+  # the cause went to stderr, which the caller does not read.
+  if ! exec {SERVING_LOCK_FD}>>"$SERVING_LOCK"; then
+    echo "!!! cannot open serving-GPU lock ($SERVING_LOCK): $(ls -ld "$SERVING_LOCK" 2>&1)" >&2
+    echo "!!! it is shared across users by design; make it group/other writable, or set" >&2
+    echo "!!!   SERVING_GPU_LOCK=<path> (a different lock)  /  SERVING_GPU_LOCK_DISABLE=1 (no mutex)" >&2
+    exit 4
+  fi
   if ! flock -w "${SERVING_LOCK_WAIT:-7200}" "$SERVING_LOCK_FD"; then
     echo "!!! serving-GPU lock timeout (${SERVING_LOCK_WAIT:-7200}s) on GPU=$GPU" >&2
     exit 4

--- a/e2e_workflow/scripts/tests/test_bench_e2e_teardown_lookup.py
+++ b/e2e_workflow/scripts/tests/test_bench_e2e_teardown_lookup.py
@@ -15,7 +15,9 @@ start it -- and that refusal is on the launch path of EVERY server in the produc
 it is asserted here rather than trusted.
 
 The gate sits before the serving-GPU lock and before any launch, so these tests need
-neither a GPU nor a model: they assert the exit code and the stderr remedy.
+neither a GPU nor a model: they assert the exit code and the stderr remedy. The two that
+run PAST the gate do reach the lock, so they are given their own lock path -- a unit test
+must not contend for the host's real GPU mutex.
 """
 import os
 import shutil
@@ -71,6 +73,12 @@ class BenchTeardownLookupTest(unittest.TestCase):
             OUT_DIR=os.path.join(self.tmp, "out"),
             REPEATS="1",
             PROFILE="0",
+            # A unit test must not take the machine's real serving-GPU mutex. The default
+            # /tmp/geak_serving_gpu_<gpu>.lock is one shared path for every user on the host, so
+            # these two tests either blocked on another tenant's benchmark (up to SERVING_LOCK_WAIT,
+            # 7200s) or could not open the file at all when another user created it first. Give the
+            # test its own lock; the mutex itself is exercised where it belongs, on a real launch.
+            SERVING_GPU_LOCK=os.path.join(self.tmp, "serving_gpu.lock"),
         )
         run_env.update(env)
         return subprocess.run(
@@ -95,6 +103,38 @@ class BenchTeardownLookupTest(unittest.TestCase):
         self.assertNotEqual(proc.returncode, MISSING_LIB_RC, proc.stderr[-2000:])
         self.assertNotIn("server_teardown.sh not found", proc.stderr)
         self.assertIn("STUB_LAUNCH_REACHED", proc.stdout, "never reached the launch")
+
+    @unittest.skipIf(os.geteuid() == 0, "root can open any lock, so the denial cannot be staged")
+    def test_an_unopenable_lock_fails_loudly_instead_of_silently(self):
+        """The serving-GPU lock is one shared path per GPU set, so on a multi-tenant host the
+        second user cannot always open it. That has to be a legible refusal.
+
+        It was not. `exec {FD}>"$LOCK"` does not stop the shell when the open fails, so the run
+        printed ">>> Acquiring serving-GPU lock ..." with no fd assigned and then died on the next
+        line with `SERVING_LOCK_FD: unbound variable` -- flock never ran, and the only line naming
+        the cause went to stderr, which the caller does not read."""
+        self.stage_lib(self.eval_dir)
+        lock = os.path.join(self.tmp, "unopenable.lock")
+        with open(lock, "w", encoding="utf-8"):
+            pass
+        os.chmod(lock, 0o400)
+        self.addCleanup(os.chmod, lock, 0o600)
+        proc = self.run_bench(SERVING_GPU_LOCK=lock)
+        self.assertEqual(proc.returncode, 4, (proc.stdout + proc.stderr)[-2000:])
+        self.assertIn("cannot open serving-GPU lock", proc.stderr)
+        self.assertIn("SERVING_GPU_LOCK", proc.stderr)          # names the way out
+        self.assertNotIn("unbound variable", proc.stderr)
+        self.assertNotIn("STUB_LAUNCH_REACHED", proc.stdout)    # and never launches
+
+    def test_a_shared_lock_is_left_openable_by_the_next_user(self):
+        """Shared is deliberate -- the GPUs are shared, so a per-user lock would hand two users
+        the same cards. Shared then requires that whoever creates it first does not lock the next
+        user out."""
+        self.stage_lib(self.eval_dir)
+        lock = os.path.join(self.tmp, "fresh.lock")
+        self.run_bench(SERVING_GPU_LOCK=lock)
+        self.assertTrue(os.path.exists(lock))
+        self.assertTrue(os.stat(lock).st_mode & 0o022, "another user could not open this lock")
 
     def test_skill_dir_fallback_is_used_and_announced(self):
         """A caller that exports SKILL_DIR keeps working from an unstaged copy -- but


### PR DESCRIPTION
Closes #421

## The defect

One lock file per GPU set, `/tmp/geak_serving_gpu_<gpu>.lock`, and nothing in the
repo ever sets `SERVING_GPU_LOCK`. Sharing it is correct — the GPUs are shared, so a
per-user lock would hand two users the same cards. But the file is created with the
creator's umask, so the second user on a host cannot open it, and the refusal is
silent: `exec {FD}>"$LOCK"` does not stop the shell, so the script prints
`>>> Acquiring serving-GPU lock ...` with no fd assigned and then dies on the next
line with `SERVING_LOCK_FD: unbound variable`. `flock` never runs.

## A/B

**Before / after, same host, same suite.**

| test | before | after |
|---|---|---|
| `test_contract_staged_beside_the_copy_passes_the_gate` | **FAIL** — `'STUB_LAUNCH_REACHED' not found` | pass |
| `test_skill_dir_fallback_is_used_and_announced` | **FAIL** — same | pass |
| `test_an_unopenable_lock_fails_loudly_instead_of_silently` *(new)* | **FAIL** | pass |
| `test_a_shared_lock_is_left_openable_by_the_next_user` *(new)* | **FAIL** | pass |
| repo suite (`--ignore=examples`) | 1077 passed, **2 failed** | **1079 passed, 0 failed** |

Both new tests were run against unpatched `bench_e2e.sh` to confirm they fail there —
a test that passes before the fix proves nothing.

**Behaviour of the failure path:**

| | before | after |
|---|---|---|
| stdout | `>>> Acquiring serving-GPU lock (...)` then nothing | same line, then the refusal |
| stderr | `Permission denied` + `SERVING_LOCK_FD: unbound variable` | `cannot open serving-GPU lock (...): -rw-r--r-- 1 <owner> ...` + both remedies |
| exit code | 1 (unbound variable) | **4** (the script's own lock-failure code) |
| `flock` called | no | no — but now on purpose, and it says so |

**Campaign impact — stated honestly:**

| measure over the claw campaign | n |
|---|---:|
| GEAK log files scanned | 2000 |
| logs carrying the lock line | 816 |
| acquire attempts / confirmations | 917 / 912 |
| explicit lock timeouts | 2 |
| **permission denials** | **0** |
| **`SERVING_LOCK_FD: unbound variable` deaths** | **0** |
| **silent `unbound variable` deaths** | **0** |

The campaign runs single-tenant, so it never hits this. **No campaign run was lost to
it, and this PR recovers no e2e gain.** It fixes a shared-host and developer-machine
defect that today fails this repo's own suite.

## What changed

1. **Create the lock under `umask 000`** so the next user can open it. Best-effort —
   a single-tenant box never needs it, so a failure to widen is not fatal.
2. **Open with `>>` and test the open.** Append rather than truncate (`>` on a lock
   another process holds gains nothing), and exit 4 with a message naming the owner,
   the mode, and both ways out (`SERVING_GPU_LOCK`, `SERVING_GPU_LOCK_DISABLE`).
3. **Give the two unit tests their own lock path.** They ran past the gate and took
   the machine's *real* GPU mutex; on a busy box that blocks for `SERVING_LOCK_WAIT`
   (7200s) instead of failing.

## What I deliberately did not do

Put `${USER}` or `$(id -u)` in the lock name. It makes the symptom vanish and removes
the mutex: two users would hold disjoint locks over the same GPUs and benchmark on
top of each other. The lock is shared because the hardware is.

