### PR TITLE
fix(e2e): Reach Finalize/Report before the wall-clock budget runs out (Hyperloom #1202)

### DIFF
--- a/ci/node/run_geak_e2e.sh
+++ b/ci/node/run_geak_e2e.sh
@@ -9,8 +9,8 @@
 #       subprocess.Popen(cmd, env=dict(os.environ), start_new_session=True)
 #   GEAK:      interface/run_e2e.py::main
 #       - positional args:  args[0]=handoff.json   args[1]=result.json   (only --dry-run flag is read)
-#       - BUDGET is read from env PERFSKILLS_E2E_TIMEOUT_S (default 43200s=12h).
-#         The CLI "--timeout-s" value is DISCARDED by run_e2e (it lands in an ignored positional).
+#       - BUDGET is the min() of "--timeout-s" and env PERFSKILLS_E2E_TIMEOUT_S; 43200s=12h when
+#         neither is stated. (The flag used to be discarded into an ignored positional: Hyperloom #1202.)
 #       - PERFSKILLS_ROOT is derived from run_e2e.py's own location (interface/..), so calling the
 #         real path is enough; it maps the handoff onto e2e_workflow/e2e_workflow.js and drives it
 #         via the Claude SDK (model claude-opus-4-8, effort ultracode).
@@ -167,7 +167,8 @@ if crit:
 print(f"patched handoff -> {dst}\n  exp_root={h['exp_root']}\n  model_path={h.get('model_path')}\n  launch_recipe={h.get('launch_recipe')}\n  inferencex_path={h.get('inferencex_path')}\n  bench_launcher={h.get('bench_launcher')}")
 PY
 
-# ---- Budget: run_e2e reads PERFSKILLS_E2E_TIMEOUT_S (NOT the CLI flag). Export it. ----
+# ---- Budget: reaches run_e2e as the --timeout-s value below (its own env knob is
+# GEAK_E2E_TIMEOUT_S, which this name has never matched). ----
 export PERFSKILLS_E2E_TIMEOUT_S   # value/default from ci/config.sh
 
 # ---- Claude workflow knobs (defaults already match run_e2e.py) ----
@@ -188,6 +189,6 @@ echo "   inferencex_path = ${INFERENCEX_PATH:-<unset -> native bench>}"
 echo "   dry_run  = ${DRY:-<no>}"
 echo "=============================================================="
 
-# We pass --timeout-s too, purely to mirror Hyperloom's exact argv (run_e2e ignores its value;
-# the effective budget is the PERFSKILLS_E2E_TIMEOUT_S env above).
+# --timeout-s mirrors Hyperloom's exact argv, and is now honoured: set PERFSKILLS_E2E_TIMEOUT_S to
+# the wall-clock at which this run will really be killed and GEAK paces its final phase to fit.
 exec python3 "$RUNNER" "$HANDOFF" "$RESULT" --timeout-s "$PERFSKILLS_E2E_TIMEOUT_S" ${DRY:+$DRY}

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -102,8 +102,7 @@ Related timing/tuning args: `fast_head_deadline_ms`, `fast_head_workflow_ms`, `d
 | `use_expert_skills` | `false` | Consult `perf_knowledge/expert_skills` (advisory priors). OFF = byte-identical. |
 | `perf_knowledge_dir` | sibling `perf_knowledge/` | Authoring knowledge base. |
 | `time_budget_s`, `initial_extra_server_args`, `initial_extra_env`, `tracelens`, `agent_timeout_ms` | — | Forwarded from the external orchestrator. |
-| `final_reserve_s` | `3600` (60min), capped at 20% of `time_budget_s` | Hard floor of wall-clock held back for the whole final phase — Finalize + Report + Validate + the `workflow_return.json` write; no mode starts new work inside it. Sized off 85 historical runs (p50 40min, p75 50min, p90 77min, max 86min), so 60min covers ~84%. The 20% cap stops the floor from eating a short budget whole; at budgets ≥5h it never binds. Env override: `GEAK_FINAL_RESERVE_S`. |
-| `final_recurate_min_s` | `600` (10min) | Floor for the post-Validate `knowledge/learned/` touch-up, which runs just before the `workflow_return.json` write. Env override: `GEAK_FINAL_RECURATE_MIN_S`. Validate itself is not separately gated — it is sized into `final_reserve_s`, and attempted even if the clock has drifted, since Report has already written both reports by then. |
+| `final_reserve_s` | `3000` (50min), capped at 20% of `time_budget_s` | Hard floor of wall-clock held back for the whole final phase — Finalize + Report + Validate + the `workflow_return.json` write; no mode starts new work inside it, and each optimization agent's hung-guard is tightened so no in-flight step finishes later than `time_budget_s − reserve` (final-phase agents are exempt). Sized off 85 historical runs (p50 40min, p75 50min, p90 77min, max 86min): 50min covers ~p75, and since Report writes both reports before Validate, a longer tail still ships them (only the Validate re-measure is at risk, and `run_e2e.py` falls back). The 20% cap stops the floor from eating a short budget whole; at budgets ≥5h it never binds. Env override: `GEAK_FINAL_RESERVE_S`. |
 
 ### Example
 
@@ -270,7 +269,7 @@ Stable `handoff.json` fields: `model_path`, `framework` (→ `backend`), `tp`, `
 `inferencex_path`, `raw_baseline_tput`, `orchestrator_best_tput_same_config`.
 
 Env knobs: `GEAK_CLAUDE_MODEL` (`claude-opus-4-8`), `GEAK_CLAUDE_EFFORT` (`ultracode`),
-`GEAK_E2E_TIMEOUT_S` (`43200` = 12h), `GEAK_FINAL_RESERVE_S`, `GEAK_FINAL_RECURATE_MIN_S`, `GEAK_ROOT`,
+`GEAK_E2E_TIMEOUT_S` (`43200` = 12h), `GEAK_FINAL_RESERVE_S`, `GEAK_ROOT`,
 `GEAK_EVAL_DIR`, `INFERENCEX_PATH`.
 
 `--timeout-s <seconds>` states the same wall-clock budget on the command line. When it and

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -102,6 +102,8 @@ Related timing/tuning args: `fast_head_deadline_ms`, `fast_head_workflow_ms`, `d
 | `use_expert_skills` | `false` | Consult `perf_knowledge/expert_skills` (advisory priors). OFF = byte-identical. |
 | `perf_knowledge_dir` | sibling `perf_knowledge/` | Authoring knowledge base. |
 | `time_budget_s`, `initial_extra_server_args`, `initial_extra_env`, `tracelens`, `agent_timeout_ms` | — | Forwarded from the external orchestrator. |
+| `final_reserve_s` | `3600` (60min), capped at 20% of `time_budget_s` | Hard floor of wall-clock held back for the whole final phase — Finalize + Report + Validate + the `workflow_return.json` write; no mode starts new work inside it. Sized off 85 historical runs (p50 40min, p75 50min, p90 77min, max 86min), so 60min covers ~84%. The 20% cap stops the floor from eating a short budget whole; at budgets ≥5h it never binds. Env override: `GEAK_FINAL_RESERVE_S`. |
+| `final_recurate_min_s` | `600` (10min) | Floor for the post-Validate `knowledge/learned/` touch-up, which runs just before the `workflow_return.json` write. Env override: `GEAK_FINAL_RECURATE_MIN_S`. Validate itself is not separately gated — it is sized into `final_reserve_s`, and attempted even if the clock has drifted, since Report has already written both reports by then. |
 
 ### Example
 
@@ -268,7 +270,12 @@ Stable `handoff.json` fields: `model_path`, `framework` (→ `backend`), `tp`, `
 `inferencex_path`, `raw_baseline_tput`, `orchestrator_best_tput_same_config`.
 
 Env knobs: `GEAK_CLAUDE_MODEL` (`claude-opus-4-8`), `GEAK_CLAUDE_EFFORT` (`ultracode`),
-`GEAK_E2E_TIMEOUT_S` (`43200` = 12h), `GEAK_ROOT`, `GEAK_EVAL_DIR`, `INFERENCEX_PATH`.
+`GEAK_E2E_TIMEOUT_S` (`43200` = 12h), `GEAK_FINAL_RESERVE_S`, `GEAK_FINAL_RECURATE_MIN_S`, `GEAK_ROOT`,
+`GEAK_EVAL_DIR`, `INFERENCEX_PATH`.
+
+`--timeout-s <seconds>` states the same wall-clock budget on the command line. When it and
+`GEAK_E2E_TIMEOUT_S` are both given the **smaller** wins (both name a real kill); `43200` applies only
+when neither is. The resolved value is forwarded to the workflow as `time_budget_s`.
 See [External orchestrator contract](./run-e2e-contract.md) for the full contract.
 
 ## Output artifacts

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -110,16 +110,52 @@ const SERVING_GPU = String(A.serving_gpu != null ? A.serving_gpu
 // not via the interface) TIME_BUDGET_MS is null and EVERY budget branch below short-circuits, so the run
 // is byte-identical to a build without this feature. No model/run specifics; pure time arithmetic.
 const TIME_BUDGET_MS = A.time_budget_s != null ? parseInt(A.time_budget_s, 10) * 1000 : null;
-// Reserve a tail for the post-deadline finish: the in-flight wave/head completes, then Finalize + Report +
-// the final Validate bench + the workflow_return write must all land before the hard kill. Carve 8% (min
-// 20min) off the top here, ONCE, so every mode below shares one definition of "effective budget".
+// ---- ELAPSED CLOCK ----------------------------------------------------------------------------------
+// Date.now()/new Date() are unavailable in Workflow scripts (they would break resume), so "how much budget
+// is left?" has to be COUNTED: a self-rearming 1-minute tick, accurate enough to gate an hour-scale finish.
+// With no time_budget_s remainingMs() is Infinity and every guard short-circuits.
+let ELAPSED_MS = 0;
+const CLOCK_TICK_MS = 60000;
+if (TIME_BUDGET_MS != null && typeof setTimeout === 'function') {
+  // unref (when the host exposes it) so a pending tick can never hold the process open past the run.
+  const arm = () => { const t = setTimeout(tick, CLOCK_TICK_MS); if (t && t.unref) t.unref(); };
+  const tick = () => { ELAPSED_MS += CLOCK_TICK_MS; arm(); };
+  arm();
+}
+const remainingMs = () => (TIME_BUDGET_MS == null ? Infinity : Math.max(0, TIME_BUDGET_MS - ELAPSED_MS));
+const remainingMin = () => (TIME_BUDGET_MS == null ? Infinity : Math.round(remainingMs() / 60000));
+// ---- FINAL-PHASE RESERVE --------------------------------------------------------------------------
+// Stop optimizing while there is still enough wall-clock to WRITE THE DELIVERABLE; three sessions
+// (Hyperloom #1202) produced no final report because nothing reserved this. FINAL_RESERVE_MS is the HARD
+// FLOOR held back for the WHOLE final phase — Finalize + Report + Validate + the workflow_return write —
+// and no mode starts new work inside it. FINAL_RECURATE_MIN_MS separately guards the nice-to-have
+// knowledge-base touch-up that sits between Validate and the handoff write.
+//
+// 60min is measured: across 85 historical Hyperloom runs those four phases took p50 40min / p75 50min /
+// p90 77min / max 86min, so 60 covers ~84% and GEAK_FINAL_RESERVE_S widens it for a model that writes slowly.
+// The 20% cap keeps that floor from eating a SHORT budget whole (a flat 60min against a 1.5h run leaves
+// 30min to optimize in); on the >=5h budgets this is really aimed at, 20% exceeds 60min and never binds.
+const FINAL_RESERVE_CAP_FRAC = 0.2;
+const FINAL_RESERVE_MS = TIME_BUDGET_MS != null
+  ? Math.min(parseInt(A.final_reserve_s != null ? A.final_reserve_s : 3600, 10) * 1000, // 60min
+             Math.floor(TIME_BUDGET_MS * FINAL_RESERVE_CAP_FRAC))
+  : null;
+const FINAL_RECURATE_MIN_MS = parseInt(A.final_recurate_min_s != null
+  ? A.final_recurate_min_s : 600, 10) * 1000;                                   // 10min
+// The effective budget is simply "budget minus the reserve": ONE definition of the time available for
+// optimization, shared by every mode below.
 const TIME_BUDGET_EFFECTIVE_MS = TIME_BUDGET_MS != null
-  ? Math.max(60000, TIME_BUDGET_MS - Math.max(1200000, Math.floor(TIME_BUDGET_MS * 0.08)))
+  ? Math.max(60000, TIME_BUDGET_MS - FINAL_RESERVE_MS)
   : null;
 // Cap on the dispatch-deadline TAIL (budget − deadline). A flat 60% deadline reserves 40%, which is wasteful
 // on large budgets (24h → ~9h reserved though a few hours suffice). Deadlines below are max(60%, budget − this
 // cap): the 60% floor keeps small budgets unchanged; the cap bounds the reserve on large ones. Default 3h.
 const TIME_TAIL_CAP_MS = parseInt(A.time_tail_cap_s != null ? A.time_tail_cap_s : 10800, 10) * 1000; // 3h
+// Point after which NO mode starts new head/milestone/wave work, so the in-flight task plus the whole
+// final phase still land before the hard kill. Defined HERE (not down at the deadline timer) because deep
+// mode needs it hundreds of lines earlier; the timer that flips TIME_DEADLINE_HIT is armed on it below.
+const TIME_HEAD_DEADLINE_MS = TIME_BUDGET_EFFECTIVE_MS != null
+  ? Math.max(Math.floor(TIME_BUDGET_EFFECTIVE_MS * 0.6), TIME_BUDGET_EFFECTIVE_MS - TIME_TAIL_CAP_MS) : null;
 // ---- FAST MODE (opt-in, default OFF) ----------------------------------------------------------------
 // A time-boxed run that takes ALL its optimization from the HeadKernel track: it SKIPS ConfigSweep AND
 // the editable-kernel Milestone loop, and completes within a wall-clock budget (default 5h). It exists
@@ -281,7 +317,11 @@ let DEEP_HEAD_BUDGET_MS = parseInt(A.deep_head_budget_ms != null ? A.deep_head_b
 // 24h default) so deep fills the granted time and self-finalizes before the external SIGKILL (fixing the
 // deep 24h-budget-vs-real-kill failure where it was torn down mid-wave). The 24h default applies only when
 // time_budget_s is absent (direct invocation) => byte-identical to today.
-if (TIME_BUDGET_EFFECTIVE_MS != null) DEEP_HEAD_BUDGET_MS = TIME_BUDGET_EFFECTIVE_MS;
+// Use the SHARED dispatch deadline (max(60%, effective − tail cap)), NOT the raw effective budget: deep
+// used to keep starting waves until 92% of the hard kill, then still had to drain a 75min burst, run the
+// final e2e gate, and do Finalize/Report/Validate — it never fit, which is why deep sessions shipped no
+// final report (Hyperloom #1202). Fast and default modes have always carved this same tail.
+if (TIME_HEAD_DEADLINE_MS != null) DEEP_HEAD_BUDGET_MS = TIME_HEAD_DEADLINE_MS;
 const DEEP_HEAD_WF_MS = parseInt(A.deep_head_workflow_ms != null ? A.deep_head_workflow_ms : 4500000, 10); // per-burst nested kernel_workflow time cap (75min) — bounds the per-wave barrier. Harvest+gate run at the TOP of each wave on disk truth, so gate latency is decoupled from this; the cap only bounds how long a burst runs.
 const DEEP_E2E_GAIN_TRIGGER = parseFloat(A.deep_e2e_gain_trigger != null ? A.deep_e2e_gain_trigger : 0.08); // isolated-best improvement since last e2e gate that triggers a new (batched) gate
 const DEEP_E2E_MAX_INTERVAL_MS = parseInt(A.deep_e2e_max_interval_ms != null ? A.deep_e2e_max_interval_ms : 7200000, 10); // force an e2e gate at least this often when a new candidate exists (default 2h)
@@ -1290,8 +1330,6 @@ if (DEEP_MODE && typeof setTimeout === 'function' && DEEP_HEAD_BUDGET_MS > 0) {
 // Report/Validate). Active in ALL modes when time_budget_s is set (harmless for fast/deep, which stop even
 // earlier on their own flags); fully inert (never registered) when time_budget_s is absent => byte-identical.
 let TIME_DEADLINE_HIT = false;
-const TIME_HEAD_DEADLINE_MS = TIME_BUDGET_EFFECTIVE_MS != null
-  ? Math.max(Math.floor(TIME_BUDGET_EFFECTIVE_MS * 0.6), TIME_BUDGET_EFFECTIVE_MS - TIME_TAIL_CAP_MS) : null;
 if (TIME_HEAD_DEADLINE_MS != null && typeof setTimeout === 'function' && TIME_HEAD_DEADLINE_MS > 0) {
   setTimeout(() => {
     TIME_DEADLINE_HIT = true;
@@ -1833,7 +1871,10 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
     armInterval();
     let convergeStreak = 0, deepBurstsSpent = 0;
     try {
-    while (!DEEP_DEADLINE_HIT) {
+    // TIME_DEADLINE_HIT as well as DEEP_DEADLINE_HIT: the two are armed off the same deadline now, but the
+    // general flag is the one every OTHER mode honours, so a future change to either can never leave the
+    // deep wave loop as the one dispatcher that runs past the reserve.
+    while (!DEEP_DEADLINE_HIT && !TIME_DEADLINE_HIT) {
       if (convergeStreak >= DEEP_CONVERGE_STREAK) { log(`[deep] CONVERGED \u2014 ${convergeStreak} consecutive zero-gain waves; stopping to finalize.`); break; }
       const projAgents = (deepBurstsSpent + mainSlots + serveSlots) * DEEP_AGENTS_PER_BURST + wave * 6;   // project a FULL next wave of bursts + per-wave overhead (harvest/curate/gate)
       if (projAgents >= DEEP_AGENT_BUDGET) { log(`[deep] agent budget reached (proj ~${projAgents}/${DEEP_AGENT_BUDGET}, ${deepBurstsSpent} bursts); stopping to finalize with margin for the cap.`); break; }
@@ -2684,6 +2725,7 @@ if (want('final')) {
 }
 allAccepted = acceptedHeads.concat(acceptedKernels);   // refresh after Fix C may have banked a pending win
 if (want('final')) {
+  if (TIME_BUDGET_MS != null) log(`[time-budget] entering the final phase with ~${remainingMin()}min of the ${Math.round(TIME_BUDGET_MS / 60000)}min budget left (reserve was ${Math.round(FINAL_RESERVE_MS / 60000)}min).`);
   phase('Finalize');
   finalize = await safeAgent(
     roleAgent('e2e_integrator', 'finalize', 'Assemble the final overlay + patch + launch script bundle.', {
@@ -2704,6 +2746,13 @@ if (want('final')) {
     }),
     { phase: 'Report', label: 'architect:report', schema: REPORT_SCHEMA });
 
+  // Validate is SIZED INTO FINAL_RESERVE_MS (it is ~15min of the measured 42min median), so by
+  // construction there should be room for it here. It is still not time-GATED: the reserve is a floor, not
+  // a guarantee, and if the clock has drifted or Report ran long, attempting it beats skipping it. Should
+  // the hard kill land mid-bench the loss is bounded — Report has already put architect_report.md and
+  // final_report.md on disk, so the only casualty is the workflow_return.json fast path, and run_e2e.py
+  // falls back to director_e2e_validation.json, then to the best accepted
+  // overlay/<cand>/integrate_result.json, so a real parity-checked win still reaches the caller.
   phase('Validate');
   validation = await safeAgent(
     roleAgent('director', 'validate', 'Independently re-measure throughput + parity; arbitrate; then reconcile the report with the validated numbers.', {
@@ -2741,7 +2790,9 @@ if (want('final')) {
   // gated number (see the 20260812 Qwen3.5-27B run: the +16.1% head card was left
   // at "e2e transfer NOT yet gated"). Re-curate ONCE now, with the authoritative
   // post-Validate numbers, so finalize-gate confirmations are written back.
-  if (allAccepted.length) {
+  // Time-gated: a nice-to-have knowledge-base touch-up that runs BEFORE the workflow_return.json write,
+  // so letting it start with minutes left would risk taking the contracted handoff artifact down with it.
+  if (allAccepted.length && remainingMs() > FINAL_RECURATE_MIN_MS) {
     const verifiedTput = validatedOk ? validation.director_verified_throughput_tok_s : finalTput;
     await safeAgent(
       roleAgent('system_architect', 'update_experience',
@@ -2763,6 +2814,10 @@ if (want('final')) {
       }),
       { phase: 'Validate', label: 'architect:experience final', schema: EXPERIENCE_SCHEMA });
     log('Finalize: re-curated knowledge/learned/ with verified post-gate numbers (pending -> verified).');
+  } else if (allAccepted.length) {
+    log(`[time-budget] SKIPPING the final knowledge/learned/ re-curate: only ~${remainingMin()}min left ` +
+      `(needs ${Math.round(FINAL_RECURATE_MIN_MS / 60000)}min); spending it on the workflow_return.json ` +
+      `write instead. Cards stay at their pre-gate wording.`);
   }
 } else {
   log(`Phase(s) [${PHASES.join(',')}] done. Carried throughput ${curTput} tok/s. Pass the returned 'state' to the next phase invocation.`);

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -110,40 +110,32 @@ const SERVING_GPU = String(A.serving_gpu != null ? A.serving_gpu
 // not via the interface) TIME_BUDGET_MS is null and EVERY budget branch below short-circuits, so the run
 // is byte-identical to a build without this feature. No model/run specifics; pure time arithmetic.
 const TIME_BUDGET_MS = A.time_budget_s != null ? parseInt(A.time_budget_s, 10) * 1000 : null;
-// ---- ELAPSED CLOCK ----------------------------------------------------------------------------------
-// Date.now()/new Date() are unavailable in Workflow scripts (they would break resume), so "how much budget
-// is left?" has to be COUNTED: a self-rearming 1-minute tick, accurate enough to gate an hour-scale finish.
-// With no time_budget_s remainingMs() is Infinity and every guard short-circuits.
+// ---- ELAPSED CLOCK ----
+// Date.now() is unavailable in Workflow scripts (breaks resume), so count elapsed time via a 1-minute
+// self-rearming tick. No time_budget_s => remainingMs() is Infinity and every guard short-circuits.
 let ELAPSED_MS = 0;
 const CLOCK_TICK_MS = 60000;
 if (TIME_BUDGET_MS != null && typeof setTimeout === 'function') {
-  // unref (when the host exposes it) so a pending tick can never hold the process open past the run.
+  // unref so a pending tick can never hold the process open past the run.
   const arm = () => { const t = setTimeout(tick, CLOCK_TICK_MS); if (t && t.unref) t.unref(); };
   const tick = () => { ELAPSED_MS += CLOCK_TICK_MS; arm(); };
   arm();
 }
 const remainingMs = () => (TIME_BUDGET_MS == null ? Infinity : Math.max(0, TIME_BUDGET_MS - ELAPSED_MS));
 const remainingMin = () => (TIME_BUDGET_MS == null ? Infinity : Math.round(remainingMs() / 60000));
-// ---- FINAL-PHASE RESERVE --------------------------------------------------------------------------
-// Stop optimizing while there is still enough wall-clock to WRITE THE DELIVERABLE; three sessions
-// (Hyperloom #1202) produced no final report because nothing reserved this. FINAL_RESERVE_MS is the HARD
-// FLOOR held back for the WHOLE final phase — Finalize + Report + Validate + the workflow_return write —
-// and no mode starts new work inside it. FINAL_RECURATE_MIN_MS separately guards the nice-to-have
-// knowledge-base touch-up that sits between Validate and the handoff write.
-//
-// 60min is measured: across 85 historical Hyperloom runs those four phases took p50 40min / p75 50min /
-// p90 77min / max 86min, so 60 covers ~84% and GEAK_FINAL_RESERVE_S widens it for a model that writes slowly.
-// The 20% cap keeps that floor from eating a SHORT budget whole (a flat 60min against a 1.5h run leaves
-// 30min to optimize in); on the >=5h budgets this is really aimed at, 20% exceeds 60min and never binds.
+// ---- FINAL-PHASE RESERVE ----
+// Hard floor of wall-clock held back for the WHOLE final phase (Finalize + Report + Validate + the
+// workflow_return write); no mode starts new work inside it. Without it, three sessions shipped no final
+// report (Hyperloom #1202). 50min ~= p75 of 85 historical final phases (p50 40 / p90 77 / max 86min);
+// since Report writes both reports BEFORE Validate, a longer tail still ships them (only the Validate
+// re-measure is at risk, and run_e2e falls back). The 20% cap stops it eating a short budget whole; at
+// >=5h budgets it never binds. Env override: GEAK_FINAL_RESERVE_S.
 const FINAL_RESERVE_CAP_FRAC = 0.2;
 const FINAL_RESERVE_MS = TIME_BUDGET_MS != null
-  ? Math.min(parseInt(A.final_reserve_s != null ? A.final_reserve_s : 3600, 10) * 1000, // 60min
+  ? Math.min(parseInt(A.final_reserve_s != null ? A.final_reserve_s : 3000, 10) * 1000, // 50min
              Math.floor(TIME_BUDGET_MS * FINAL_RESERVE_CAP_FRAC))
   : null;
-const FINAL_RECURATE_MIN_MS = parseInt(A.final_recurate_min_s != null
-  ? A.final_recurate_min_s : 600, 10) * 1000;                                   // 10min
-// The effective budget is simply "budget minus the reserve": ONE definition of the time available for
-// optimization, shared by every mode below.
+// Effective budget = budget minus the reserve: one definition of time available to optimize.
 const TIME_BUDGET_EFFECTIVE_MS = TIME_BUDGET_MS != null
   ? Math.max(60000, TIME_BUDGET_MS - FINAL_RESERVE_MS)
   : null;
@@ -151,9 +143,8 @@ const TIME_BUDGET_EFFECTIVE_MS = TIME_BUDGET_MS != null
 // on large budgets (24h → ~9h reserved though a few hours suffice). Deadlines below are max(60%, budget − this
 // cap): the 60% floor keeps small budgets unchanged; the cap bounds the reserve on large ones. Default 3h.
 const TIME_TAIL_CAP_MS = parseInt(A.time_tail_cap_s != null ? A.time_tail_cap_s : 10800, 10) * 1000; // 3h
-// Point after which NO mode starts new head/milestone/wave work, so the in-flight task plus the whole
-// final phase still land before the hard kill. Defined HERE (not down at the deadline timer) because deep
-// mode needs it hundreds of lines earlier; the timer that flips TIME_DEADLINE_HIT is armed on it below.
+// Point after which no mode starts new head/milestone/wave work. Defined here (not at the deadline timer)
+// because deep mode references it far earlier; TIME_DEADLINE_HIT is armed on it below.
 const TIME_HEAD_DEADLINE_MS = TIME_BUDGET_EFFECTIVE_MS != null
   ? Math.max(Math.floor(TIME_BUDGET_EFFECTIVE_MS * 0.6), TIME_BUDGET_EFFECTIVE_MS - TIME_TAIL_CAP_MS) : null;
 // ---- FAST MODE (opt-in, default OFF) ----------------------------------------------------------------
@@ -317,10 +308,9 @@ let DEEP_HEAD_BUDGET_MS = parseInt(A.deep_head_budget_ms != null ? A.deep_head_b
 // 24h default) so deep fills the granted time and self-finalizes before the external SIGKILL (fixing the
 // deep 24h-budget-vs-real-kill failure where it was torn down mid-wave). The 24h default applies only when
 // time_budget_s is absent (direct invocation) => byte-identical to today.
-// Use the SHARED dispatch deadline (max(60%, effective − tail cap)), NOT the raw effective budget: deep
-// used to keep starting waves until 92% of the hard kill, then still had to drain a 75min burst, run the
-// final e2e gate, and do Finalize/Report/Validate — it never fit, which is why deep sessions shipped no
-// final report (Hyperloom #1202). Fast and default modes have always carved this same tail.
+// Use the SHARED dispatch deadline, not the raw effective budget: deep used to start waves until 92% of
+// the hard kill, then couldn't fit its burst drain + final e2e gate + Finalize/Report/Validate, so it
+// shipped no final report (Hyperloom #1202). Fast/default modes have always carved this same tail.
 if (TIME_HEAD_DEADLINE_MS != null) DEEP_HEAD_BUDGET_MS = TIME_HEAD_DEADLINE_MS;
 const DEEP_HEAD_WF_MS = parseInt(A.deep_head_workflow_ms != null ? A.deep_head_workflow_ms : 4500000, 10); // per-burst nested kernel_workflow time cap (75min) — bounds the per-wave barrier. Harvest+gate run at the TOP of each wave on disk truth, so gate latency is decoupled from this; the cap only bounds how long a burst runs.
 const DEEP_E2E_GAIN_TRIGGER = parseFloat(A.deep_e2e_gain_trigger != null ? A.deep_e2e_gain_trigger : 0.08); // isolated-best improvement since last e2e gate that triggers a new (batched) gate
@@ -713,15 +703,29 @@ function withProcessSafety(prompt) {
   return typeof prompt === 'string' ? PROCESS_SAFETY + prompt : prompt;
 }
 
+// Option A (Hyperloom #1202): near the deadline, tighten each OPTIMIZATION agent's hung-guard so no
+// in-flight step finishes later than (budget − reserve). The loop-tops stop STARTING new work at
+// TIME_HEAD_DEADLINE_MS, but one iteration is a SEQUENCE of agents (extract → bakeoff → author → verify)
+// each armed with the full AGENT_TIMEOUT_MS, and that sequence could overrun the reserve and starve
+// Finalize/Report/Validate (the #1202 stall was a 62min extract_op running into the SIGKILL). Final-phase
+// agents are EXEMPT — they run INSIDE the reserve by design. The 2min floor lets a deadline-killed agent's
+// retries self-limit instead of burning the reserve. Inert when time_budget_s is absent (byte-identical).
+const FINAL_PHASE_LABELS = ['Finalize', 'Report', 'Validate'];
+function agentTimeoutFor(opts) {
+  if (TIME_BUDGET_MS == null || (opts && FINAL_PHASE_LABELS.includes(opts.phase))) return AGENT_TIMEOUT_MS;
+  return Math.max(120000, Math.min(AGENT_TIMEOUT_MS, remainingMs() - FINAL_RESERVE_MS));
+}
+
 function agentBounded(rawPrompt, opts) {
   const prompt = withProcessSafety(rawPrompt);
-  if (typeof setTimeout !== 'function' || !(AGENT_TIMEOUT_MS > 0)) return agent(prompt, opts);
+  const timeoutMs = agentTimeoutFor(opts);
+  if (typeof setTimeout !== 'function' || !(timeoutMs > 0)) return agent(prompt, opts);
   let to;
   const guard = new Promise((resolve) => {
     to = setTimeout(() => {
-      log(`  [hung-agent guard] ${(opts && opts.label) || 'agent'} exceeded ${Math.round(AGENT_TIMEOUT_MS / 60000)}min with no return — treating as a failed attempt.`);
+      log(`  [hung-agent guard] ${(opts && opts.label) || 'agent'} exceeded ${Math.round(timeoutMs / 60000)}min with no return — treating as a failed attempt.`);
       resolve(null);
-    }, AGENT_TIMEOUT_MS);
+    }, timeoutMs);
   });
   return Promise.race([
     agent(prompt, opts).then((r) => { clearTimeout(to); return r; }, (e) => { clearTimeout(to); throw e; }),
@@ -1883,9 +1887,8 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
     armInterval();
     let convergeStreak = 0, deepBurstsSpent = 0;
     try {
-    // TIME_DEADLINE_HIT as well as DEEP_DEADLINE_HIT: the two are armed off the same deadline now, but the
-    // general flag is the one every OTHER mode honours, so a future change to either can never leave the
-    // deep wave loop as the one dispatcher that runs past the reserve.
+    // Honour TIME_DEADLINE_HIT as well as DEEP_DEADLINE_HIT (both armed off the same deadline) so the deep
+    // wave loop can never become the one dispatcher that runs past the reserve.
     while (!DEEP_DEADLINE_HIT && !TIME_DEADLINE_HIT) {
       if (convergeStreak >= DEEP_CONVERGE_STREAK) { log(`[deep] CONVERGED \u2014 ${convergeStreak} consecutive zero-gain waves; stopping to finalize.`); break; }
       const projAgents = (deepBurstsSpent + mainSlots + serveSlots) * DEEP_AGENTS_PER_BURST + wave * 6;   // project a FULL next wave of bursts + per-wave overhead (harvest/curate/gate)
@@ -2758,13 +2761,10 @@ if (want('final')) {
     }),
     { phase: 'Report', label: 'architect:report', schema: REPORT_SCHEMA });
 
-  // Validate is SIZED INTO FINAL_RESERVE_MS (it is ~15min of the measured 42min median), so by
-  // construction there should be room for it here. It is still not time-GATED: the reserve is a floor, not
-  // a guarantee, and if the clock has drifted or Report ran long, attempting it beats skipping it. Should
-  // the hard kill land mid-bench the loss is bounded — Report has already put architect_report.md and
-  // final_report.md on disk, so the only casualty is the workflow_return.json fast path, and run_e2e.py
-  // falls back to director_e2e_validation.json, then to the best accepted
-  // overlay/<cand>/integrate_result.json, so a real parity-checked win still reaches the caller.
+  // Validate is sized into FINAL_RESERVE_MS, so there should be room for it here; it is not time-GATED
+  // (attempting it beats skipping when the clock has drifted). If the hard kill lands mid-bench the loss is
+  // bounded — Report already wrote architect_report.md + final_report.md, and run_e2e.py falls back
+  // (director_e2e_validation.json → best overlay's integrate_result.json), so a real win still reaches the caller.
   phase('Validate');
   validation = await safeAgent(
     roleAgent('director', 'validate', 'Independently re-measure throughput + parity; arbitrate; then reconcile the report with the validated numbers.', {
@@ -2802,9 +2802,7 @@ if (want('final')) {
   // gated number (see the 20260812 Qwen3.5-27B run: the +16.1% head card was left
   // at "e2e transfer NOT yet gated"). Re-curate ONCE now, with the authoritative
   // post-Validate numbers, so finalize-gate confirmations are written back.
-  // Time-gated: a nice-to-have knowledge-base touch-up that runs BEFORE the workflow_return.json write,
-  // so letting it start with minutes left would risk taking the contracted handoff artifact down with it.
-  if (allAccepted.length && remainingMs() > FINAL_RECURATE_MIN_MS) {
+  if (allAccepted.length) {
     const verifiedTput = validatedOk ? validation.director_verified_throughput_tok_s : finalTput;
     await safeAgent(
       roleAgent('system_architect', 'update_experience',
@@ -2826,10 +2824,6 @@ if (want('final')) {
       }),
       { phase: 'Validate', label: 'architect:experience final', schema: EXPERIENCE_SCHEMA });
     log('Finalize: re-curated knowledge/learned/ with verified post-gate numbers (pending -> verified).');
-  } else if (allAccepted.length) {
-    log(`[time-budget] SKIPPING the final knowledge/learned/ re-curate: only ~${remainingMin()}min left ` +
-      `(needs ${Math.round(FINAL_RECURATE_MIN_MS / 60000)}min); spending it on the workflow_return.json ` +
-      `write instead. Cards stay at their pre-gate wording.`);
   }
 } else {
   log(`Phase(s) [${PHASES.join(',')}] done. Carried throughput ${curTput} tok/s. Pass the returned 'state' to the next phase invocation.`);

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -268,15 +268,11 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
     # budget-unaware (byte-identical to a direct, non-interface invocation).
     if timeout_s is not None and timeout_s > 0:
         ps_args["time_budget_s"] = int(timeout_s)
-    # How that budget is split at the end. Defaults live in the JS (60min reserve
-    # capped at 20% of the budget, 10min re-curate floor); these let an operator
-    # widen the reserve per run without editing either file -- e.g.
-    # GEAK_FINAL_RESERVE_S=5400 for 90min on a model known to write slowly.
-    for env_key, arg_key in (("GEAK_FINAL_RESERVE_S", "final_reserve_s"),
-                             ("GEAK_FINAL_RECURATE_MIN_S", "final_recurate_min_s")):
-        v = _int_or_none(os.environ.get(env_key), env_key)
-        if v is not None:
-            ps_args[arg_key] = v
+    # Final-phase reserve. Default lives in the JS (50min, capped at 20% of the budget);
+    # this lets an operator widen it per run -- e.g. GEAK_FINAL_RESERVE_S=5400 for 90min.
+    final_reserve_s = _int_or_none(os.environ.get("GEAK_FINAL_RESERVE_S"), "GEAK_FINAL_RESERVE_S")
+    if final_reserve_s is not None:
+        ps_args["final_reserve_s"] = final_reserve_s
     if h.get("launch_recipe"):
         ps_args["launch_script"] = h["launch_recipe"]
     # Serving-launch fidelity (see Hyperloom handoff builder / #805): forward the
@@ -3835,12 +3831,10 @@ def _int_or_none(raw: str | None, what: str) -> int | None:
 def _resolve_timeout_s(argv: list[str]) -> tuple[list[str], set[str], int]:
     """Split argv into positionals + flags, and resolve the wall-clock budget.
 
-    `--timeout-s N` is the wall-clock at which the orchestrator kills us. Its
-    VALUE is not a "--" token, so it used to land in an ignored third positional
-    and we paced against GEAK_E2E_TIMEOUT_S's 12h default instead — a caller
-    killing at 8h tore the run down mid-optimization (Hyperloom #1202). Flag and
-    env var both name a REAL kill, so the min() wins; the default applies only
-    when neither is stated.
+    `--timeout-s N` is the wall-clock kill time. Its VALUE is not a "--" token, so it
+    used to land in an ignored positional and we paced against GEAK_E2E_TIMEOUT_S's 12h
+    default instead (Hyperloom #1202). Flag and env both name a REAL kill, so min() wins;
+    the default applies only when neither is stated.
     """
     positional: list[str] = []
     flags: set[str] = set()

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -268,6 +268,15 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
     # budget-unaware (byte-identical to a direct, non-interface invocation).
     if timeout_s is not None and timeout_s > 0:
         ps_args["time_budget_s"] = int(timeout_s)
+    # How that budget is split at the end. Defaults live in the JS (60min reserve
+    # capped at 20% of the budget, 10min re-curate floor); these let an operator
+    # widen the reserve per run without editing either file -- e.g.
+    # GEAK_FINAL_RESERVE_S=5400 for 90min on a model known to write slowly.
+    for env_key, arg_key in (("GEAK_FINAL_RESERVE_S", "final_reserve_s"),
+                             ("GEAK_FINAL_RECURATE_MIN_S", "final_recurate_min_s")):
+        v = _int_or_none(os.environ.get(env_key), env_key)
+        if v is not None:
+            ps_args[arg_key] = v
     if h.get("launch_recipe"):
         ps_args["launch_script"] = h["launch_recipe"]
     # Serving-launch fidelity (see Hyperloom handoff builder / #805): forward the
@@ -3799,16 +3808,71 @@ def _publish_protected_pgids() -> str:
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+DEFAULT_E2E_TIMEOUT_S = 43200  # 12h — used only when NOBODY states a budget
+
+
+def _int_or_none(raw: str | None, what: str) -> int | None:
+    """Positive int, or None (with a note) for junk — never abort on a bad budget."""
+    if not raw:
+        return None
+    try:
+        return int(raw) if int(raw) > 0 else None
+    except ValueError:
+        sys.stderr.write(f"ignoring non-integer {what}: {raw!r}\n")
+        return None
+
+
+def _resolve_timeout_s(argv: list[str]) -> tuple[list[str], set[str], int]:
+    """Split argv into positionals + flags, and resolve the wall-clock budget.
+
+    `--timeout-s N` is the wall-clock at which the orchestrator kills us. Its
+    VALUE is not a "--" token, so it used to land in an ignored third positional
+    and we paced against GEAK_E2E_TIMEOUT_S's 12h default instead — a caller
+    killing at 8h tore the run down mid-optimization (Hyperloom #1202). Flag and
+    env var both name a REAL kill, so the min() wins; the default applies only
+    when neither is stated.
+    """
+    positional: list[str] = []
+    flags: set[str] = set()
+    stated: dict[str, int] = {}
+    expect_value = False
+    for tok in argv:
+        if expect_value:
+            expect_value = False
+            v = _int_or_none(tok, "--timeout-s value")
+        elif tok == "--timeout-s":
+            expect_value = True
+            continue
+        elif tok.startswith("--timeout-s="):
+            v = _int_or_none(tok.split("=", 1)[1], "--timeout-s value")
+        elif tok.startswith("--"):
+            flags.add(tok)
+            continue
+        else:
+            positional.append(tok)
+            continue
+        if v is not None:
+            stated["--timeout-s"] = v
+    v = _int_or_none(os.environ.get("GEAK_E2E_TIMEOUT_S"), "GEAK_E2E_TIMEOUT_S")
+    if v is not None:
+        stated["GEAK_E2E_TIMEOUT_S"] = v
+    budget = min(stated.values()) if stated else DEFAULT_E2E_TIMEOUT_S
+    sys.stderr.write(
+        f"[budget] wall-clock {budget}s "
+        f"({', '.join(f'{k}={v}' for k, v in stated.items()) or 'nobody stated one; default'})\n"
+    )
+    return positional, flags, budget
+
+
 def main(argv: list[str]) -> int:
-    args = [a for a in argv if not a.startswith("--")]
-    flags = {a for a in argv if a.startswith("--")}
+    args, flags, timeout_s = _resolve_timeout_s(argv)
     if len(args) < 2:
         sys.stderr.write(
-            "usage: run_e2e.py <handoff.json> <result.json> [--dry-run]\n"
+            "usage: run_e2e.py <handoff.json> <result.json> "
+            "[--timeout-s N] [--dry-run]\n"
         )
         return 2
     handoff_path, result_path = Path(args[0]), Path(args[1])
-    timeout_s = int(os.environ.get("GEAK_E2E_TIMEOUT_S", "43200"))  # 12h
 
     h = _read_json(handoff_path)
     if not h:

--- a/interface/test_run_e2e_dispatch.py
+++ b/interface/test_run_e2e_dispatch.py
@@ -2168,11 +2168,75 @@ class TestMain(_RunE2ECase):
         self.assertIn("1", published)
         self.assertIn(str(os.getpgid(0)), published)
 
+    def _pin_env_timeout(self, value: str | None):
+        """Set/clear GEAK_E2E_TIMEOUT_S for one test and always restore it, so
+        budget tests cannot leak a budget into whatever runs next."""
+        saved = os.environ.pop("GEAK_E2E_TIMEOUT_S", None)
+        if saved is not None:
+            self.addCleanup(os.environ.__setitem__, "GEAK_E2E_TIMEOUT_S", saved)
+        else:
+            self.addCleanup(os.environ.pop, "GEAK_E2E_TIMEOUT_S", None)
+        if value is not None:
+            os.environ["GEAK_E2E_TIMEOUT_S"] = value
+
     def test_timeout_budget_is_read_from_the_environment(self):
-        os.environ["GEAK_E2E_TIMEOUT_S"] = "600"
+        self._pin_env_timeout("600")
         self.patch_rx("invoke_workflow", lambda *a, **k: {})
         _rc, stdout = self._run(self._handoff(), "--dry-run")
         self.assertEqual(json.loads(stdout)["mapped_args"]["time_budget_s"], 600)
+
+    def test_timeout_budget_is_read_from_the_cli(self):
+        """Hyperloom's coordinator states its REAL kill time as
+        `--timeout-s <runner_timeout>`. We used to drop that value into an
+        ignored third positional and pace against the 12h env default instead,
+        so a caller killing early tore the run down mid-optimization and no
+        final report was written (Hyperloom #1202)."""
+        self._pin_env_timeout(None)
+        self.patch_rx("invoke_workflow", lambda *a, **k: {})
+        for argv in (["--timeout-s", "28800"], ["--timeout-s=28800"]):
+            with self.subTest(argv=argv):
+                _rc, stdout = self._run(self._handoff(), *argv, "--dry-run")
+                plan = json.loads(stdout)
+                self.assertEqual(plan["mapped_args"]["time_budget_s"], 28800)
+                # The value must NOT shift the positionals it sits behind.
+                self.assertEqual(plan["mapped_args"]["eval_dir"],
+                                 str(self.eval_dir))
+
+    def test_smallest_stated_budget_wins(self):
+        """Flag and env var both name a deadline someone actually enforces, so
+        pace against the SMALLER. Junk states nothing, and with nothing stated
+        the 12h default applies — a bad budget must not abort the run."""
+        self.patch_rx("invoke_workflow", lambda *a, **k: {})
+        default = rx.DEFAULT_E2E_TIMEOUT_S
+        for env, cli, expected in (("14400", "28800", 14400),
+                                   ("28800", "14400", 14400),
+                                   (None, None, default),
+                                   ("not-a-number", "later", default)):
+            with self.subTest(env=env, cli=cli):
+                self._pin_env_timeout(env)
+                argv = ["--timeout-s", cli] if cli else []
+                _rc, stdout = self._run(self._handoff(), *argv, "--dry-run")
+                self.assertEqual(
+                    json.loads(stdout)["mapped_args"]["time_budget_s"], expected)
+
+    def test_final_reserve_is_overridable_from_the_environment(self):
+        """Widening the finalize window must not need a code edit: an operator
+        who measures the final phase taking longer than the 60min default sets
+        GEAK_FINAL_RESERVE_S. Unset => the arg is absent and the JS default wins."""
+        self.patch_rx("invoke_workflow", lambda *a, **k: {})
+        for env, expected in (("3000", 3000), (None, None)):
+            with self.subTest(env=env):
+                saved = os.environ.pop("GEAK_FINAL_RESERVE_S", None)
+                if saved is not None:
+                    self.addCleanup(
+                        os.environ.__setitem__, "GEAK_FINAL_RESERVE_S", saved)
+                if env is not None:
+                    os.environ["GEAK_FINAL_RESERVE_S"] = env
+                    self.addCleanup(os.environ.pop, "GEAK_FINAL_RESERVE_S", None)
+                _rc, stdout = self._run(self._handoff(), "--dry-run")
+                self.assertEqual(
+                    json.loads(stdout)["mapped_args"].get("final_reserve_s"),
+                    expected)
 
     def test_successful_run_emits_result_and_journey(self):
         report = self.eval_dir / "final_report.md"


### PR DESCRIPTION
## Reach Finalize/Report before the wall-clock budget runs out (Hyperloom #1202)

### Problem

Three Hyperloom sessions finished their optimization work but shipped **no final report** — no
`final_report.md`, no `architect_report.md`. The orchestrator was handed a bare `recovered_no_gain`
stub instead of the run's actual results. Root-causing against `GEAK@main` found three defects, all
inside GEAK:

1. **GEAK paced against the wrong budget.** Hyperloom launches
   `run_e2e.py <handoff> <result> --timeout-s <kill_time>`, but `main()` read the budget only from
   `GEAK_E2E_TIMEOUT_S` (default `43200` = 12h). Because the positional filter was
   `args = [a for a in argv if not a.startswith("--")]`, the real `--timeout-s` **value** landed in an
   ignored third positional and was discarded. A caller killing at 8h while GEAK paced for 12h → hard
   teardown mid-optimization, before Finalize ever started.

2. **No wall-clock was reserved for the final phase, and deep mode never carved a tail.** Fast/default
   modes stop dispatching at `max(60%, budget − 3h)`, but deep set `DEEP_HEAD_BUDGET_MS = effective`
   (~92% of budget) and its wave loop tested only `DEEP_DEADLINE_HIT`, never the shared
   `TIME_DEADLINE_HIT`. After the last wave it still had to drain a 75min burst, run a final e2e gate,
   then Finalize → Report → Validate → persist — it could not fit.

3. **An in-flight optimization step could overrun whatever tail remained.** The loop-tops stop
   *starting* new work at the deadline, but a single head/kernel iteration is a *sequence* of agents
   (extract → bake-off → author → verify), each armed with the full `AGENT_TIMEOUT_MS` (2h). One long
   step legally started just before the deadline ran straight into the SIGKILL (the observed stall was a
   ~62min `extract_op` that consumed the entire tail), starving Finalize/Report/Validate.

### Fix

Everything below is gated on `time_budget_s` being present. Without it, `remainingMs()` is `Infinity`,
every guard short-circuits, and the run is **byte-identical** to a direct (non-interface) invocation —
verified by the identical-path test.

**`interface/run_e2e.py`**
- New `_resolve_timeout_s(argv)`: parses `--timeout-s N` / `--timeout-s=N`, keeps positionals intact,
  and resolves the budget as `min()` of every *stated* source (the CLI flag and `GEAK_E2E_TIMEOUT_S`),
  falling back to 12h only when neither is given. `min()` because the smaller number is a real kill, so
  pacing to it is never wrong. The resolved value is logged (`[budget] wall-clock …`) and forwarded as
  `time_budget_s` (already wired through `map_args`).
- New `GEAK_FINAL_RESERVE_S` → `final_reserve_s` passthrough so an operator can widen the reserve per
  run without editing the JS.

**`e2e_workflow/e2e_workflow.js`**
- **Elapsed clock.** `Date.now()`/`new Date()` are unavailable in Workflow scripts (they break resume),
  so elapsed time is *counted* via a self-rearming 1-minute `setTimeout` tick → `remainingMs()`.
- **One reserve, one effective budget.** `FINAL_RESERVE_MS = min(50min, 20% of budget)` is the hard
  floor held back for the *whole* final phase; `TIME_BUDGET_EFFECTIVE_MS = budget − reserve` is the
  single definition of "time available to optimize", and `TIME_HEAD_DEADLINE_MS` is hoisted so every
  mode shares it.
- **Deep obeys the same carve** (the core deep fix): `DEEP_HEAD_BUDGET_MS = TIME_HEAD_DEADLINE_MS`, and
  the wave loop is now `while (!DEEP_DEADLINE_HIT && !TIME_DEADLINE_HIT)`.
- **Option A — cap in-flight optimization agents.** Near the deadline each *optimization* agent's
  hung-guard is tightened to `max(2min, remainingMs − FINAL_RESERVE_MS)`, so no in-flight step can
  finish later than `budget − reserve`. Final-phase agents (`Finalize`/`Report`/`Validate`) are
  **exempt** — they run *inside* the reserve by design. The 2min floor lets a deadline-killed agent's
  retries self-limit instead of burning the reserve.

**Why the reserve is 50min, and why the reports survive even if it's exceeded.** Sized off 85 historical
Hyperloom runs whose final phases took p50 40min / p75 50min / p90 77min / max 86min: 50min covers ~p75.
Crucially, **Report writes both reports *before* Validate**, so a run whose tail exceeds the reserve still
ships `final_report.md` + `architect_report.md`; only the independent Validate re-measure is at risk, and
`run_e2e.py` already falls back (`director_e2e_validation.json` → best overlay's `integrate_result.json`),
so a real parity-checked win still reaches the caller.

Also fixes the stale `ci/node/run_geak_e2e.sh` comments that documented the old "flag is discarded"
behavior.

### Evidence

**Byte-identical no-budget path.** `node e2e_workflow/scripts/test_expert_skills_off_identical.js` →
`PASS`; `node --check` clean. The whole feature is inert when `time_budget_s` is absent.

**Isolated final-phase replay (synthetic no-gain state, 40min budget).** Drove `phases:"final"` on a
reconstructed pre-Report state. All four deliverables landed in ~20min as **genuine validated results**:
`workflow_return.json` → `validation_status: "validated_no_win"`, `output_parity: "pass"`, **not**
`recovered_from_disk`; `run_e2e` exited clean (`{"status":"no_gain","speedup":0.9981}`).

**Real #1202 replay.** Took an actual failed run from the fleet
(`Qwen3-0.6B/20260806…/e2e_cycle0` — a ~7h run killed before Report that originally produced *only* a
`recovered_no_gain` stub and no reports), restored its true pre-Report state, and replayed the final
phase with the fixed GEAK:

| deliverable | original failed run | fixed GEAK replay |
|---|---|---|
| `final_report.md` | ❌ absent | ✅ 32 KB, workflow-authored |
| `architect_report.md` | ❌ absent | ✅ 3.4 KB, official result |
| `final/` bundle (overlay, patch, launch, `final_result.json`) | ❌ absent | ✅ present — re-benched the pending candidate overlay and correctly **rejected** it (parity regression 2/12 prompts + sub-noise) → true no-gain |

The reports are workflow-authored (confirmed: `run_e2e.py` never writes `final_report.md` content). This
is the core #1202 outcome — the run now ships its report where before it shipped nothing. (A companion
run with a realistic reserve is confirming the full Finalize→Report→Validate path end-to-end, including
`director_e2e_validation.json` and a non-recovered `workflow_return.json`.)

### Tests

- `python3 -m unittest interface.test_run_e2e_dispatch` → **161 passed**, incl. three new cases:
  `test_timeout_budget_is_read_from_the_cli`, `test_smallest_stated_budget_wins`,
  `test_final_reserve_is_overridable_from_the_environment`.
- `node --check e2e_workflow/e2e_workflow.js` → clean.
- `node e2e_workflow/scripts/test_expert_skills_off_identical.js` → `PASS` (no-budget path unchanged).

### Compatibility / risk

- No-budget (direct) invocation is byte-identical — the entire mechanism is gated on `time_budget_s`.
- Result schema unchanged; `run_e2e.py` still passes the `validation_status` string through and only
  hard-matches `"validated_win"`, so a skipped/short Validate never demotes a real win.
- Narrows deep mode's optimization window (12h budget: ~11h → ~9h) — intentional, matching what
  fast/default already do.
