### PR TITLE
fix(kb): pack a rebind overlay's implementation, not just its manifest

### DIFF
--- a/e2e_workflow/scripts/e2e_store.py
+++ b/e2e_workflow/scripts/e2e_store.py
@@ -53,6 +53,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shutil
 import sys
 import tarfile
@@ -665,10 +666,77 @@ _ARTIFACT_KEYS = (("patch", "final_patch", "final.patch"),
 
 OVERLAY_MANIFEST = "_overlay_manifest.json"
 OVERLAY_TARBALL = "overlay.tar.gz"
+# Build/interpreter caches. Neither survives being moved to another reader's box, and both are
+# larger than the source they were derived from.
+OVERLAY_SKIP_DIRS = ("__pycache__", ".torch_ext")
 # Holds the TemporaryDirectory objects alive for the life of the process. The tarball has to still
 # be on disk when the store uploads it, which happens long after _artifact_files() returns, and a
 # TemporaryDirectory that goes out of scope deletes its tree immediately.
 _PACKED = []
+
+
+_IMPORT_RE = re.compile(r"^\s*(?:from\s+([A-Za-z_]\w*)\s+import\b|import\s+([A-Za-z_]\w*))",
+                        re.MULTILINE)
+
+
+def _sibling_imports(path: str) -> list:
+    """Top-level module names `path` imports, by source text rather than by importing it.
+
+    Reading the source is the only option here: importing an overlay module off the write path
+    would run its top-level code — which for an authored kernel means compiling Triton against
+    whatever GPU the writer happens to be on. The regex takes plain `import X` / `from X import`
+    only; a dotted or relative form is somebody else's package, not an overlay sibling.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            source = handle.read()
+    except OSError:
+        return []
+    return [a or b for a, b in _IMPORT_RE.findall(source)]
+
+
+def _rebind_modules(manifest_path: str) -> list:
+    """Every overlay-root module a `rebinds` manifest needs, transitively, deduplicated.
+
+    The manifest names only the module the rebind binds TO. That is regularly a shim: GLM-5.2's
+    `dsa_engage_c0_triton` is 1.6 KB of `from dsa_authored_c0_triton import tilelang_sparse_fwd`
+    wrapping a 23 KB authored Triton kernel, and packing the manifest's name alone shipped a
+    tarball that raises ImportError the moment sitecustomize.py runs it. So each packed module's
+    own imports are followed, and any that resolves to a sibling at the overlay root is packed
+    too. Names that resolve to nothing at the root are just ordinary third-party imports and are
+    left alone; the closure therefore terminates at the overlay boundary.
+
+    A malformed manifest returns [] rather than raising: the caller is packing a best-effort
+    artifact, and `_repro()` is the thing that decides whether what came out is enough.
+    """
+    try:
+        with open(manifest_path) as handle:
+            manifest = json.load(handle)
+    except (OSError, ValueError):
+        return []
+    root = os.path.dirname(manifest_path)
+    seen, out = set(), []
+    queue = [str((entry or {}).get("impl_module") or "") for entry in (manifest.get("rebinds") or [])]
+    while queue:
+        module = queue.pop(0).split(".")[0]
+        # A dotted name would escape the overlay root, and an absolute/relative path is not a
+        # module name at all; both are refused rather than resolved into somebody's filesystem.
+        if not module or module in seen or os.path.isabs(module) or os.sep in module:
+            continue
+        as_file, as_pkg = os.path.join(root, module + ".py"), os.path.join(root, module)
+        if not os.path.isfile(as_file) and not os.path.isdir(as_pkg):
+            continue
+        seen.add(module)
+        out.append(module)
+        if os.path.isfile(as_file):
+            queue.extend(_sibling_imports(as_file))
+        else:
+            for base, dirs, names in os.walk(as_pkg):
+                dirs[:] = [d for d in dirs if d not in OVERLAY_SKIP_DIRS]
+                for name in names:
+                    if name.endswith(".py"):
+                        queue.extend(_sibling_imports(os.path.join(base, name)))
+    return out
 
 
 def _pack_overlay(dirpath: str) -> str:
@@ -680,11 +748,22 @@ def _pack_overlay(dirpath: str) -> str:
     an overlay — the runs that cleared _repro()'s reproducibility gate were the ones that also
     happened to emit a kernel patch, and a pure-overlay win could not be recorded at all.
 
-    Only the mechanism goes in: the manifest, the sitecustomize.py that installs it, and the
-    `_patched/` modules the manifest names. An accepted-candidate directory also holds the A/B
-    evidence it was judged on (`cand/`, `ref/`, server logs, profiles) — that is how the number was
-    arrived at, not how it is reproduced, and it is several times the size of what a reader needs.
-    `__pycache__` is skipped: a .pyc is stale the moment the reader's interpreter differs.
+    Only the mechanism goes in: the manifest, the sitecustomize.py that installs it, and the code
+    the manifest names. The manifest names it two different ways and BOTH have to be packed. A
+    `modules` entry replaces a whole upstream module and points at a file under `_patched/`. A
+    `rebinds` entry leaves the module alone and swaps one symbol for `impl_module`'s — a sibling
+    package or .py file at the overlay's top level, NOT under `_patched/`. Packing only `_patched/`
+    silently produced a tarball with a manifest that rebinds to an import that is not in it: the
+    gpt-oss-120b `_fwd_kernel` win is a `rebinds` overlay whose entire HIP kernel lives in
+    `geak_hip_extend/`, and the record would have promised a reproducible run and shipped nothing
+    to reproduce it with.
+
+    An accepted-candidate directory also holds the A/B evidence it was judged on (`cand/`, `ref/`,
+    server logs, profiles) — that is how the number was arrived at, not how it is reproduced, and
+    it is several times the size of what a reader needs. `__pycache__` is skipped: a .pyc is stale
+    the moment the reader's interpreter differs. `.torch_ext/` is skipped for the same reason one
+    step further along: it is a torch cpp_extension BUILD cache (ninja logs, .o, a gfx-specific
+    .so) that the reader's own load() rebuilds from the .hip source that is packed.
 
     Everything is packed under a single `overlay/` top level so the reader can untar into the
     bundle root and get one predictable directory to point PYTHONPATH at (see _launch_text).
@@ -692,23 +771,34 @@ def _pack_overlay(dirpath: str) -> str:
     No manifest means this is not an overlay directory. Returning "" then is deliberate — the gate
     refuses the record rather than have it promise a tarball of something nobody can install.
     """
-    if not os.path.isfile(os.path.join(dirpath, OVERLAY_MANIFEST)):
+    manifest_path = os.path.join(dirpath, OVERLAY_MANIFEST)
+    if not os.path.isfile(manifest_path):
         return ""
     holder = tempfile.TemporaryDirectory(prefix="e2e_overlay_")
     _PACKED.append(holder)
     out = os.path.join(holder.name, OVERLAY_TARBALL)
-    with tarfile.open(out, "w:gz") as tar:
-        for name in (OVERLAY_MANIFEST, "sitecustomize.py"):
-            src = os.path.join(dirpath, name)
-            if os.path.isfile(src):
-                tar.add(src, arcname="overlay/" + name)
-        for root, dirs, names in os.walk(os.path.join(dirpath, "_patched")):
-            dirs[:] = [d for d in dirs if d != "__pycache__"]
+
+    def _add_tree(tar, root_dir):
+        for root, dirs, names in os.walk(root_dir):
+            dirs[:] = [d for d in dirs if d not in OVERLAY_SKIP_DIRS]
             for name in names:
                 if name.endswith(".pyc"):
                     continue
                 src = os.path.join(root, name)
                 tar.add(src, arcname="overlay/" + os.path.relpath(src, dirpath))
+
+    with tarfile.open(out, "w:gz") as tar:
+        for name in (OVERLAY_MANIFEST, "sitecustomize.py"):
+            src = os.path.join(dirpath, name)
+            if os.path.isfile(src):
+                tar.add(src, arcname="overlay/" + name)
+        _add_tree(tar, os.path.join(dirpath, "_patched"))
+        for module in _rebind_modules(manifest_path):
+            pkg = os.path.join(dirpath, module)
+            if os.path.isdir(pkg):
+                _add_tree(tar, pkg)
+            elif os.path.isfile(pkg + ".py"):
+                tar.add(pkg + ".py", arcname="overlay/" + module + ".py")
     return out
 
 

--- a/e2e_workflow/scripts/e2e_store.py
+++ b/e2e_workflow/scripts/e2e_store.py
@@ -695,32 +695,44 @@ def _sibling_imports(path: str) -> list:
     return [a or b for a, b in _IMPORT_RE.findall(source)]
 
 
-def _rebind_modules(manifest_path: str) -> list:
-    """Every overlay-root module a `rebinds` manifest needs, transitively, deduplicated.
+def _overlay_modules(manifest_path: str) -> list:
+    """Every overlay-root module the mechanism needs, transitively, deduplicated.
 
-    The manifest names only the module the rebind binds TO. That is regularly a shim: GLM-5.2's
-    `dsa_engage_c0_triton` is 1.6 KB of `from dsa_authored_c0_triton import tilelang_sparse_fwd`
-    wrapping a 23 KB authored Triton kernel, and packing the manifest's name alone shipped a
-    tarball that raises ImportError the moment sitecustomize.py runs it. So each packed module's
-    own imports are followed, and any that resolves to a sibling at the overlay root is packed
-    too. Names that resolve to nothing at the root are just ordinary third-party imports and are
-    left alone; the closure therefore terminates at the overlay boundary.
+    Two roots, because the overlay has two entry points. The manifest names the module each
+    rebind binds TO, and sitecustomize.py is the code that installs them — an overlay that
+    captures shapes or traces a seam does that work in siblings sitecustomize.py imports
+    directly, with no manifest entry naming them at all.
 
-    A malformed manifest returns [] rather than raising: the caller is packing a best-effort
-    artifact, and `_repro()` is the thing that decides whether what came out is enough.
+    Neither root is the whole story on its own, because what they name is regularly a shim:
+    GLM-5.2's `dsa_engage_c0_triton` is 1.6 KB of `from dsa_authored_c0_triton import
+    tilelang_sparse_fwd` wrapping a 23 KB authored Triton kernel, and packing the manifest's
+    name alone shipped a tarball that raises ImportError the moment sitecustomize.py runs it.
+    So each packed module's own imports are followed, and any that resolves to a sibling at the
+    overlay root is packed too. Names that resolve to nothing at the root are just ordinary
+    third-party imports and are left alone; the closure therefore terminates at the overlay
+    boundary.
+
+    A malformed manifest still yields sitecustomize.py's side of the closure rather than
+    raising: the caller is packing a best-effort artifact, and `_repro()` is the thing that
+    decides whether what came out is enough.
     """
+    root = os.path.dirname(manifest_path)
     try:
         with open(manifest_path) as handle:
             manifest = json.load(handle)
     except (OSError, ValueError):
-        return []
-    root = os.path.dirname(manifest_path)
+        manifest = {}
+    if not isinstance(manifest, dict):
+        manifest = {}
     seen, out = set(), []
     queue = [str((entry or {}).get("impl_module") or "") for entry in (manifest.get("rebinds") or [])]
+    queue.extend(_sibling_imports(os.path.join(root, "sitecustomize.py")))
     while queue:
+        # A submodule rebind (`geak_authored.gemm_flydsl`) is addressed by its top-level package,
+        # which is what sits at the overlay root and what has to be packed. An absolute or
+        # separator-bearing name is not a module name at all and is refused rather than resolved
+        # into somebody's filesystem.
         module = queue.pop(0).split(".")[0]
-        # A dotted name would escape the overlay root, and an absolute/relative path is not a
-        # module name at all; both are refused rather than resolved into somebody's filesystem.
         if not module or module in seen or os.path.isabs(module) or os.sep in module:
             continue
         as_file, as_pkg = os.path.join(root, module + ".py"), os.path.join(root, module)
@@ -793,7 +805,7 @@ def _pack_overlay(dirpath: str) -> str:
             if os.path.isfile(src):
                 tar.add(src, arcname="overlay/" + name)
         _add_tree(tar, os.path.join(dirpath, "_patched"))
-        for module in _rebind_modules(manifest_path):
+        for module in _overlay_modules(manifest_path):
             pkg = os.path.join(dirpath, module)
             if os.path.isdir(pkg):
                 _add_tree(tar, pkg)

--- a/e2e_workflow/scripts/tests/test_e2e_store.py
+++ b/e2e_workflow/scripts/tests/test_e2e_store.py
@@ -635,3 +635,76 @@ def test_compiled_bytecode_is_left_out_of_the_bundle(tmp_path):
         names = tar.getnames()
     assert not any(n.endswith(".pyc") for n in names)
     assert not any("__pycache__" in n for n in names)
+
+
+def _rebind_overlay(tmp_path, impl="engage"):
+    """A `rebinds` overlay: the implementation is a sibling at the root, not under `_patched/`."""
+    d = tmp_path / "overlay"
+    d.mkdir()
+    (d / e2e_store.OVERLAY_MANIFEST).write_text(json.dumps(
+        {"modules": [], "rebinds": [{"target": "vllm.attn:fwd", "impl_module": impl,
+                                     "impl_attr": "fwd"}]}))
+    (d / "sitecustomize.py").write_text("# hook\n")
+    return d
+
+
+def test_a_rebind_ships_the_module_it_binds_to(tmp_path):
+    """Packing only `_patched/` gave a manifest that rebinds to an import the tarball lacks."""
+    import tarfile
+    d = _rebind_overlay(tmp_path)
+    (d / "engage.py").write_text("def fwd(): pass\n")
+    with tarfile.open(e2e_store._pack_overlay(str(d)), "r:gz") as tar:
+        names = tar.getnames()
+    assert "overlay/engage.py" in names
+
+
+def test_a_rebind_through_a_shim_ships_the_kernel_behind_it(tmp_path):
+    """The manifest's module is regularly 1 KB re-exporting the real kernel from a sibling."""
+    import tarfile
+    d = _rebind_overlay(tmp_path)
+    (d / "engage.py").write_text("from authored import fwd\n")
+    (d / "authored.py").write_text("import triton\n\ndef fwd(): pass\n")
+    with tarfile.open(e2e_store._pack_overlay(str(d)), "r:gz") as tar:
+        names = tar.getnames()
+    assert "overlay/authored.py" in names, "the shim shipped without the kernel behind it"
+    assert not any("triton" in n for n in names), "a third-party import is not an overlay sibling"
+
+
+def test_a_submodule_rebind_ships_its_package(tmp_path):
+    """`geak_authored.gemm_flydsl` is addressed by the package that sits at the overlay root."""
+    import tarfile
+    d = _rebind_overlay(tmp_path, impl="geak_authored.gemm")
+    (d / "geak_authored").mkdir()
+    (d / "geak_authored" / "__init__.py").write_text("")
+    (d / "geak_authored" / "gemm.py").write_text("def fwd(): pass\n")
+    with tarfile.open(e2e_store._pack_overlay(str(d)), "r:gz") as tar:
+        names = tar.getnames()
+    assert "overlay/geak_authored/__init__.py" in names
+    assert "overlay/geak_authored/gemm.py" in names
+
+
+def test_sitecustomize_siblings_travel_with_it(tmp_path):
+    """A capture or trace overlay names its helpers nowhere but in sitecustomize.py's imports."""
+    import tarfile
+    d = _rebind_overlay(tmp_path)
+    (d / "engage.py").write_text("def fwd(): pass\n")
+    (d / "sitecustomize.py").write_text("import os\ntry:\n    import capture_shapes\n"
+                                        "except Exception:\n    pass\n")
+    (d / "capture_shapes.py").write_text("SHAPES = []\n")
+    with tarfile.open(e2e_store._pack_overlay(str(d)), "r:gz") as tar:
+        names = tar.getnames()
+    assert "overlay/capture_shapes.py" in names
+
+
+def test_a_module_name_that_could_escape_the_root_is_refused(tmp_path):
+    """`impl_module` is a module name; anything path-shaped is not resolved into the filesystem."""
+    import tarfile
+    d = tmp_path / "overlay"
+    d.mkdir()
+    (d / e2e_store.OVERLAY_MANIFEST).write_text(json.dumps(
+        {"rebinds": [{"impl_module": "/etc/passwd"}, {"impl_module": "../escape"},
+                     {"impl_module": "a/b"}]}))
+    (d / "sitecustomize.py").write_text("# hook\n")
+    with tarfile.open(e2e_store._pack_overlay(str(d)), "r:gz") as tar:
+        names = tar.getnames()
+    assert names == ["overlay/" + e2e_store.OVERLAY_MANIFEST, "overlay/sitecustomize.py"]


### PR DESCRIPTION
## What breaks today

`_pack_overlay` carries the manifest, `sitecustomize.py`, and the `_patched/` tree. That is the
whole overlay only for a **patch-style** rebind, where the replacement module *is* the `_patched/`
copy.

A **`rebinds`** overlay leaves the upstream module alone and swaps one symbol for
`impl_module`'s. That module sits at the overlay **root**, not under `_patched/`, so nothing
matched it and the tarball shipped a manifest pointing at a file that was not in the archive.
Unpack it, put it on `PYTHONPATH`, and `sitecustomize.py` raises `ImportError` on the first line
that matters.

Measured on the DeepSeek-V4-Pro authored sparse-MLA decode win (2.311x isolated, +4.141% e2e):

```
$ git show origin/main:e2e_workflow/scripts/e2e_store.py   # _pack_overlay on the winning overlay
overlay/_overlay_manifest.json
overlay/sitecustomize.py
```

Two entries, both metadata. The 30 KB kernel, its seam, and the retuned prefill launcher were all
absent — the record promised a reproducible run and shipped nothing to reproduce it with.

## Why naming the manifest's module is not enough

That module is regularly a shim:

- GLM-5.2's `dsa_engage_c0_triton` is 1.6 KB of `from dsa_authored_c0_triton import
  tilelang_sparse_fwd` wrapping a 23 KB authored Triton kernel.
- gpt-oss-120b's `_fwd_kernel` win keeps its entire HIP source in `geak_hip_extend/`.

So `_overlay_modules` walks the **transitive closure** from each `rebinds[*].impl_module`, and
`_sibling_imports` reads that closure out of the source **text** with a regex rather than by
importing the module. Importing an overlay module on the write path would run its top level, which
for an authored kernel means compiling Triton against whatever GPU the writer happens to be
sitting on.

A name that resolves to nothing at the overlay root is an ordinary third-party import and is left
alone, so the closure terminates at the overlay boundary. A submodule rebind
(`geak_authored.gemm_flydsl`) is addressed by its top-level package, which is what sits at the
root. Names that are absolute or carry a path separator are refused rather than resolved into
somebody's filesystem.

## Second commit: the other entry point

Seeding the closure from the manifest alone left `sitecustomize.py` out. An overlay that captures
shapes or traces a seam does that work in siblings `sitecustomize.py` imports **directly**, with
no manifest entry naming them — the sparse-MLA capture overlays import `capture_shapes` and
`seam_trace`, and both were missing from the tarball while the hook that imports them was in it.
Both roots now seed the same walk.

The second commit also corrects a comment that claimed a dotted `impl_module` is refused. The code
splits on the first dot before that check, so it never was; what is actually refused is an
absolute or separator-bearing name.

## Verification

Swept `_pack_overlay` old-vs-new across the **42 overlay directories** of the `hl_matrix_0824`
matrix (31 `rebinds`, 11 patch-style):

| | |
|---|---|
| rebinds overlays incomplete under the current packer | **31 / 31** |
| files now carried that were previously dropped | **52** |
| overlays that lost a file (regression check `old ⊆ new`) | **0** |
| packed modules left importing a sibling absent from the archive | **0** |

The last row is an independent closure check — it re-derives each tarball's import graph from the
source and asserts every sibling-resolvable name is present, rather than trusting the packer's own
notion of the closure.

Representative gains: `overlay_c0_triton` 2 → 5 entries (`hl_sparse_decode.py`,
`hl_sparse_decode_seam.py`, `hl_prefill_ragged_tuned.py`); `overlay_c1_flydsl` picks up the whole
`geak_authored/` package; the llama-3.1-8B tuning overlays pick up `geak_fp8_rowwise.py`.

Tests: the three existing `_pack_overlay` tests still pass, plus five new ones covering the plain
rebind, the shim indirection, a submodule rebind, `sitecustomize.py`'s siblings, and the escape
refusal. **All four positive new tests fail against `origin/main`'s packer** (verified by swapping
the implementation under the test module).

