### PR TITLE
Align every GEAK benchmark on the Hyperloom warm-server protocol

### DIFF
--- a/.github/workflows/ci-l0-checks.yml
+++ b/.github/workflows/ci-l0-checks.yml
@@ -123,6 +123,8 @@ jobs:
             kernel_workflow/scripts/tests/test_kb_loop_offline.py \
             interface/test_effective_config.py \
             e2e_workflow/scripts/tests/test_bench_replica_lifecycle.py \
+            e2e_workflow/scripts/tests/test_bench_summarize.py \
+            e2e_workflow/scripts/tests/test_inferencex_client_warmup_parity.py \
             e2e_workflow/scripts/tests/test_roofline_skill.py \
             e2e_workflow/scripts/tests/test_vllm_adapter_profiler_config.py \
             geak/test_bootstrap.py

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -90,14 +90,19 @@ Related timing/tuning args: `fast_head_deadline_ms`, `fast_head_workflow_ms`, `d
 |---|---|---|
 | `accuracy_gate` | `none` | `none` \| `gsm8k`. For quantized kernels, switch the bar to task accuracy. |
 | `accuracy_limit` | `200` | Number of gsm8k questions. |
-| `accuracy_tol` | `0.03` | Allowed exact-match drop (`cand_em >= baseline_em - tol`); sized to the sampling noise at `accuracy_limit=200`. |
-| `accuracy_floor` | `0.5` | Absolute exact-match both legs must clear, so a broken baseline cannot pass an equally broken candidate. |
+| `accuracy_tol` | `0.01` | Allowed exact-match drop (`cand_em >= baseline_em - tol`). |
 
 ### Measurement and misc args
 
 | Arg | Default | Description |
 |---|---|---|
 | `noise_band_pct` | `0.5` | e2e acceptance band (%). |
+| `measurement_mode` | `warm_server` | Lifecycle behind EVERY throughput number. `warm_server` = boot one server per leg, discard a full warmup round, time the next round (Hyperloom's protocol). `isolated_server` = one fresh server per sample, for when boot-to-boot variance is what must be gated on. |
+| `search_replicas`, `parity_replicas` | `1` | Timed samples per leg for search / parity legs. |
+| `validation_measurement_mode` | `warm_server` | Lifecycle for the final re-measure; set to `isolated_server` to make validation stricter than the search that fed it. |
+| `validation_rounds` | `1` | Timed rounds per leg when validation is `warm_server`. |
+| `validation_replicas` | `3` | Fresh-server samples per leg when validation is `isolated_server`. |
+| `validation_tight_s` | `1500` | If less than this much wall-clock remains entering Validate, drop to one timed sample per leg rather than shipping no validated number. |
 | `ab_finish_retries` | `3` | A/B leg completion retries. |
 | `use_expert_skills` | `false` | Consult `perf_knowledge/expert_skills` (advisory priors). OFF = byte-identical. |
 | `perf_knowledge_dir` | sibling `perf_knowledge/` | Authoring knowledge base. |
@@ -105,6 +110,17 @@ Related timing/tuning args: `fast_head_deadline_ms`, `fast_head_workflow_ms`, `d
 | `warm_start`, `warm_start_match`, `warm_start_min_speedup`, `kb_mode`, `kb_store_dir`, `kb_framework_version` | see the kernel-layer table | Forwarded verbatim to the kernel lanes. Corrective re-authors are forced to `reference` (they must keep the isolated win). |
 | `time_budget_s`, `initial_extra_server_args`, `initial_extra_env`, `tracelens`, `agent_timeout_ms` | — | Forwarded from the external orchestrator. |
 | `final_reserve_s` | `3000` (50min), capped at 20% of `time_budget_s` | Hard floor of wall-clock held back for the whole final phase — Finalize + Report + Validate + the `workflow_return.json` write; no mode starts new work inside it, and each optimization agent's hung-guard is tightened so no in-flight step finishes later than `time_budget_s − reserve` (final-phase agents are exempt). Sized off 85 historical runs (p50 40min, p75 50min, p90 77min, max 86min): 50min covers ~p75, and since Report writes both reports before Validate, a longer tail still ships them (only the Validate re-measure is at risk, and `run_e2e.py` falls back). The 20% cap stops the floor from eating a short budget whole; at budgets ≥5h it never binds. Env override: `GEAK_FINAL_RESERVE_S`. |
+
+> **Throughput numbers are comparable only within one lifecycle.** A `warm_server` round runs against a
+> server that has already served a full round, so for the same config it differs from the cold-cache
+> `isolated_server` number by an amount whose sign and size are not predictable from the config alone:
+> it rises with prefix-cache reuse, and a workload with little shared prefix can land either way
+> (measured on DeepSeek-V4-Pro TP8, `RANDOM_RANGE_RATIO=1.0` / ISL 8192: warm 826.9 vs isolated median
+> 833.3 tok/s). Both legs of any ratio must come from the same mode, and a number produced here
+> must not be compared against a record written before `warm_server` became the default (KB entries,
+> older reports) — re-measure the reference instead. `bench_summary.json.measurement_mode` records
+> which lifecycle produced any given number. With a single timed sample, `spread` is `0.0%` by
+> construction: that is an absence of dispersion evidence, not a quiet box.
 
 ### Example
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -90,14 +90,14 @@ Related timing/tuning args: `fast_head_deadline_ms`, `fast_head_workflow_ms`, `d
 |---|---|---|
 | `accuracy_gate` | `none` | `none` \| `gsm8k`. For quantized kernels, switch the bar to task accuracy. |
 | `accuracy_limit` | `200` | Number of gsm8k questions. |
-| `accuracy_tol` | `0.01` | Allowed exact-match drop (`cand_em >= baseline_em - tol`). |
+| `accuracy_tol` | `0.03` | Allowed exact-match drop (`cand_em >= baseline_em - tol`); sized to the sampling noise at `accuracy_limit=200`. |
+| `accuracy_floor` | `0.5` | Absolute exact-match both legs must clear, so a broken baseline cannot pass an equally broken candidate. |
 
 ### Measurement and misc args
 
 | Arg | Default | Description |
 |---|---|---|
 | `noise_band_pct` | `0.5` | e2e acceptance band (%). |
-| `e2e_repeats` | `2` | Repeats per timed measurement. |
 | `ab_finish_retries` | `3` | A/B leg completion retries. |
 | `use_expert_skills` | `false` | Consult `perf_knowledge/expert_skills` (advisory priors). OFF = byte-identical. |
 | `perf_knowledge_dir` | sibling `perf_knowledge/` | Authoring knowledge base. |

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -100,9 +100,7 @@ Related timing/tuning args: `fast_head_deadline_ms`, `fast_head_workflow_ms`, `d
 | `measurement_mode` | `warm_server` | Lifecycle behind EVERY throughput number. `warm_server` = boot one server per leg, discard a full warmup round, time the next round (Hyperloom's protocol). `isolated_server` = one fresh server per sample, for when boot-to-boot variance is what must be gated on. |
 | `search_replicas`, `parity_replicas` | `1` | Timed samples per leg for search / parity legs. |
 | `validation_measurement_mode` | `warm_server` | Lifecycle for the final re-measure; set to `isolated_server` to make validation stricter than the search that fed it. |
-| `validation_rounds` | `1` | Timed rounds per leg when validation is `warm_server`. |
-| `validation_replicas` | `3` | Fresh-server samples per leg when validation is `isolated_server`. |
-| `validation_tight_s` | `1500` | If less than this much wall-clock remains entering Validate, drop to one timed sample per leg rather than shipping no validated number. |
+| `validation_replicas` | `3` | Fresh-server samples per leg when validation is `isolated_server`. Ignored under `warm_server`, which is one timed round per leg by definition. |
 | `ab_finish_retries` | `3` | A/B leg completion retries. |
 | `use_expert_skills` | `false` | Consult `perf_knowledge/expert_skills` (advisory priors). OFF = byte-identical. |
 | `perf_knowledge_dir` | sibling `perf_knowledge/` | Authoring knowledge base. |
@@ -111,16 +109,10 @@ Related timing/tuning args: `fast_head_deadline_ms`, `fast_head_workflow_ms`, `d
 | `time_budget_s`, `initial_extra_server_args`, `initial_extra_env`, `tracelens`, `agent_timeout_ms` | — | Forwarded from the external orchestrator. |
 | `final_reserve_s` | `3000` (50min), capped at 20% of `time_budget_s` | Hard floor of wall-clock held back for the whole final phase — Finalize + Report + Validate + the `workflow_return.json` write; no mode starts new work inside it, and each optimization agent's hung-guard is tightened so no in-flight step finishes later than `time_budget_s − reserve` (final-phase agents are exempt). Sized off 85 historical runs (p50 40min, p75 50min, p90 77min, max 86min): 50min covers ~p75, and since Report writes both reports before Validate, a longer tail still ships them (only the Validate re-measure is at risk, and `run_e2e.py` falls back). The 20% cap stops the floor from eating a short budget whole; at budgets ≥5h it never binds. Env override: `GEAK_FINAL_RESERVE_S`. |
 
-> **Throughput numbers are comparable only within one lifecycle.** A `warm_server` round runs against a
-> server that has already served a full round, so for the same config it differs from the cold-cache
-> `isolated_server` number by an amount whose sign and size are not predictable from the config alone:
-> it rises with prefix-cache reuse, and a workload with little shared prefix can land either way
-> (measured on DeepSeek-V4-Pro TP8, `RANDOM_RANGE_RATIO=1.0` / ISL 8192: warm 826.9 vs isolated median
-> 833.3 tok/s). Both legs of any ratio must come from the same mode, and a number produced here
-> must not be compared against a record written before `warm_server` became the default (KB entries,
-> older reports) — re-measure the reference instead. `bench_summary.json.measurement_mode` records
-> which lifecycle produced any given number. With a single timed sample, `spread` is `0.0%` by
-> construction: that is an absence of dispersion evidence, not a quiet box.
+> **Throughput numbers are comparable only within one lifecycle**, and both legs of any ratio must
+> come from the same one. `bench_summary.json.measurement_mode` records which produced a given number;
+> the full rule, with the measured evidence for it, is in the header of
+> `e2e_workflow/scripts/bench_e2e.sh`.
 
 ### Example
 

--- a/e2e_workflow/PLAN.md
+++ b/e2e_workflow/PLAN.md
@@ -41,11 +41,12 @@ Finalize → Report → Validate`.
 
 - **Budget** = number of kernel-optimization tasks (config sweep is free). `noImprove<2` early-stop.
 - Each accepted change compounds into the carried-forward overlay + config.
-- Throughput measured warm, repeated, median, vs TRUE baseline; every kernel gated on e2e delta >
+- Throughput measured warm, same lifecycle as the TRUE baseline; every kernel gated on e2e delta >
   noise band AND output parity.
 
 ## Measurement discipline
-Warm server always; ≥3 repeats, median + spread; profile and bench share ISL/OSL/conc; output parity
+Warm server always; one discarded warmup round then one timed round (`warm_server`), extra samples
+only when a dispersion estimate is needed; profile and bench share ISL/OSL/conc; output parity
 (greedy/temp=0, fixed seed) on every numeric-changing step; accept only deltas above the noise band.
 
 ## Build status

--- a/e2e_workflow/README.md
+++ b/e2e_workflow/README.md
@@ -242,12 +242,16 @@ By default the e2e gate accepts a kernel on **throughput delta + greedy output p
 kernel rounds differently and flips a few borderline greedy argmaxes — so you can switch the bar to
 **task accuracy**:
 ```
-args: { ...same..., accuracy_gate:"gsm8k", accuracy_limit:200, accuracy_tol:0.01 }
+args: { ...same..., accuracy_gate:"gsm8k", accuracy_limit:200, accuracy_tol:0.03, accuracy_floor:0.5 }
 ```
 - `accuracy_gate:"gsm8k"` → the Integrator serves a fresh TRUE baseline vs the candidate, runs sampled
-  gsm8k (5-shot, greedy, fixed seed), and accepts iff `cand_em >= baseline_em - accuracy_tol`.
+  gsm8k (5-shot, greedy, fixed seed), and accepts iff both legs clear `accuracy_floor` AND
+  `cand_em >= baseline_em - accuracy_tol`.
 - `accuracy_limit` = #questions (default **200**; deep uses a larger sample at finalize to de-noise the
-  boundary). `accuracy_tol` = allowed exact-match drop (default **0.01**).
+  boundary). `accuracy_tol` = allowed exact-match drop (default **0.03**, sized to the sampling noise
+  at n=200 — a tighter bar rejects kernels whose quality has not moved). `accuracy_floor` = absolute
+  score both legs must clear (default **0.5**), so a broken baseline cannot wave through an equally
+  broken candidate.
 - The eval client is `scripts/gsm8k_eval.py` (model-agnostic; queries the OpenAI-compatible endpoint).
 - Leaving it unset (`"none"`) changes nothing vs before — the gate stays throughput + parity only.
 

--- a/e2e_workflow/README.md
+++ b/e2e_workflow/README.md
@@ -52,12 +52,12 @@ rigid script): it confirms the chosen `backend` stack, the model, GPU visibility
 sources, available op backends, and the model's arch class; degrades gracefully and writes
 `env_report.{md,json}` that every later phase routes on.
 Every accepted change compounds into the carried-forward overlay + config; throughput is always
-measured warm, repeated, median, vs the TRUE baseline.
+measured on a warm server, in the same lifecycle as the TRUE baseline it is compared against.
 
 ## Pluggable serving backend
 The serving stack is NOT baked in. `args.backend` (sglang|vllm, default sglang) selects
 `scripts/adapters/<backend>.sh`, which `scripts/bench_e2e.sh` (a backend-agnostic dispatcher: owns
-server lifecycle, warmup, repeats, median+spread summary, free-port allocation) sources. Adding a new
+server lifecycle, warmup, timed round(s), summary, free-port allocation) sources. Adding a new
 stack = adding one adapter that defines `adapter_launch / adapter_health / adapter_bench`
 (+ optional `adapter_default_port`). No role or orchestration change. `MODEL` is **required** — there
 is no rig-specific default that could silently bench the wrong target.
@@ -242,16 +242,12 @@ By default the e2e gate accepts a kernel on **throughput delta + greedy output p
 kernel rounds differently and flips a few borderline greedy argmaxes — so you can switch the bar to
 **task accuracy**:
 ```
-args: { ...same..., accuracy_gate:"gsm8k", accuracy_limit:200, accuracy_tol:0.03, accuracy_floor:0.5 }
+args: { ...same..., accuracy_gate:"gsm8k", accuracy_limit:200, accuracy_tol:0.01 }
 ```
 - `accuracy_gate:"gsm8k"` → the Integrator serves a fresh TRUE baseline vs the candidate, runs sampled
-  gsm8k (5-shot, greedy, fixed seed), and accepts iff both legs clear `accuracy_floor` AND
-  `cand_em >= baseline_em - accuracy_tol`.
+  gsm8k (5-shot, greedy, fixed seed), and accepts iff `cand_em >= baseline_em - accuracy_tol`.
 - `accuracy_limit` = #questions (default **200**; deep uses a larger sample at finalize to de-noise the
-  boundary). `accuracy_tol` = allowed exact-match drop (default **0.03**, sized to the sampling noise
-  at n=200 — a tighter bar rejects kernels whose quality has not moved). `accuracy_floor` = absolute
-  score both legs must clear (default **0.5**), so a broken baseline cannot wave through an equally
-  broken candidate.
+  boundary). `accuracy_tol` = allowed exact-match drop (default **0.01**).
 - The eval client is `scripts/gsm8k_eval.py` (model-agnostic; queries the OpenAI-compatible endpoint).
 - Leaving it unset (`"none"`) changes nothing vs before — the gate stays throughput + parity only.
 

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -406,9 +406,21 @@ const DEEP_FINAL_ACCURACY_LIMIT = parseInt(A.deep_final_accuracy_limit != null ?
 // (over-strict) byte-parity. Default 'none' => unchanged byte/greedy parity (normal/fast untouched).
 const ACCURACY_GATE = String(A.accuracy_gate || 'none').trim();          // 'none' | 'gsm8k'
 const ACCURACY_LIMIT = parseInt(A.accuracy_limit != null ? A.accuracy_limit : 200, 10); // sampled gsm8k subset size
-const ACCURACY_TOL = parseFloat(A.accuracy_tol != null ? A.accuracy_tol : 0.01);        // allowed absolute exact_match drop vs baseline
+// Allowed absolute exact_match drop. Set BY the sample size: both legs answer the same seed-pinned
+// subset at temp=0, so the noise scale is the DISCORDANT pairs, sd(delta)=sqrt(d)/n ~= 1.6pt at
+// n=200 / 5% discordance. The old 0.01 sat at 0.6 sd and so rejected ~1 in 4 kernels whose quality
+// had not moved -- the very over-rejection this gate replaces byte-parity to avoid. 0.03 is ~1.9 sd
+// and still tighter than Hyperloom's 0.05; broken quant drops 20-90 points, not 3.
+// To tighten it, do NOT raise accuracy_limit (n=500 buys sd ~1.0pt for 2.5x the eval time) -- use a
+// paired McNemar test over the per-question `ok` flags gsm8k_eval.py already writes, which is free.
+const ACCURACY_TOL = parseFloat(A.accuracy_tol != null ? A.accuracy_tol : 0.03);
+// Absolute floor on BOTH legs. A purely relative gate is blind when the BASELINE is broken: an
+// equally broken candidate passes. Hyperloom's floor is 0.5 after a run kept a 0.00076 candidate;
+// healthy gsm8k baselines land >= 0.63 and the broken ones scored 0.196 and 0.000.
+const ACCURACY_FLOOR = parseFloat(A.accuracy_floor != null ? A.accuracy_floor : 0.5);
 const ACCURACY_INPUTS = (ACCURACY_GATE !== 'none')
-  ? { ACCURACY_GATE, ACCURACY_LIMIT, ACCURACY_TOL, GSM8K_EVAL_SCRIPT: `${WORKFLOW_DIR}/scripts/gsm8k_eval.py` }
+  ? { ACCURACY_GATE, ACCURACY_LIMIT, ACCURACY_TOL, ACCURACY_FLOOR,
+      GSM8K_EVAL_SCRIPT: `${WORKFLOW_DIR}/scripts/gsm8k_eval.py` }
   : {};
 // The AMD authoring knowledge base (REFERENCE ONLY — facts/how-to, never decisions; agents always
 // measure). Default: sibling perf_knowledge/. Workflows enumerate candidates from
@@ -574,13 +586,28 @@ const INIT_ENV = String(A.initial_extra_env || '');
 // every later candidate overlay instead of being dropped at Setup.
 const INIT_BASE_OVERLAY = String(A.initial_overlay_pythonpath || '');
 const EFFECTIVE_CONFIG_DIGEST = String(A.effective_config_digest || '');
-// Throughput measurements use independent server replicas.  Search/parity use
-// one Hyperloom-equivalent replica; final validation uses three replicas to
-// estimate variance.  The bench dispatcher owns retry/degraded aggregation.
-const MEASUREMENT_MODE = String(A.measurement_mode || 'isolated_server');
+// One lifecycle for EVERY throughput number (baseline, search A/B, parity, validation), because
+// a cache-cold search number and a cache-warm validation number are not comparable and the gains
+// carried between phases used to mix the two. warm_server = Hyperloom's protocol: one server per
+// leg, round 1 a full warmup that is discarded, round 2 IS the number.
+// isolated_server (REPLICAS fresh servers per leg) stays available when boot-to-boot variance is
+// what must be gated on. The bench dispatcher owns retry/degraded aggregation in both modes.
+const MEASUREMENT_MODE = String(A.measurement_mode || 'warm_server');
 const PARITY_REPLICAS = parseInt(A.parity_replicas != null ? A.parity_replicas : 1, 10);
 const SEARCH_REPLICAS = parseInt(A.search_replicas != null ? A.search_replicas : 1, 10);
 const VALIDATION_REPLICAS = parseInt(A.validation_replicas != null ? A.validation_replicas : 3, 10);
+// Validation keeps its OWN knob so an operator can make the final re-measure stricter than the
+// search that fed it (isolated_server + validation_replicas=3 buys the boot-to-boot dispersion
+// test). Default is warm_server like everything else, which is what the orchestrator rebenches
+// against — and the cheap one: isolated validation is 6-12 cold boots serialized behind the
+// serving-GPU flock, enough to overrun FINAL_RESERVE_MS and ship no validated number at all.
+const VALIDATION_MEASUREMENT_MODE = String(A.validation_measurement_mode || 'warm_server');
+const VALIDATION_ROUNDS = parseInt(A.validation_rounds != null ? A.validation_rounds : 1, 10);
+const VALIDATION_SAMPLES = VALIDATION_MEASUREMENT_MODE === 'warm_server'
+  ? VALIDATION_ROUNDS : VALIDATION_REPLICAS;
+// Too little clock left for a multi-sample re-measure: fall back to one timed round per leg. The
+// ratio stays drift-corrected, only the dispersion test is lost, and one number beats no number.
+const VALIDATION_TIGHT_MS = parseInt(A.validation_tight_s != null ? A.validation_tight_s : 1500, 10) * 1000;
 // CUDA/HIP-graph deployment requirement (general; derived from the serving config, NOT hardcoded).
 // vllm/sglang capture the steady-state decode path into a FULL CUDA graph UNLESS --enforce-eager is set.
 // A kernel that wins only via its OWN per-call graph-capture+replay wrapper falls back to eager inside the
@@ -604,9 +631,8 @@ const GRAPH_REQ = CUDA_GRAPH_DEPLOY ? (
 // Acceptance noise band (%). Isolated-server ref/candidate measurements, non-overlap, and engagement
 // proof (see e2e_integrator) make a 0.5% default trustworthy. Prompt-tunable.
 const NOISE_BAND_DEFAULT = parseFloat(A.noise_band_pct != null ? A.noise_band_pct : 0.5);
-// Legacy timed-repeat input retained for callers that explicitly select the legacy protocol.
-// Isolated-server runs use the purpose-specific replica counts above.
-const E2E_REPEATS = parseInt(A.e2e_repeats != null ? A.e2e_repeats : 2, 10);
+// No timed-repeat knob on purpose: the round count belongs to the lifecycle (bench_e2e.sh derives
+// it from GEAK_REPEAT_MODE + MEASUREMENT_PURPOSE), so a second knob could only disagree with it.
 // Every integrate A/B MUST measure BOTH legs (reference + candidate). When the
 // integrator returns gate:'incomplete'/ab_complete:false (it only ran ref, hung,
 // or degraded), the orchestrator RE-INVOKES it to finish the missing leg up to
@@ -2283,7 +2309,7 @@ if (want('setup')) {
           roleAgent('config_tuner', 'sweep', brief,
             {
               EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, BASELINE_THROUGHPUT: BASELINE_TPUT,
-              NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
+              NOISE_BAND_PCT: NOISE_BAND,
               CONFIG_DIRECTIONS: [{
                 rank: 1,
                 direction: 'kb_warm_start:' + (c.direction || 'unlabeled'),
@@ -2517,7 +2543,7 @@ if (want('setup')) {
         if (viaOverlay) overlayReplayed.add(k.bundle);
         const isolated = Number(k.isolated_speedup) || 0;
         const kbIntegrateInputs = {
-          EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
+          EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, NOISE_BAND_PCT: NOISE_BAND,
           KERNEL_RESULT: {
             short_name: k.name, winner_kind: kind,
             // Both spellings, because the two tracks read different ones and this synthetic result
@@ -2933,7 +2959,7 @@ if (want('config') && CONFIG_TUNE_ENABLED && strategy && (strategy.config_direct
   const sweep = await safeAgent(
     roleAgent('config_tuner', 'sweep', 'Sweep the ranked config axes one at a time; keep wins.', {
       EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, BASELINE_THROUGHPUT: BASELINE_TPUT,
-      NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS, CONFIG_DIRECTIONS: strategy.config_directions,
+      NOISE_BAND_PCT: NOISE_BAND, CONFIG_DIRECTIONS: strategy.config_directions,
       CURRENT_FLAGS: curFlags, CURRENT_ENV: curEnv, CURRENT_OVERLAY: curOverlay,
       MEASUREMENT_PURPOSE: 'search', REPLICAS: SEARCH_REPLICAS,
       SKILL_DIR: WORKFLOW_DIR, ...KB_REF_INPUTS,
@@ -3026,7 +3052,7 @@ if (want('tune') && TUNING_SKILLSET_ENABLED) {
       BASELINE_THROUGHPUT: BASELINE_TPUT, CURRENT_THROUGHPUT: curTput,
       CURRENT_FLAGS: curFlags, CURRENT_ENV: curEnv, CURRENT_OVERLAY: curOverlay,
       MEASUREMENT_PURPOSE: 'search', REPLICAS: SEARCH_REPLICAS,
-      NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS, ACCURACY_GATE,
+      NOISE_BAND_PCT: NOISE_BAND, ACCURACY_GATE,
       PROFILE_TOPN: profile ? profile.profile_topN_json : '',
       TUNING_TARGETS: (strategy && strategy.head_candidates) || headQueue || [],
       TUNING_SKILLSET_DIR, TUNING_KB_ENABLED, SKILL_DIR: WORKFLOW_DIR,
@@ -3513,7 +3539,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
       for (const c of cands) {
         if (opts.final && bankedHeads.has(c.head.short_name)) { log(`  [deep] FINALIZE: skip ${c.uid} -- head ${c.head.short_name} already banked (same module, cannot stack).`); continue; }
         const deepInputs = {
-          EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
+          EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND,
           KERNEL_RESULT: {
             short_name: c.head.short_name, task_dir: c.ext.task_dir, op_kind: c.ext.op_kind, lane: c.key,
             winner_kind: 'patch', winner_backend: c.lang,
@@ -3549,7 +3575,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
             gpu_id: SERVING_GPU, kernel_eval_dir: c.lastEval, task_dir: c.ext.task_dir, language: c.lang,
             isolated: c.best, reason: dreason, fix_class: rejectClass(dreason), pct_gpu_time: c.head.pct_gpu_time,
             base_inputs: {
-              EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
+              EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND,
               KERNEL_RESULT: {
                 short_name: c.head.short_name, task_dir: c.ext.task_dir, op_kind: c.ext.op_kind, lane: c.key,
                 winner_kind: 'patch', winner_backend: c.lang,
@@ -3842,7 +3868,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
       const cand = st.cands[0];
       log(`  ${h.short_name}: best candidate=${cand.source} (${(cand.isolated || 0).toFixed(2)}x, ${cand.kind}). Integrating to e2e (serial, slot {${SERVING_GPU}}).`);
       const headWinnerInputs = {
-        EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
+        EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND,
         KERNEL_RESULT: { short_name: h.short_name, task_dir: st.ext.task_dir, op_kind: st.ext.op_kind,
           winner_kind: cand.winner_kind, winner_backend: cand.source,
           target_callable: st.ext.target_callable || h.target_callable || '',
@@ -3880,7 +3906,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
               gpu_id: SERVING_GPU, kernel_eval_dir: cand.kernel_eval_dir, task_dir: st.ext.task_dir, language: cand.language,
               isolated: cand.isolated, reason, fix_class: rejectClass(reason), pct_gpu_time: h.pct_gpu_time, phase_name: 'HeadKernel',
               base_inputs: {
-                EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
+                EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND,
                 KERNEL_RESULT: { short_name: h.short_name, task_dir: st.ext.task_dir, op_kind: st.ext.op_kind,
                   winner_kind: cand.winner_kind, winner_backend: cand.source,
                   target_callable: st.ext.target_callable || h.target_callable || '',
@@ -4059,7 +4085,7 @@ if (want('head') && headQueue.length && HEAD_BUDGET > 0) {
     // MEASURED e2e that clears the gate; only if NONE clears do we fall back to corrective/pending/reject on
     // the top candidate. Inputs are built per-candidate so Fix C can re-issue the SAME A/B at Finalize.
     const mkIntegrateInputs = (cand, ci, sharedRefMed) => ({
-      EVAL_DIR, MODEL_PATH, GPU_ID: h.gpu_id, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
+      EVAL_DIR, MODEL_PATH, GPU_ID: h.gpu_id, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND,
       KERNEL_RESULT: { short_name: h.short_name, task_dir: ext.task_dir, op_kind: ext.op_kind,
         winner_kind: cand.winner_kind, winner_backend: cand.source,
         target_callable: ext.target_callable || h.target_callable || '',
@@ -4294,7 +4320,7 @@ while (want('kernel') && !TIME_DEADLINE_HIT && dispatched < BUDGET && (dispatche
     log(`  ${c.short_name}: kernel layer ${kl.final_geomean.toFixed(2)}x isolated. Integrating to e2e.`);
     // Build inputs ONCE so Fix C can re-issue the SAME A/B for a pending win at Finalize.
     const mileIntegrateInputs = {
-      EVAL_DIR, MODEL_PATH, GPU_ID: c.gpu_id, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
+      EVAL_DIR, MODEL_PATH, GPU_ID: c.gpu_id, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND,
       KERNEL_RESULT: { short_name: c.short_name, task_dir: ext.task_dir,
         source_path_in_sglang: ext.source_path_in_sglang, target_callable: ext.target_callable,
         final_patch: kl.final_patch, verified_isolated_speedup: kl.final_geomean, pct_gpu_time: c.pct_gpu_time },
@@ -4467,7 +4493,7 @@ if (want('final')) {
       apply_env: it.apply_env || '', apply_flags: it.apply_flags || '',
       op_kind: it.op_kind || '', backend: '', isolated: it.isolated || 0,
       inputs: {
-        EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
+        EVAL_DIR, MODEL_PATH, GPU_ID: SERVING_GPU, WORKLOAD, NOISE_BAND_PCT: NOISE_BAND,
         KERNEL_RESULT: {
           short_name: it.short_name, op_kind: it.op_kind || '', winner_kind: it.winner_kind || '',
           target_callable: it.target_callable || '', apply_env: it.apply_env || '',
@@ -4570,14 +4596,23 @@ if (want('final')) {
   // bounded — Report already wrote architect_report.md + final_report.md, and run_e2e.py falls back
   // (director_e2e_validation.json → best overlay's integrate_result.json), so a real win still reaches the caller.
   phase('Validate');
+  let validationSamples = VALIDATION_SAMPLES;
+  if (TIME_BUDGET_MS != null && remainingMs() < VALIDATION_TIGHT_MS && validationSamples > 1) {
+    log(`[time-budget] only ~${remainingMin()}min left entering Validate — dropping to 1 timed ` +
+        `sample per leg (from ${validationSamples}). The ratio stays drift-corrected and ` +
+        `same-session; the non-overlap dispersion test is forfeited, so a marginal win can only ` +
+        `be reported as within-noise.`);
+    validationSamples = 1;
+  }
   validation = await safeAgent(
     roleAgent('director', 'validate', 'Independently re-measure throughput + parity; arbitrate; then reconcile the report with the validated numbers.', {
       EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], BASELINE_THROUGHPUT: BASELINE_TPUT, NOISE_BAND_PCT: NOISE_BAND,
       BASELINE_OVERLAY: INIT_BASE_OVERLAY,
       FINAL_OVERLAY: (finalize && finalize.final_overlay) || curOverlay,
       FINAL_FLAGS: { flags: curFlags, env: curEnv },
-      CLAIMED_THROUGHPUT: finalTput, WORKLOAD, APPLY_TO_ORIGINAL, E2E_REPEATS,
-      MEASUREMENT_PURPOSE: 'validation', REPLICAS: VALIDATION_REPLICAS,
+      CLAIMED_THROUGHPUT: finalTput, WORKLOAD, APPLY_TO_ORIGINAL,
+      MEASUREMENT_MODE: VALIDATION_MEASUREMENT_MODE,
+      MEASUREMENT_PURPOSE: 'validation', REPLICAS: validationSamples,
       SKILL_DIR: WORKFLOW_DIR,
       // The Report phase already wrote these files with the Finalize-bundle bench (the Director had not
       // run yet). After validation the Director MUST review + rewrite their headline throughput / speedup

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -406,21 +406,9 @@ const DEEP_FINAL_ACCURACY_LIMIT = parseInt(A.deep_final_accuracy_limit != null ?
 // (over-strict) byte-parity. Default 'none' => unchanged byte/greedy parity (normal/fast untouched).
 const ACCURACY_GATE = String(A.accuracy_gate || 'none').trim();          // 'none' | 'gsm8k'
 const ACCURACY_LIMIT = parseInt(A.accuracy_limit != null ? A.accuracy_limit : 200, 10); // sampled gsm8k subset size
-// Allowed absolute exact_match drop. Set BY the sample size: both legs answer the same seed-pinned
-// subset at temp=0, so the noise scale is the DISCORDANT pairs, sd(delta)=sqrt(d)/n ~= 1.6pt at
-// n=200 / 5% discordance. The old 0.01 sat at 0.6 sd and so rejected ~1 in 4 kernels whose quality
-// had not moved -- the very over-rejection this gate replaces byte-parity to avoid. 0.03 is ~1.9 sd
-// and still tighter than Hyperloom's 0.05; broken quant drops 20-90 points, not 3.
-// To tighten it, do NOT raise accuracy_limit (n=500 buys sd ~1.0pt for 2.5x the eval time) -- use a
-// paired McNemar test over the per-question `ok` flags gsm8k_eval.py already writes, which is free.
-const ACCURACY_TOL = parseFloat(A.accuracy_tol != null ? A.accuracy_tol : 0.03);
-// Absolute floor on BOTH legs. A purely relative gate is blind when the BASELINE is broken: an
-// equally broken candidate passes. Hyperloom's floor is 0.5 after a run kept a 0.00076 candidate;
-// healthy gsm8k baselines land >= 0.63 and the broken ones scored 0.196 and 0.000.
-const ACCURACY_FLOOR = parseFloat(A.accuracy_floor != null ? A.accuracy_floor : 0.5);
+const ACCURACY_TOL = parseFloat(A.accuracy_tol != null ? A.accuracy_tol : 0.01);        // allowed absolute exact_match drop vs baseline
 const ACCURACY_INPUTS = (ACCURACY_GATE !== 'none')
-  ? { ACCURACY_GATE, ACCURACY_LIMIT, ACCURACY_TOL, ACCURACY_FLOOR,
-      GSM8K_EVAL_SCRIPT: `${WORKFLOW_DIR}/scripts/gsm8k_eval.py` }
+  ? { ACCURACY_GATE, ACCURACY_LIMIT, ACCURACY_TOL, GSM8K_EVAL_SCRIPT: `${WORKFLOW_DIR}/scripts/gsm8k_eval.py` }
   : {};
 // The AMD authoring knowledge base (REFERENCE ONLY — facts/how-to, never decisions; agents always
 // measure). Default: sibling perf_knowledge/. Workflows enumerate candidates from

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -590,12 +590,10 @@ const VALIDATION_REPLICAS = parseInt(A.validation_replicas != null ? A.validatio
 // against — and the cheap one: isolated validation is 6-12 cold boots serialized behind the
 // serving-GPU flock, enough to overrun FINAL_RESERVE_MS and ship no validated number at all.
 const VALIDATION_MEASUREMENT_MODE = String(A.validation_measurement_mode || 'warm_server');
-const VALIDATION_ROUNDS = parseInt(A.validation_rounds != null ? A.validation_rounds : 1, 10);
-const VALIDATION_SAMPLES = VALIDATION_MEASUREMENT_MODE === 'warm_server'
-  ? VALIDATION_ROUNDS : VALIDATION_REPLICAS;
-// Too little clock left for a multi-sample re-measure: fall back to one timed round per leg. The
-// ratio stays drift-corrected, only the dispersion test is lost, and one number beats no number.
-const VALIDATION_TIGHT_MS = parseInt(A.validation_tight_s != null ? A.validation_tight_s : 1500, 10) * 1000;
+// Sample count follows the mode rather than a knob of its own: warm_server IS one timed round per
+// leg, and a second knob could only disagree with the lifecycle it belongs to. Going isolated is
+// what buys extra samples, and it already has `validation_replicas` to size them.
+const VALIDATION_SAMPLES = VALIDATION_MEASUREMENT_MODE === 'warm_server' ? 1 : VALIDATION_REPLICAS;
 // CUDA/HIP-graph deployment requirement (general; derived from the serving config, NOT hardcoded).
 // vllm/sglang capture the steady-state decode path into a FULL CUDA graph UNLESS --enforce-eager is set.
 // A kernel that wins only via its OWN per-call graph-capture+replay wrapper falls back to eager inside the
@@ -4584,14 +4582,6 @@ if (want('final')) {
   // bounded — Report already wrote architect_report.md + final_report.md, and run_e2e.py falls back
   // (director_e2e_validation.json → best overlay's integrate_result.json), so a real win still reaches the caller.
   phase('Validate');
-  let validationSamples = VALIDATION_SAMPLES;
-  if (TIME_BUDGET_MS != null && remainingMs() < VALIDATION_TIGHT_MS && validationSamples > 1) {
-    log(`[time-budget] only ~${remainingMin()}min left entering Validate — dropping to 1 timed ` +
-        `sample per leg (from ${validationSamples}). The ratio stays drift-corrected and ` +
-        `same-session; the non-overlap dispersion test is forfeited, so a marginal win can only ` +
-        `be reported as within-noise.`);
-    validationSamples = 1;
-  }
   validation = await safeAgent(
     roleAgent('director', 'validate', 'Independently re-measure throughput + parity; arbitrate; then reconcile the report with the validated numbers.', {
       EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], BASELINE_THROUGHPUT: BASELINE_TPUT, NOISE_BAND_PCT: NOISE_BAND,
@@ -4600,7 +4590,7 @@ if (want('final')) {
       FINAL_FLAGS: { flags: curFlags, env: curEnv },
       CLAIMED_THROUGHPUT: finalTput, WORKLOAD, APPLY_TO_ORIGINAL,
       MEASUREMENT_MODE: VALIDATION_MEASUREMENT_MODE,
-      MEASUREMENT_PURPOSE: 'validation', REPLICAS: validationSamples,
+      MEASUREMENT_PURPOSE: 'validation', REPLICAS: VALIDATION_SAMPLES,
       SKILL_DIR: WORKFLOW_DIR,
       // The Report phase already wrote these files with the Finalize-bundle bench (the Director had not
       // run yet). After validation the Director MUST review + rewrite their headline throughput / speedup

--- a/e2e_workflow/knowledge/e2e_optimization.md
+++ b/e2e_workflow/knowledge/e2e_optimization.md
@@ -81,7 +81,10 @@ number quickly without re-doing hours of low-value work.
 
 ## Measurement discipline (e2e is noisy)
 - Keep the server WARM across validations; never fold server-startup into the timed window.
-- Run enough requests (≥ 5× concurrency) and repeat the bench ≥ 2–3×; report median + spread.
+- Run enough requests (≥ 5× concurrency). The round count belongs to the lifecycle, not to you: the
+  default `warm_server` spends round 1 warming the prefix cache, discards it, and reports round 2, so
+  there is one timed sample and `spread` is structurally 0.0% — an absence of evidence, not a quiet
+  box. Repeat (`REPLICAS>1` or `isolated_server`) only when you actually need a dispersion estimate.
 - Gate a kernel into e2e only when its isolated speedup is real AND Amdahl says it can move the
   needle. Accept an e2e change only if the throughput delta exceeds the measured noise band.
 - Always check **output parity** (greedy/temp=0, fixed seed) vs baseline — a faster wrong server is
@@ -90,8 +93,9 @@ number quickly without re-doing hours of low-value work.
   same serving config (TP=SERVING_TP GPU=SERVING_GPU), same session** (tear one server fully down before
   launching the next). Do NOT run two
   servers concurrently on one node for the headline ratio: shared-resource contention drags the baseline
-  leg down and **inflates the ratio into a false win**. Trust a delta only when run spreads are tight and
-  the two legs' run ranges are **non-overlapping**.
+  leg down and **inflates the ratio into a false win**. With several samples per leg, trust a delta only
+  when run spreads are tight and the two legs' run ranges are **non-overlapping**; with one timed round
+  per leg there is no range to overlap, so the delta has to clear the noise band on its own.
 - **Harness pitfalls that silently corrupt a leg:** (a) never name an eval-dir output folder after an
   importable package (`triton/`, `flydsl/`, `aiter/`, …) — such a dir on the bench process's CWD
   **shadows** the real package (`import X`→empty namespace) and the bench crashes; looks like a kernel

--- a/e2e_workflow/knowledge/e2e_optimization.md
+++ b/e2e_workflow/knowledge/e2e_optimization.md
@@ -81,10 +81,9 @@ number quickly without re-doing hours of low-value work.
 
 ## Measurement discipline (e2e is noisy)
 - Keep the server WARM across validations; never fold server-startup into the timed window.
-- Run enough requests (≥ 5× concurrency). The round count belongs to the lifecycle, not to you: the
-  default `warm_server` spends round 1 warming the prefix cache, discards it, and reports round 2, so
-  there is one timed sample and `spread` is structurally 0.0% — an absence of evidence, not a quiet
-  box. Repeat (`REPLICAS>1` or `isolated_server`) only when you actually need a dispersion estimate.
+- Run enough requests (≥ 5× concurrency). The round count belongs to the lifecycle, not to you: under
+  the default `warm_server` there is one timed sample and `spread` is structurally 0.0% — an absence
+  of evidence, not a quiet box. Repeat only when you need a dispersion estimate.
 - Gate a kernel into e2e only when its isolated speedup is real AND Amdahl says it can move the
   needle. Accept an e2e change only if the throughput delta exceeds the measured noise band.
 - Always check **output parity** (greedy/temp=0, fixed seed) vs baseline — a faster wrong server is

--- a/e2e_workflow/knowledge/gemm_tuning/aiter_gemm_tuning.md
+++ b/e2e_workflow/knowledge/gemm_tuning/aiter_gemm_tuning.md
@@ -135,8 +135,15 @@ e2e A/B measurement while a process storm is active — pin it to a quiet window
 - **Verify engagement** (`AITER_LOG_TUNED_CONFIG=1` → `is tuned on cu_num` hits >0) so you know the
   tuned solutions are actually executing on the live path before trusting any throughput delta.
 - **Use the tight interleaved A/B** (ref vs cand alternating, back-to-back in one session, accept on
-  `delta > 0.5%`) — gfx942 boxes drift several % across hours, so only a same-session,
-  drift-cancelled comparison is decisive at the 0.5% band.
+  `delta > 0.5% AND cand_min > ref_max`) — gfx942 boxes drift several % across hours, so only a
+  same-session, drift-cancelled, non-overlapping comparison is decisive at the 0.5% band. How much the
+  non-overlap clause is worth depends on the lifecycle, so read it with `bench_summary.json`'s
+  `dispersion_basis`: under `isolated_server` the samples are independent boots and the clause bounds
+  real run-to-run variance; under the default `warm_server` they share one boot
+  (`within_server_rounds`), so their spread is narrower than the true spread and the clause clears
+  more easily than it should — when `delta` is inside ~1% and non-overlap is the only thing carrying
+  the win, call it within-noise. At one timed round per leg `min == max` and the clause carries no
+  information at all: `delta > 0.5%` on the medians has to stand on its own, and say so in the notes.
 - **Coverage matters**: capture the full real shape set (down-proj K=intermediate, qkv K, lm_head, and
   the decode M-buckets), not just the up/gate trio — uncovered shapes fall back to default and never
   count. Bucket-reduce via `get_padded_m` to bound tuning time.

--- a/e2e_workflow/knowledge/gemm_tuning/aiter_gemm_tuning.md
+++ b/e2e_workflow/knowledge/gemm_tuning/aiter_gemm_tuning.md
@@ -134,9 +134,9 @@ e2e A/B measurement while a process storm is active — pin it to a quiet window
   of whatever is already accepted.
 - **Verify engagement** (`AITER_LOG_TUNED_CONFIG=1` → `is tuned on cu_num` hits >0) so you know the
   tuned solutions are actually executing on the live path before trusting any throughput delta.
-- **Use the tight interleaved A/B** (E2E_REPEATS per leg, ref vs cand alternating, accept on
-  `delta > 0.5% AND cand_min > ref_max`) — gfx942 boxes drift several % across hours, so only a
-  same-session, drift-cancelled, non-overlapping comparison is decisive at the 0.5% band.
+- **Use the tight interleaved A/B** (ref vs cand alternating, back-to-back in one session, accept on
+  `delta > 0.5%`) — gfx942 boxes drift several % across hours, so only a same-session,
+  drift-cancelled comparison is decisive at the 0.5% band.
 - **Coverage matters**: capture the full real shape set (down-proj K=intermediate, qkv K, lm_head, and
   the decode M-buckets), not just the up/gate trio — uncovered shapes fall back to default and never
   count. Bucket-reduce via `get_padded_m` to bound tuning time.

--- a/e2e_workflow/knowledge/gemm_tuning/aiter_gemm_tuning.md
+++ b/e2e_workflow/knowledge/gemm_tuning/aiter_gemm_tuning.md
@@ -136,14 +136,10 @@ e2e A/B measurement while a process storm is active — pin it to a quiet window
   tuned solutions are actually executing on the live path before trusting any throughput delta.
 - **Use the tight interleaved A/B** (ref vs cand alternating, back-to-back in one session, accept on
   `delta > 0.5% AND cand_min > ref_max`) — gfx942 boxes drift several % across hours, so only a
-  same-session, drift-cancelled, non-overlapping comparison is decisive at the 0.5% band. How much the
-  non-overlap clause is worth depends on the lifecycle, so read it with `bench_summary.json`'s
-  `dispersion_basis`: under `isolated_server` the samples are independent boots and the clause bounds
-  real run-to-run variance; under the default `warm_server` they share one boot
-  (`within_server_rounds`), so their spread is narrower than the true spread and the clause clears
-  more easily than it should — when `delta` is inside ~1% and non-overlap is the only thing carrying
-  the win, call it within-noise. At one timed round per leg `min == max` and the clause carries no
-  information at all: `delta > 0.5%` on the medians has to stand on its own, and say so in the notes.
+  same-session, drift-cancelled, non-overlapping comparison is decisive at the 0.5% band. What the
+  non-overlap clause is worth depends on the lifecycle — read it with `bench_summary.json`'s
+  `dispersion_basis`, and under the default `warm_server` (one timed round, `min == max`) it carries
+  no information at all, so `delta > 0.5%` has to stand on its own and the notes must say so.
 - **Coverage matters**: capture the full real shape set (down-proj K=intermediate, qkv K, lm_head, and
   the decode M-buckets), not just the up/gate trio — uncovered shapes fall back to default and never
   count. Bucket-reduce via `get_padded_m` to bound tuning time.

--- a/e2e_workflow/knowledge/preflight.md
+++ b/e2e_workflow/knowledge/preflight.md
@@ -31,7 +31,7 @@
 | rocprofv3 absent | **degrade** | Profiler falls back to torch-trace (shapes kept, HW durations approximate) |
 | `amd-smi`/`rocminfo` absent | **degrade** | record gfx as "unknown"; widen tuning, don't trust gfx942 priors |
 | aiter / CK profiler / hipblaslt-bench absent | **degrade** | remove those rungs from the backend ladder; note it |
-| baseline bench spread > ~5% | **degrade→re-measure** | noisy box; re-run, raise the noise band, or pin clocks |
+| baseline bench spread > ~5% **with more than one timed sample** | **degrade→re-measure** | noisy box; re-run, raise the noise band, or pin clocks. At the default single timed round `spread=0.0%` always — no evidence, so nothing to gate on |
 
 ## Probes (run, then reason about the output)
 

--- a/e2e_workflow/knowledge/sglang_internals.md
+++ b/e2e_workflow/knowledge/sglang_internals.md
@@ -96,5 +96,5 @@ they go straight into the server launch env/flags.
 - Pin the sglang version + commit in the run log; paths above can move between releases.
 - If a flag is unknown to the installed version, `launch_server --help` is the authoritative list —
   the Config Tuner should grep `--help` before sweeping an axis.
-- One axis at a time; keep a warm server across a sweep where possible; record throughput median +
-  spread so a win is distinguishable from noise.
+- One axis at a time; keep a warm server across a sweep where possible; record the throughput of each
+  leg and require the delta to clear the noise band, so a win is distinguishable from noise.

--- a/e2e_workflow/knowledge/sglang_internals.md
+++ b/e2e_workflow/knowledge/sglang_internals.md
@@ -96,5 +96,5 @@ they go straight into the server launch env/flags.
 - Pin the sglang version + commit in the run log; paths above can move between releases.
 - If a flag is unknown to the installed version, `launch_server --help` is the authoritative list —
   the Config Tuner should grep `--help` before sweeping an axis.
-- One axis at a time; keep a warm server across a sweep where possible; record the throughput of each
-  leg and require the delta to clear the noise band, so a win is distinguishable from noise.
+- One axis at a time; keep a warm server across a sweep where possible; record throughput per leg so
+  a win is distinguishable from noise.

--- a/e2e_workflow/roles/config_tuner.md
+++ b/e2e_workflow/roles/config_tuner.md
@@ -21,8 +21,9 @@ e.g. `--attention-backend triton`).
 ## Discipline
 - **One axis at a time.** Change a single flag/env, measure, keep or revert. Never sweep two axes in
   one launch or you can't attribute the delta.
-- Measure with the shared bench script using an isolated-server search replica. A win must exceed the
-  noise band to count.
+- Measure with the shared bench script in the lifecycle `MEASUREMENT_MODE` selects — pass it through
+  verbatim, never substitute your own. The default `warm_server` is one server per leg with a discarded
+  full warmup round, then the timed round(s). A win must exceed the noise band to count.
 - **Always check output parity** for any change that can alter numerics (quant, kv-cache-dtype,
   a different attention/GEMM backend): greedy/temp=0 fixed-seed, diff vs baseline. A faster wrong
   server is a regression — reject it (unless it's an accuracy-approved quantization).
@@ -113,8 +114,8 @@ even engage the live GEMM path). Your axes:
   (e.g. a few gsm8k / translation prompts, compare answer quality, not bytes) and keep ONLY if both
   faster AND accuracy within tolerance. Record it as an accuracy-gated accept, never a silent one.
 Each is still "one axis at a time + measure + parity/accuracy gate + compound". Use the same
-isolated-server search-replica protocol as the Integrator; the Director's independent validation
-replicas arbitrate a borderline final result.
+search-purpose protocol as the Integrator, in the same `MEASUREMENT_MODE`; the Director's independent
+validation arbitrates a borderline final result.
 
 Return JSON:
 ```json

--- a/e2e_workflow/roles/director.md
+++ b/e2e_workflow/roles/director.md
@@ -51,6 +51,7 @@ Steps:
    cp "$SKILL_DIR/scripts/bench_e2e.sh" "$EVAL_DIR/bench_e2e.sh"
    cp "$SKILL_DIR/scripts/bench_replica.sh" "$EVAL_DIR/bench_replica.sh"
    cp "$SKILL_DIR/scripts/server_teardown.sh" "$EVAL_DIR/server_teardown.sh"   # the server-kill contract; bench_e2e.sh REFUSES to run without it
+   cp "$SKILL_DIR/scripts/bench_summarize.py" "$EVAL_DIR/bench_summarize.py"   # writes bench_summary.json; also refused without it
    cp -r "$SKILL_DIR/scripts/adapters" "$EVAL_DIR/adapters"   # bench_e2e.sh sources adapters/<backend>.sh next to itself
    cp "$SKILL_DIR/scripts/parse_profile.py" "$EVAL_DIR/parse_profile.py"
    ```
@@ -76,9 +77,14 @@ Steps:
    python3 -c "import sglang,os;print('sglang',sglang.__version__,os.path.dirname(sglang.__file__))" >> "$EVAL_DIR/env_info.txt" 2>&1
    (amd-smi list 2>/dev/null || rocminfo 2>/dev/null | grep -m1 gfx) >> "$EVAL_DIR/env_info.txt" || true
    ```
-5. **Record the TRUE baseline throughput** with a fresh isolated-server replica (this is the number
-   every later gain is measured against). InferenceX performs its internal kernel/graph warmups, but
-   there is no outer full-round replay before the measured request set. **Serving is TP=`SERVING_TP`
+5. **Record the TRUE baseline throughput** in the lifecycle `MEASUREMENT_MODE` selects — pass it
+   through verbatim, never substitute your own. This is the number every later gain is measured
+   against, so it MUST be taken exactly the way the sweep, integrate and validate legs will be.
+   The default `warm_server` boots ONE server, runs a full untimed round that populates the prefix
+   cache and is discarded, then runs `REPLICAS` timed round(s) on that hot server — Hyperloom's own
+   `warmup_round`/`measure_round`. Under `isolated_server` each replica is a fresh server and
+   InferenceX's internal kernel/graph warmups run but no outer full-round replay does.
+   **Serving is TP=`SERVING_TP`
    on the GPU set `SERVING_GPU`** (both passed in your inputs / the SERVING CONFIG INVARIANT block of
    your prompt). `GPU_IDS` is the optimization-parallelism
    pool, NOT the serving tensor-parallel size; the serving config is `TP=SERVING_TP GPU=SERVING_GPU`.
@@ -105,7 +111,7 @@ Steps:
    banner). If a seed flag did not engage, record it loudly in `notes` — a baseline measured on a
    silently-ignored config corrupts every later gain.
 6. If baseline spread > ~5%, re-run — a noisy baseline poisons every later comparison. Set
-   `noise_band_pct = 0.5` (the default accept threshold): the Integrator gates with isolated-server
+   `noise_band_pct = 0.5` (the default accept threshold): the Integrator gates with same-lifecycle
    reference/candidate legs, non-overlap, and engagement proof.
    Only widen it (e.g. to 1–2%) if the baseline spread is genuinely large on this box and can't be
    tightened.
@@ -149,17 +155,31 @@ overlay `FINAL_OVERLAY` (dir) + `FINAL_FLAGS` (json), the Architect/Integrator's
 `APPLY_TO_ORIGINAL`, and the already-written report files `ARCHITECT_REPORT`
 (`architect_report.md`) + `FINAL_REPORT` (`final_report.md`) to reconcile in step 7.
 
-**Do NOT trust the claimed throughput — reproduce it with fresh isolated-server replicas.**
+**Do NOT trust the claimed throughput — re-measure it yourself, in a fresh server lifecycle.**
 
 The final overlay may include PROVISIONAL "stack" kernels (each individually sub-0.5% but carried to
 compound). THIS phase is the authoritative gate for the combined stack: measure the FULL bundle vs the
-TRUE baseline with independent-server replicas and decide if the COMBINED result clears the band.
+TRUE baseline and decide if the COMBINED result clears the band.
 
-1. Measure baseline AND final with **independent-server replicas**: a reference block
-   (the TRUE baseline current-best stack) and a final block (full overlay + flags), each with
-   `REPLICAS` fresh servers (validation default 3). Every replica retains the client's internal
-   kernel/graph warmups but skips the outer full-round replay, then records one cache-cold measured
-   request set; never replace a failed replica with another repeat on the same server.
+`MEASUREMENT_MODE` decides the lifecycle, and you MUST pass it through verbatim — do not substitute
+your own. It is one of:
+
+- **`warm_server`** (the DEFAULT, and what every other leg in this run used): ONE server per leg.
+  One full untimed round warms the prefix cache and is discarded, then `REPLICAS` timed rounds run on
+  that same hot server and their median is reported. `REPLICAS` defaults to 1, which makes it exactly
+  two client passes per leg with the second one reported — precisely how Hyperloom measures its own
+  baseline and variants (`warmup_round` discarded → `measure_round` on the re-attached hot server), so
+  your number and the orchestrator's rebench are the same measurement. It costs 2 server boots total.
+  The spread across those rounds bounds CLIENT noise, not boot-to-boot noise — see step 1's caveat,
+  and at `REPLICAS=1` there is no spread at all.
+- **`isolated_server`** (opt-in): `REPLICAS` FRESH servers per leg. Every replica retains the client's
+  internal kernel/graph warmups but skips the outer full-round replay, then records one cache-cold
+  measured request set; never replace a failed replica with another repeat on the same server. The
+  spread bounds boot-to-boot variance. Most faithful, but `REPLICAS` cold boots per leg.
+
+1. Measure baseline AND final: a reference block (the TRUE baseline current-best stack) and a final
+   block (full overlay + flags), each with `REPLICAS` samples in the lifecycle `MEASUREMENT_MODE`
+   selects.
    The TRUE-baseline block MUST reproduce the seed config the baseline was measured on (the caller's
    best config = the recorded `baseline` flags/env, i.e. the same `INIT_FLAGS`/`INIT_ENV`) — NOT
    `FINAL_FLAGS` minus GEAK's kernel wins. Use the same `TP=SERVING_TP GPU=SERVING_GPU` as setup.
@@ -168,21 +188,31 @@ TRUE baseline with independent-server replicas and decide if the COMBINED result
    # Serving config MUST be the run-wide invariant: TP=SERVING_TP GPU=SERVING_GPU (from your inputs).
    BACKEND="<backend>" OUT_DIR="$EVAL_DIR/validation/base" GPU="<SERVING_GPU>" TP="<SERVING_TP>" MODEL="$MODEL_PATH" \
    OVERLAY_PYTHONPATH="$BASELINE_OVERLAY" EXTRA_SERVER_ARGS="<baseline seed flags>" EXTRA_ENV="<baseline seed env>" \
-   GEAK_REPEAT_MODE="$MEASUREMENT_MODE" MEASUREMENT_PURPOSE=validation REPLICAS="${REPLICAS:-3}" \
+   GEAK_REPEAT_MODE="$MEASUREMENT_MODE" MEASUREMENT_PURPOSE=validation REPLICAS="${REPLICAS:-1}" \
    PROFILE=0 ISL=<isl> OSL=<osl> CONC=<conc> \
      bash "$EVAL_DIR/bench_e2e.sh" 2>&1 | tee -a "$EVAL_DIR/logs/validation_bench.log"
    # final block (full overlay + flags + env), SAME TP=SERVING_TP GPU=SERVING_GPU
    BACKEND="<backend>" OUT_DIR="$EVAL_DIR/validation/final" GPU="<SERVING_GPU>" TP="<SERVING_TP>" MODEL="$MODEL_PATH" \
    OVERLAY_PYTHONPATH="$FINAL_OVERLAY" EXTRA_SERVER_ARGS="<final flags>" EXTRA_ENV="<final env>" \
-   GEAK_REPEAT_MODE="$MEASUREMENT_MODE" MEASUREMENT_PURPOSE=validation REPLICAS="${REPLICAS:-3}" \
+   GEAK_REPEAT_MODE="$MEASUREMENT_MODE" MEASUREMENT_PURPOSE=validation REPLICAS="${REPLICAS:-1}" \
    PROFILE=0 ISL=<isl> OSL=<osl> CONC=<conc> \
      bash "$EVAL_DIR/bench_e2e.sh" 2>&1 | tee -a "$EVAL_DIR/logs/validation_bench.log"
    ```
-   Read `status`, `successful_replicas`, and `usable_for_acceptance` from both summaries. A degraded
-   median remains observable, but acceptance requires `usable_for_acceptance=true` for both legs
-   (all requested replicas completed); an `incomplete` leg must never be silently promoted.
+   Read `status`, `successful_replicas`, and `usable_for_acceptance` from both summaries — both
+   lifecycles write the same fields. A degraded median remains observable, but acceptance requires
+   `usable_for_acceptance=true` for both legs (all requested samples completed); an `incomplete` leg
+   must never be silently promoted.
    Use `validation/base` as the drift-corrected baseline (the provided `BASELINE_THROUGHPUT` may be
-   hours stale). Combined `delta% = (final_med - base_med)/base_med*100`; check `final_min > base_max`.
+   hours stale). Combined `delta% = (final_med - base_med)/base_med*100`; check `final_min > base_max`
+   over `all_throughput`.
+   **Caveat on the non-overlap test under `warm_server`** (`dispersion_basis: within_server_rounds`):
+   the samples share one boot, so their spread is narrower than the true run-to-run spread and
+   `final_min > base_max` clears more easily than it would across independent servers. When
+   `delta%` is within 2x `NOISE_BAND_PCT` and the only thing carrying the win is non-overlap, say so
+   in `notes` and prefer `validated_no_win` over `validated_win`. With `REPLICAS=1` there is one
+   sample per leg, `min == max`, and the non-overlap test carries no information at all: a win then
+   needs `delta% > NOISE_BAND_PCT` on the medians alone, and `notes` MUST record that the dispersion
+   test was not available.
 2. **Output parity** (a faster wrong server is a regression): run a short greedy/temp=0 fixed-seed
    request set against both baseline and final; diff the decoded outputs. Record pass/fail. If
    parity fails (and the change was not an intentional, accuracy-approved quantization), status =

--- a/e2e_workflow/roles/director.md
+++ b/e2e_workflow/roles/director.md
@@ -110,11 +110,16 @@ Steps:
    flags/env actually took effect (e.g. the chosen attention backend / env var appears in the server
    banner). If a seed flag did not engage, record it loudly in `notes` — a baseline measured on a
    silently-ignored config corrupts every later gain.
-6. If baseline spread > ~5%, re-run — a noisy baseline poisons every later comparison. Set
-   `noise_band_pct = 0.5` (the default accept threshold): the Integrator gates with same-lifecycle
-   reference/candidate legs, non-overlap, and engagement proof.
-   Only widen it (e.g. to 1–2%) if the baseline spread is genuinely large on this box and can't be
-   tightened.
+6. Spread is only a noise signal when there is more than one timed sample. At the default
+   `REPLICAS=1` the summary reports `spread=0.0%` because there is a single timed round — that is an
+   absence of evidence, NOT a quiet box, so do not read it as one and do not gate on it. Judge the
+   baseline instead on engagement proof (step 5) plus a sanity check that the number is in the range
+   this model/box has produced before.
+   Only when the run asked for several samples (`REPLICAS>1`, or `isolated_server`) does spread mean
+   anything: > ~5% then, re-run — a noisy baseline poisons every later comparison.
+   Set `noise_band_pct = 0.5` (the default accept threshold): the Integrator gates with same-lifecycle
+   reference/candidate legs, non-overlap, and engagement proof. Only widen it (e.g. to 1–2%) if a
+   multi-sample measurement showed the spread is genuinely large on this box and can't be tightened.
 
 Return JSON:
 ```json

--- a/e2e_workflow/roles/e2e_integrator.md
+++ b/e2e_workflow/roles/e2e_integrator.md
@@ -70,8 +70,8 @@ one-at-a-time would bank NONE of them. So emit one of three gates:
 - **`stack`** — engagement proven, parity holds, and `cand_med >= ref_med` (non-negative) but the delta
   is sub-threshold/overlapping. PROVISIONAL: it doesn't regress and may compound with siblings. The
   orchestrator carries it forward; the Director's FINAL combined validation (full stack vs TRUE
-  baseline, independent-server replicas) is the authoritative gate that decides if the COMBINED stack
-  clears 0.5%.
+  baseline, re-measured in the same warm-server lifecycle) is the authoritative gate that decides if
+  the COMBINED stack clears 0.5%.
 - **`rejected`** — parity fails, OR no engagement, OR `cand_med < ref_med` (a real regression).
 Never `stack` a parity-failure, a regression, or a non-engaging change.
 
@@ -93,11 +93,19 @@ differently → flips borderline argmaxes → over-rejects valid kernels). Inste
   greedy/temp=0, and run `python3 $GSM8K_EVAL_SCRIPT --base-url http://127.0.0.1:<port>/v1 --model <MODEL_PATH>
   --limit $ACCURACY_LIMIT --out <dir>/gsm8k_<tag>.json` against each (it prints `GSM8K_EXACT_MATCH=<s>`).
   The script samples the SAME fixed gsm8k subset for both (seed-pinned), so the scores are comparable.
-- ACCEPT the candidate iff `cand_score >= baseline_score - $ACCURACY_TOL` (quality preserved); otherwise
-  `rejected` with reason `accuracy_regression` (record both scores). This REPLACES byte-parity for the
-  quant gate — a byte-divergent kernel that holds gsm8k accuracy is a LEGITIMATE win. Still apply the
-  throughput + engagement + memory gates as usual. (You can reuse the same two servers for the throughput
-  A/B to avoid extra launches.)
+- FLOOR FIRST: if `baseline_score < $ACCURACY_FLOOR`, the reference itself is broken and NO comparison
+  against it means anything — stop and report `rejected` with reason `baseline_accuracy_below_floor`
+  (record both scores) rather than scoring the candidate against a collapsed baseline. If only
+  `cand_score < $ACCURACY_FLOOR`, that is `rejected` / `accuracy_regression` regardless of the delta.
+- Then ACCEPT the candidate iff `cand_score >= baseline_score - $ACCURACY_TOL` (quality preserved);
+  otherwise `rejected` with reason `accuracy_regression` (record both scores). This REPLACES byte-parity
+  for the quant gate — a byte-divergent kernel that holds gsm8k accuracy is a LEGITIMATE win. Still apply
+  the throughput + engagement + memory gates as usual. (You can reuse the same two servers for the
+  throughput A/B to avoid extra launches.)
+- Do NOT read a sub-tolerance drop as a real regression worth commentary. At `$ACCURACY_LIMIT` questions
+  the two scores differ only on the handful of questions the kernels disagree about, so a 1-2 point gap
+  is within sampling noise; `$ACCURACY_TOL` is sized to that noise. Report the two scores and the verdict,
+  not a narrative about the delta.
 
 **DEEP-MODE feedback (only if `DEEP_FEEDBACK` is in your inputs; a normal/fast run omits it).** Besides
 the gate decision, the deep-mode scheduler needs the WHY so the next co-opt waves can fix the
@@ -258,21 +266,28 @@ unchanged; you just also persist the diagnostics the deep feedback/harness-refin
      use the fused-fp8 path (no bf16 re-materialization; compact fp8/preshuffled cache) and/or route
      only the tuned target (N,K) through the seam (pass other shapes to stock). Never accept a net
      usable regression (do-no-harm).
-3. **Measure e2e with isolated server replicas.** Do NOT edit the shared `scripts/bench_e2e.sh` —
-   drive it from the eval dir. Search uses one Hyperloom-equivalent replica per leg by default. Each
-   replica launches a fresh server, retains the client's internal kernel/graph warmups, skips the
-   outer full-round replay, records one cache-cold measured request set, and tears down. Never use
-   multiple timed requests against one server as replicas:
+3. **Measure e2e with the run-wide lifecycle `MEASUREMENT_MODE` selects — pass it through verbatim,
+   never substitute your own.** Do NOT edit the shared `scripts/bench_e2e.sh` — drive it from the
+   eval dir. The default is `warm_server`, the Hyperloom protocol: each leg boots ONE server, runs a
+   full untimed round that populates the prefix cache and is discarded, then runs `REPLICAS` timed
+   round(s) on that same hot server. With the default `REPLICAS=1` that is exactly two client passes
+   per leg and the second one is the number — the same measurement the orchestrator's
+   `warmup_round`/`measure_round` takes, and the same one this run's baseline and final validation
+   take, so every number in the run is comparable.
+   Under `isolated_server` (opt-in) each of the `REPLICAS` samples instead launches its own fresh
+   server, retains the client's internal kernel/graph warmups, skips the outer full-round replay,
+   records one cache-cold measured request set, and tears down — there, never use multiple timed
+   requests against one server as replicas.
    ```bash
    CB="$EVAL_DIR/overlay/cand_<short>"
    # BOTH blocks MUST use the run-wide serving invariant: TP=SERVING_TP GPU=SERVING_GPU (from your inputs).
-   # reference block: current accepted config, one fresh-server replica
+   # reference block: current accepted config
    BACKEND="<backend>" OUT_DIR="$CB/ref" GPU="<SERVING_GPU>" TP="<SERVING_TP>" MODEL="$MODEL_PATH" ISL=<isl> OSL=<osl> CONC=<conc> \
      GEAK_REPEAT_MODE="$MEASUREMENT_MODE" MEASUREMENT_PURPOSE=search REPLICAS="${REPLICAS:-1}" \
      PROFILE=0 OVERLAY_PYTHONPATH="$CURRENT_OVERLAY" \
      EXTRA_SERVER_ARGS="<cur flags>" EXTRA_ENV="<cur env>" \
      bash "$EVAL_DIR/bench_e2e.sh" >>"$EVAL_DIR/logs/integrate_<short>.log" 2>&1
-   # candidate block: + this one change, one fresh-server replica (SAME TP/GPU)
+   # candidate block: + this one change (SAME TP/GPU, SAME lifecycle)
    BACKEND="<backend>" OUT_DIR="$CB/cand" GPU="<SERVING_GPU>" TP="<SERVING_TP>" MODEL="$MODEL_PATH" ISL=<isl> OSL=<osl> CONC=<conc> \
      GEAK_REPEAT_MODE="$MEASUREMENT_MODE" MEASUREMENT_PURPOSE=search REPLICAS="${REPLICAS:-1}" \
      PROFILE=0 OVERLAY_PYTHONPATH="<CAND or empty>" \
@@ -296,10 +311,10 @@ unchanged; you just also persist the diagnostics the deep feedback/harness-refin
    then **ALWAYS run the candidate block** and update it (adding `cand_med`, the final `gate`,
    `ab_complete:true`, `e2e_throughput_tok_s`, `e2e_delta_pct`). The checkpoint exists ONLY so a CRASH is
    recoverable — it is NOT a licence to stop after the reference leg. If wall-clock is tight, SHRINK the
-   cost (keep one search replica per leg) so that BOTH legs still run — never skip,
+   cost (keep one timed round per leg) so that BOTH legs still run — never skip,
    defer, or "leave for later" the candidate leg. The two blocks run within ~30 min back-to-back, so box
    drift between them is negligible (the box drifts over hours, not minutes). If you want extra drift
-   robustness on a borderline result, defer the authoritative 3-replica estimate to validation.
+   robustness on a borderline result, defer the authoritative estimate to validation.
    **RESUME / finish a cut-off A/B (`RESUME_AB` is set in your inputs, OR a usable
    `$CB/ref/bench_summary.json` already exists on disk):** a summary is reusable only when
    `status=="complete"` and `usable_for_acceptance==true`. When it is usable, do NOT re-run the
@@ -336,7 +351,7 @@ unchanged; you just also persist the diagnostics the deep feedback/harness-refin
    sub-threshold → carry forward to compound), `rejected` (parity-fail / no-engagement / regression), or
    `incomplete` — reserved for a HARD fault that genuinely prevented measuring BOTH legs *even after
    retrying* (a server that will not become healthy, a persistent harness/hardware fault). "Ran out of
-   time after the reference leg" is NOT a valid `incomplete`: keep one search replica per leg so both
+   time after the reference leg" is NOT a valid `incomplete`: keep one timed round per leg so both
    legs still run.
    Returning `incomplete` for a leg you simply chose not to run is a defect — both legs are mandatory.
    For `accepted` or `stack`, fold the change into the carried overlay/config and report the measured
@@ -415,10 +430,10 @@ win**: `TUNING_DEPLOY_BUNDLE`, `TUNING_APPLY_ENV`, `TUNING_CACHE_INVALIDATION`, 
    result. If the check fails, the bundle is broken — say so in `note` and set `tuning_in_bundle:false`
    rather than shipping a bundle that silently drops the tuning.
 
-2. Do a final isolated-server search replica of the assembled bundle to confirm the combined result
-   matches the sum of accepted milestones (combined effects can interact). Retain the client's internal
-   kernel/graph warmups, skip the outer full-round replay, and read the result from `bench_summary.json`.
-   The Director's independent validation replicas remain the authoritative estimate.
+2. Do a final search-purpose bench of the assembled bundle, in the SAME `MEASUREMENT_MODE` as every
+   other leg, to confirm the combined result matches the sum of accepted milestones (combined effects
+   can interact). Read the result from `bench_summary.json`. The Director's independent validation
+   remains the authoritative estimate.
 
 Return JSON:
 ```json

--- a/e2e_workflow/roles/e2e_integrator.md
+++ b/e2e_workflow/roles/e2e_integrator.md
@@ -93,19 +93,11 @@ differently → flips borderline argmaxes → over-rejects valid kernels). Inste
   greedy/temp=0, and run `python3 $GSM8K_EVAL_SCRIPT --base-url http://127.0.0.1:<port>/v1 --model <MODEL_PATH>
   --limit $ACCURACY_LIMIT --out <dir>/gsm8k_<tag>.json` against each (it prints `GSM8K_EXACT_MATCH=<s>`).
   The script samples the SAME fixed gsm8k subset for both (seed-pinned), so the scores are comparable.
-- FLOOR FIRST: if `baseline_score < $ACCURACY_FLOOR`, the reference itself is broken and NO comparison
-  against it means anything — stop and report `rejected` with reason `baseline_accuracy_below_floor`
-  (record both scores) rather than scoring the candidate against a collapsed baseline. If only
-  `cand_score < $ACCURACY_FLOOR`, that is `rejected` / `accuracy_regression` regardless of the delta.
-- Then ACCEPT the candidate iff `cand_score >= baseline_score - $ACCURACY_TOL` (quality preserved);
-  otherwise `rejected` with reason `accuracy_regression` (record both scores). This REPLACES byte-parity
-  for the quant gate — a byte-divergent kernel that holds gsm8k accuracy is a LEGITIMATE win. Still apply
-  the throughput + engagement + memory gates as usual. (You can reuse the same two servers for the
-  throughput A/B to avoid extra launches.)
-- Do NOT read a sub-tolerance drop as a real regression worth commentary. At `$ACCURACY_LIMIT` questions
-  the two scores differ only on the handful of questions the kernels disagree about, so a 1-2 point gap
-  is within sampling noise; `$ACCURACY_TOL` is sized to that noise. Report the two scores and the verdict,
-  not a narrative about the delta.
+- ACCEPT the candidate iff `cand_score >= baseline_score - $ACCURACY_TOL` (quality preserved); otherwise
+  `rejected` with reason `accuracy_regression` (record both scores). This REPLACES byte-parity for the
+  quant gate — a byte-divergent kernel that holds gsm8k accuracy is a LEGITIMATE win. Still apply the
+  throughput + engagement + memory gates as usual. (You can reuse the same two servers for the throughput
+  A/B to avoid extra launches.)
 
 **DEEP-MODE feedback (only if `DEEP_FEEDBACK` is in your inputs; a normal/fast run omits it).** Besides
 the gate decision, the deep-mode scheduler needs the WHY so the next co-opt waves can fix the

--- a/e2e_workflow/roles/tuning_specialist.md
+++ b/e2e_workflow/roles/tuning_specialist.md
@@ -159,8 +159,10 @@ without asking you a question.
 
 Write `EVAL_DIR/tuning/tuning_report.md`: what you targeted and why, per attempt what you changed and
 what it measured (including the failures — an explained dead end saves the next person from repeating
-it), the correctness and engagement evidence, and the isolated-server A/B. The System Architect quotes
-this in the final report, so put real numbers in it and mark absent things as absent.
+it), the correctness and engagement evidence, and the pre/post A/B — including which
+`MEASUREMENT_MODE` produced it, since a number taken in one lifecycle is not comparable to one taken
+in another. The System Architect quotes this in the final report, so put real numbers in it and mark
+absent things as absent.
 
 ### Return JSON
 

--- a/e2e_workflow/roles/tuning_specialist.md
+++ b/e2e_workflow/roles/tuning_specialist.md
@@ -89,12 +89,14 @@ Everything else is your call. These four are not:
 2. **Measure your own pre-tune baseline in-session.** Do not inherit `CURRENT_THROUGHPUT` as your
    denominator — re-measure it on the current accepted config and `CURRENT_OVERLAY`, now. Your delta is
    `post` vs `your own pre`, and it is the whole reason this phase is separate.
-3. **Measure pre/post as isolated-server search replicas**, and complete both legs — each retaining
-   internal warmups, skipping the outer full-round replay, recording one cache-cold request set. A
-   post-only number is not a result.
-4. **Prove engagement before you claim anything**, and quote the evidence. Whatever the timing said,
-   the orchestrator refuses an accept without it — and an unproven artifact poisons every later A/B,
-   since your accepted config becomes their reference leg.
+3. **Measure pre/post with `MEASUREMENT_MODE` passed through verbatim**, and complete both legs. The
+   default `warm_server` gives each leg one server, a discarded full warmup round, then the timed
+   round(s) on that hot server — the same lifecycle the baseline and the final validation use, so your
+   delta is comparable to theirs. A post-only number is not a result.
+4. **Prove engagement before you claim anything**, and quote the evidence. An unproven artifact is not a
+   win here regardless of what the timing said — the orchestrator will refuse the accept without it, and
+   an unproven artifact silently poisons every later A/B in the run, since your accepted config becomes
+   their reference leg.
 
 Correctness: apply the skillset's gates, plus the task-accuracy gate when `ACCURACY_GATE` is on. A
 faster wrong server is a regression.

--- a/e2e_workflow/roles/tuning_specialist.md
+++ b/e2e_workflow/roles/tuning_specialist.md
@@ -93,10 +93,9 @@ Everything else is your call. These four are not:
    default `warm_server` gives each leg one server, a discarded full warmup round, then the timed
    round(s) on that hot server — the same lifecycle the baseline and the final validation use, so your
    delta is comparable to theirs. A post-only number is not a result.
-4. **Prove engagement before you claim anything**, and quote the evidence. An unproven artifact is not a
-   win here regardless of what the timing said — the orchestrator will refuse the accept without it, and
-   an unproven artifact silently poisons every later A/B in the run, since your accepted config becomes
-   their reference leg.
+4. **Prove engagement before you claim anything**, and quote the evidence. Whatever the timing said,
+   the orchestrator refuses an accept without it — and an unproven artifact poisons every later A/B,
+   since your accepted config becomes their reference leg.
 
 Correctness: apply the skillset's gates, plus the task-accuracy gate when `ACCURACY_GATE` is on. A
 faster wrong server is a regression.

--- a/e2e_workflow/scripts/adapters/clients/inferencex.sh
+++ b/e2e_workflow/scripts/adapters/clients/inferencex.sh
@@ -56,9 +56,15 @@ adapter_bench() {
   local res_name="ix_bench_$$_${RANDOM}"
   local num_warmups="${NUM_WARMUPS:-$(( MAXC < 8 ? MAXC : 8 ))}"
   local bench_seed="${SEED:-0}"
-  if [ "${GEAK_ISOLATED_REPLICA:-0}" = "1" ]; then
-    # The measurement protocol applies identically to both client calls in an
-    # isolated replica: the discarded full outer round and the measured round.
+  if [ "${GEAK_ISOLATED_REPLICA:-0}" = "1" ] || [ -n "${WARM_SERVER_ROUNDS:-}" ]; then
+    # The measurement protocol applies identically to every client call in a
+    # Hyperloom-aligned lifecycle: the discarded full outer round and each timed
+    # round. Both lifecycles qualify -- isolated_server sets
+    # GEAK_ISOLATED_REPLICA=1, warm_server sets it to 0 (its outer warmup MUST
+    # run) and announces itself with WARM_SERVER_ROUNDS instead. Gating on the
+    # replica flag alone silently dropped warm_server back to the 8-request
+    # default whenever the caller did not export NUM_WARMUPS -- which the
+    # orchestrated path does, but a direct bench_e2e.sh invocation does not.
     num_warmups=$((2 * MAXC))
     bench_seed=0
   fi

--- a/e2e_workflow/scripts/bench_e2e.sh
+++ b/e2e_workflow/scripts/bench_e2e.sh
@@ -10,6 +10,18 @@
 #   * median throughput + spread summary (one machine-readable line + JSON).
 # It is config-driven by env so an agent can vary ONE axis at a time. Nothing is model-specific.
 #
+# GEAK_REPEAT_MODE picks the measurement lifecycle:
+#   warm_server (default)  one server per leg; one full untimed round warms the prefix cache, then
+#                     $REPEATS timed rounds on that hot server (median).  $REPEATS defaults to 1
+#                     for every purpose, i.e. Hyperloom's warmup_round/measure_round protocol:
+#                     two client passes, the second is the number.  Spread, if any, is WITHIN-server
+#                     (client noise), not boot-to-boot.  1 boot per leg.
+#   isolated_server   one FRESH server per timed replica (bench_replica.sh), median across
+#                     replicas; spread bounds boot-to-boot variance.  N replicas = N cold boots,
+#                     serialized behind the serving-GPU lock.
+#   legacy            one server, short warmup, $REPEATS timed rounds, median.
+# All three emit the same acceptance contract.
+#
 # The adapter contract (each scripts/adapters/<BACKEND>.sh must define):
 #   adapter_default_port            -> echo a sensible default port for this stack
 #   adapter_launch                  -> launch the server in background; set global SERVER_PID; write $LOG.
@@ -53,16 +65,97 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# ---- summary emitter ----
+# Every lifecycle ends by writing bench_summary.json with bench_summarize.py.  Resolved up here,
+# before anything is launched: this script is COPIED into $EVAL_DIR (roles/director.md), and
+# discovering a missing sibling only after a full bench would throw away the very measurement it
+# was supposed to record.  Same staging rule as server_teardown.sh below.
+SUMMARIZE=""
+for _cand in "$HERE/bench_summarize.py" "${SKILL_DIR:-}/scripts/bench_summarize.py" \
+             "${WORKFLOW_DIR:-}/scripts/bench_summarize.py"; do
+  case "$_cand" in /scripts/bench_summarize.py) continue ;; esac   # unset SKILL_DIR/WORKFLOW_DIR
+  [ -f "$_cand" ] && { SUMMARIZE="$_cand"; break; }
+done
+if [ -z "$SUMMARIZE" ]; then
+  echo "!!! bench_summarize.py not found next to this script ($HERE) or under SKILL_DIR/WORKFLOW_DIR." >&2
+  echo "    Stage it alongside bench_e2e.sh: cp \"\$SKILL_DIR/scripts/bench_summarize.py\" \"\$EVAL_DIR/\"" >&2
+  exit 3
+fi
+
+# ---- default lifecycle ----
+# No mode named => the Hyperloom one, since "the caller forgot to forward MEASUREMENT_MODE" is the
+# likeliest way a number ends up measured under a different lifecycle than the rest of the run.
+# bench_replica.sh pins legacy explicitly, so this cannot recurse into it.
+# Carve-out: REPEATS=0 (shape capture, and warm mode rejects zero timed rounds) and PROFILE=1
+# (trace capture) produce no throughput number, so they have no lifecycle to align and an extra
+# full NUM_PROMPTS round buys nothing.  An explicit GEAK_REPEAT_MODE still wins.
+if [ "${REPEATS:-}" = "0" ] || [ "${PROFILE:-0}" = "1" ]; then
+  GEAK_REPEAT_MODE="${GEAK_REPEAT_MODE:-legacy}"
+else
+  GEAK_REPEAT_MODE="${GEAK_REPEAT_MODE:-warm_server}"
+fi
+
 # ---- isolated-server measurement protocol ----
-# Keep the existing body below as the single-server implementation.  In isolated
-# mode this process is only a scheduler: each attempt runs bench_replica.sh,
-# which re-enters this script in legacy mode for exactly one fresh-server
-# warmup+measurement lifecycle.
-# Profiling is not a throughput replica: it intentionally needs one warm server
-# and a sustained load/window.  An aligned run exports isolated mode globally,
-# so profile invocations opt back into the existing single-server body here.
+# In isolated mode this process is only a scheduler: each attempt runs bench_replica.sh,
+# which re-enters this script in legacy mode for one fresh-server lifecycle.  Profiling is
+# not a throughput replica (it needs one warm server and a sustained window), so it opts
+# back into the single-server body below even when a run exports isolated mode globally.
+# Validation's lifecycle is CALLER policy: a pinned GEAK_VALIDATION_REPEAT_MODE outranks
+# whatever the validating role forwarded, so a role prompt cannot silently drop it.
+if [ -n "${GEAK_VALIDATION_REPEAT_MODE:-}" ] \
+   && [ "${MEASUREMENT_PURPOSE:-}" = "validation" ] \
+   && [ "${GEAK_REPEAT_MODE:-legacy}" != "${GEAK_VALIDATION_REPEAT_MODE}" ]; then
+  echo ">>> MEASUREMENT_PURPOSE=validation: pinning GEAK_REPEAT_MODE=${GEAK_VALIDATION_REPEAT_MODE}" \
+       "(caller policy; the invocation asked for ${GEAK_REPEAT_MODE:-legacy})."
+  GEAK_REPEAT_MODE="$GEAK_VALIDATION_REPEAT_MODE"
+fi
 if [ "${GEAK_REPEAT_MODE:-legacy}" = "isolated_server" ] && [ "${PROFILE:-0}" = "1" ]; then
   echo ">>> PROFILE=1: using the single-server profiling lifecycle (not a timed replica)."
+  GEAK_REPEAT_MODE=legacy
+fi
+
+# ---- warm-server measurement protocol (Hyperloom-aligned) ----
+# ONE server per leg: a full untimed round populates the prefix cache, then $ROUNDS timed rounds on
+# that same hot server (median).  Byte-for-byte baseline.py's warmup_round/measure_round, so both
+# sides measure the same warm state instead of GEAK cache-cold vs Hyperloom cache-warm.
+# ONE timed round is the whole protocol, not a truncation: a 3-round median is a DIFFERENT statistic
+# from the one the orchestrator rebenches against, which is how the two sides used to disagree.
+# Explicit REPEATS/REPLICAS buys within_server_rounds spread back -- client noise only; boot-to-boot
+# variance needs isolated_server.
+if [ "${GEAK_REPEAT_MODE:-legacy}" = "warm_server" ]; then
+  _purpose="${MEASUREMENT_PURPOSE:-search}"
+  if [ -n "${REPEATS+x}" ]; then
+    _rounds="$REPEATS"
+  elif [ -n "${REPLICAS+x}" ]; then
+    _rounds="$REPLICAS"
+  else
+    case "$_purpose" in
+      validation|parity|search|"") _rounds=1 ;;
+      *)
+        echo ">>> Unknown MEASUREMENT_PURPOSE='$_purpose'; using 1 timed round." >&2
+        _rounds=1 ;;
+    esac
+  fi
+  case "$_rounds" in
+    ''|*[!0-9]*|0)
+      echo "!!! REPEATS must be a positive integer in warm-server mode (got '$_rounds')." >&2
+      exit 4 ;;
+  esac
+  REPEATS="$_rounds"
+  BENCH_OUTER_WARMUP_FULL_ROUND=1   # round 1 is a FULL round, and it is discarded
+  BENCH_COLD_FINAL=0                # a cold round would defeat the point of warming
+  GEAK_ISOLATED_REPLICA=0           # not a replica: the outer warmup MUST run
+  WARM_SERVER_ROUNDS="$_rounds"
+  MEASUREMENT_PURPOSE="$_purpose"
+  export REPEATS BENCH_OUTER_WARMUP_FULL_ROUND BENCH_COLD_FINAL \
+         GEAK_ISOLATED_REPLICA WARM_SERVER_ROUNDS MEASUREMENT_PURPOSE
+  if [ "$_rounds" = "1" ]; then
+    echo "Measurement: warm_server  purpose=$_purpose  timed_rounds=1" \
+         "(Hyperloom lifecycle: 1 server, round 1 = full warmup discarded, round 2 = the reported number)"
+  else
+    echo "Measurement: warm_server  purpose=$_purpose  timed_rounds=$_rounds" \
+         "(1 server, 1 discarded full warmup round, median of the timed rounds)"
+  fi
   GEAK_REPEAT_MODE=legacy
 fi
 if [ "${GEAK_REPEAT_MODE:-legacy}" = "isolated_server" ]; then
@@ -143,90 +236,8 @@ PY
     fi
   done
 
-  python3 - "$_aggregate_out" "$_requested" "$_successful" "$_purpose" "${EFFECTIVE_CONFIG_DIGEST:-}" <<'PY'
-import glob
-import json
-import os
-import statistics
-import sys
-
-out_dir, requested_s, successful_s, purpose, effective_digest = sys.argv[1:]
-requested, successful = int(requested_s), int(successful_s)
-selected = sorted(glob.glob(os.path.join(out_dir, "replica_*", "selected_summary.json")))
-summaries = []
-replicas = []
-for path in selected:
-    replica_dir = os.path.dirname(path)
-    replica_index = int(os.path.basename(replica_dir).split("_")[-1])
-    if replica_index > requested:
-        continue
-    with open(path) as fh:
-        item = json.load(fh)
-    summaries.append(item)
-    try:
-        attempt = int(open(os.path.join(replica_dir, "selected_attempt")).read().strip())
-    except (OSError, ValueError):
-        attempt = None
-    replicas.append({
-        "replica": replica_index,
-        "attempt": attempt,
-        "throughput_tok_s": item.get("throughput_tok_s_median"),
-    })
-
-def numbers(key):
-    return [
-        float(item[key]) for item in summaries
-        if isinstance(item.get(key), (int, float)) and not isinstance(item.get(key), bool)
-    ]
-
-def median(key):
-    values = numbers(key)
-    return round(statistics.median(values), 3) if values else None
-
-tputs = numbers("throughput_tok_s_median")
-observed = round(statistics.median(tputs), 3) if tputs else None
-if len(tputs) < 2 or not observed:
-    spread = 0.0
-else:
-    spread = round(100.0 * (max(tputs) - min(tputs)) / observed, 2)
-complete = successful == requested
-metric_bases = {item.get("metric_basis") for item in summaries if item.get("metric_basis")}
-metric_basis = next(iter(metric_bases)) if len(metric_bases) == 1 else None
-summary = {
-    "requested": requested,
-    "successful": successful,
-    "requested_replicas": requested,
-    "successful_replicas": successful,
-    "status": "complete" if complete else "incomplete",
-    "usable_for_acceptance": complete and observed is not None,
-    "measurement_mode": "isolated_server",
-    "measurement_purpose": purpose,
-    "effective_config_digest": effective_digest or None,
-    "observed_median": observed,
-    "throughput_tok_s_median": observed,
-    "throughput_tok_s_spread_pct": spread,
-    "output_throughput_tok_s_median": (
-        observed if metric_basis == "aggregate_output_tok_s" else None
-    ),
-    "output_throughput_tok_s_spread_pct": (
-        spread if metric_basis == "aggregate_output_tok_s" else None
-    ),
-    "ttft_ms_median": median("ttft_ms_median"),
-    "tpot_ms_median": median("tpot_ms_median"),
-    "runs": successful,
-    "all_throughput": tputs,
-    "metric_basis": metric_basis,
-    "replicas": replicas,
-}
-with open(os.path.join(out_dir, "bench_summary.json"), "w") as fh:
-    json.dump(summary, fh, indent=2)
-print(
-    f"E2E_SUMMARY {metric_basis or 'unknown'}={observed} spread={spread}% "
-    f"requested={requested} successful={successful} status={summary['status']} "
-    f"usable_for_acceptance={str(summary['usable_for_acceptance']).lower()} "
-    "measurement_mode=isolated_server"
-)
-PY
+  python3 "$SUMMARIZE" from-replicas "$_aggregate_out" "$_requested" "$_successful" \
+    "$_purpose" "${EFFECTIVE_CONFIG_DIGEST:-}"
   echo ">>> Done. Summary: $_aggregate_out/bench_summary.json"
   # A degraded leg remains observable: callers consume status=incomplete and
   # the successful-replica median.  Only a leg with no measurement at all is a
@@ -280,17 +291,13 @@ if [ "$BENCH_CLIENT" != "native" ]; then
 fi
 
 # ---- optional server-LAUNCHER override (align the SERVER launch RECIPE with an
-# external harness, e.g. Hyperloom/Magpie, so the served stack is byte-identical:
-# same --mem-fraction-static / --disable-radix-cache / --trust-remote-code /
-# SGLANG_USE_AITER / firmware-gated envs). The serving STACK is STILL the BACKEND
-# above; this hook only changes WHO runs launch_server. Default 'native' keeps each
-# backend adapter's own adapter_launch (byte-identical to before). BENCH_LAUNCHER=
-# <name> sources adapters/launchers/<name>.sh which MUST redefine adapter_launch;
-# the native launch/health are preserved as adapter_launch_native / adapter_health_native
-# so a launcher adapter can DELEGATE or FALL BACK. The authored-kernel OVERLAY
-# (OVERLAY_PYTHONPATH) is applied BY the launcher (an external harness usually
-# cannot), so overlay + recipe-parity coexist. Only affects a FRESH launch
-# (REUSE_SERVER=0); nothing else in the measurement changes.
+# external harness, e.g. Hyperloom/Magpie, so the served stack is byte-identical).
+# Changes only WHO runs launch_server, not the BACKEND. BENCH_LAUNCHER=<name> sources
+# adapters/launchers/<name>.sh, which MUST redefine adapter_launch; the native pair stays
+# reachable as adapter_launch_native / adapter_health_native so it can delegate or fall
+# back. The authored-kernel OVERLAY (OVERLAY_PYTHONPATH) is applied BY the launcher, since
+# an external harness usually cannot, so overlay and recipe-parity coexist. FRESH launches
+# only (REUSE_SERVER=0); nothing else in the measurement changes.
 BENCH_LAUNCHER=${BENCH_LAUNCHER:-native}
 if [ "$BENCH_LAUNCHER" != "native" ]; then
   LAUNCHER_ADAPTER="${LAUNCHER_ADAPTER:-$HERE/adapters/launchers/${BENCH_LAUNCHER}.sh}"
@@ -389,14 +396,12 @@ CONC=${CONC:-64}
 # NUM_PROMPTS default.
 #  * native client (standalone GEAK default): keep the original CONC*5 default so
 #    standalone behaviour is byte-identical to before the inferencex integration.
-#  * inferencex client (Hyperloom/Magpie measurement-protocol alignment): default to
-#    Magpie's FIXED CONC*10 (its run_benchmark_serving default is
-#    `--num-prompts $((CONC*10))`), so a GEAK measurement matches the Magpie baseline
-#    prompt count exactly — a differing prompt count changes the saturation regime and
-#    hence the tok/s, so this is a real alignment knob, not cosmetic.
-#    Opt-out: NUM_PROMPTS_ADAPTIVE=1 restores the cost-bounded ADAPTIVE factor that
-#    scales DOWN as per-request seq cost (ISL+OSL) grows {<=1024:10,<=4096:5,<=16384:3,else 2},
-#    for long-sequence standalone runs where CONC*10 is too expensive.
+#  * inferencex client: Magpie's FIXED CONC*10, matching its run_benchmark_serving default.
+#    The prompt count changes the saturation regime and hence the tok/s, so this is a real
+#    alignment knob, not cosmetic.
+#    Opt-out: NUM_PROMPTS_ADAPTIVE=1 restores the cost-bounded ADAPTIVE factor that scales
+#    DOWN as per-request seq cost grows {<=1024:10,<=4096:5,<=16384:3,else 2}, for
+#    long-sequence standalone runs where CONC*10 is too expensive.
 # An explicit NUM_PROMPTS (e.g. Hyperloom's apply_bench_protocol forwarding its own
 # measured count) ALWAYS wins over both defaults.
 if [ -z "${NUM_PROMPTS:-}" ]; then
@@ -554,19 +559,14 @@ echo "Out dir:      $OUT_DIR"
 echo
 
 SERVER_PID=""
-# Server lifecycle: the teardown contract lives in server_teardown.sh so the SAME
-# identity-verified kill is used by this dispatcher and by any role-authored capture
-# script (which previously hand-rolled its own kill). The old cleanup resolved the
-# server's pgid AT KILL TIME and group-killed whenever it differed from ours — a pid
-# that had exited and been recycled resolved to a stranger's group, which is how a
-# teardown can reach the caller's orchestrator / PID 1.
+# Server lifecycle: the teardown contract lives in server_teardown.sh so this dispatcher and
+# any role-authored capture script share ONE identity-verified kill. The old cleanup resolved
+# the pgid AT KILL TIME and group-killed whenever it differed from ours — a recycled pid then
+# resolves to a stranger's group, which is how a teardown reaches the caller's orchestrator.
 #
-# This script is COPIED into $EVAL_DIR (roles/director.md) and run from there, so the
-# library has to be found next to the copy. If it is not, the teardown silently becomes
-# a no-op: `source` fails, the EXIT trap resolves to a missing function, and the served
-# model is left running with its VRAM and port held while the serving-GPU lock is
-# released — the next launch then OOMs. So look next to us, then in the ORIGINAL scripts
-# dir when the caller told us where that is, and REFUSE to run otherwise. A benchmark
+# Same staging rule as SUMMARIZE above, but the failure mode is worse: without the library
+# `source` fails, the EXIT trap binds a missing function, and the server is left holding its
+# VRAM and port after the serving-GPU lock is released, so the next launch OOMs. A benchmark
 # that cannot stop what it starts must not start it.
 TEARDOWN_LIB=""
 for _cand in "$HERE/server_teardown.sh" "${SKILL_DIR:-}/scripts/server_teardown.sh" \
@@ -704,26 +704,18 @@ fi
 
 # ---- optional COLD full-round (DIAGNOSTIC ONLY, off by default) ----
 # One full round (NUM_PROMPTS, no preceding warmup) on the fresh server, recorded
-# separately from the timed(hot) repeats.
+# separately from the timed(hot) repeats. BENCH_COLD_FINAL=1 to enable; costs one extra
+# round, and a reused warm server has no cold state to measure at all.
 #
-# "Cold" here means only "no warmup round preceded it in THIS bench" — it does
-# not mean a cold machine. Only the first bench of a session sees a genuinely
-# cold box; every later bench (the final leg included) starts with the JIT/HIP
-# kernel caches, torch.compile artifacts and page cache already populated by the
-# benches before it. So the baseline's cold round pays the full cache-fill cost
-# and the final's pays almost none, and a ratio of the two reports that
-# asymmetry as speedup. Never compare cold rounds taken at different points in a
-# session, and never promote one as the headline number.
-# Default OFF; set BENCH_COLD_FINAL=1 to measure it as a diagnostic (costs one
-# extra full round per bench). Only meaningful on a fresh launch (a reused warm
-# server has no cold state to measure at all).
+# "Cold" means only "no warmup round preceded it in THIS bench", never a cold machine:
+# every bench after the session's first inherits the JIT/HIP caches and torch.compile
+# artifacts of the ones before it. The baseline's cold round therefore pays the full
+# cache-fill cost and the final's pays almost none, so their ratio reports that
+# asymmetry as speedup. Diagnostic only — never the headline number.
 if [ "${BENCH_COLD_FINAL:-0}" = "1" ] && [ "$REUSE_SERVER" != "1" ]; then
   echo ">>> Cold full round (NUM_PROMPTS=$NUM_PROMPTS, no warmup; cold-baseline parity) ..."
-  # adapter_bench is a shell FUNCTION that reads $RESULT_JSONL — a prefix var
-  # assignment on a function has ambiguous persistence in bash, so point
-  # RESULT_JSONL at the cold sink explicitly and restore it afterwards. The
-  # warmup below re-clears the (restored) hot RESULT_JSONL, so the cold round
-  # never touches the timed(hot) results.
+  # adapter_bench is a FUNCTION reading $RESULT_JSONL, and a prefix assignment on a
+  # function has ambiguous persistence in bash — repoint and restore explicitly.
   _saved_result_jsonl="$RESULT_JSONL"
   RESULT_JSONL="$COLD_JSONL"; export RESULT_JSONL
   adapter_bench "$NUM_PROMPTS" "$CONC" 0 || echo "!!! cold round failed (continuing)"
@@ -731,10 +723,9 @@ if [ "${BENCH_COLD_FINAL:-0}" = "1" ] && [ "$REUSE_SERVER" != "1" ]; then
 fi
 
 # ---- optional outer warmup (never timed) ----
-# Cache-cold isolated replicas skip this invocation: their benchmark client still
-# performs its own internal warmup, but the timed prompt set is not pre-populated
-# by an earlier full replay. Legacy/default runs retain the historical short
-# CONC-prompt warmup, and explicit full-round callers retain the full warmup.
+# Cache-cold isolated replicas skip it (the client still warms itself internally; the
+# timed prompt set just is not pre-replayed). Legacy keeps the short CONC-prompt warmup;
+# warm_server sets BENCH_OUTER_WARMUP_FULL_ROUND=1 for the full discarded round.
 if [ "${GEAK_ISOLATED_REPLICA:-0}" = "1" ] \
    && [ "${BENCH_OUTER_WARMUP_FULL_ROUND:-0}" != "1" ]; then
   echo ">>> Skipping outer warmup (compute-warm/cache-cold isolated replica) ..."
@@ -748,7 +739,8 @@ else
   fi
   if ! adapter_bench "$_warmup_prompts" "$CONC" 0 >/dev/null 2>&1; then
     if [ "${BENCH_OUTER_WARMUP_FULL_ROUND:-0}" = "1" ]; then
-      echo "!!! Full outer warmup failed; isolated replica is invalid." >&2
+      echo "!!! Full outer warmup failed; this measurement is invalid" \
+           "(the timed rounds would not be warm)." >&2
       exit 2
     fi
   fi
@@ -854,90 +846,6 @@ PY
 fi
 
 # ---- summarize (median throughput across repeats) — backend-independent ----
-python3 - "$RESULT_JSONL" "$OUT_DIR/bench_summary.json" "$COLD_JSONL" <<'PY'
-import json, os, sys, statistics
-runs_path, out_path = sys.argv[1], sys.argv[2]
-cold_path = sys.argv[3] if len(sys.argv) > 3 else None
-def pick(d, *keys):
-    for k in keys:
-        if k in d and isinstance(d[k], (int, float)): return float(d[k])
-    return None
-# metric selection: default = OUTPUT-only token throughput (output/s), to match the Hyperloom
-# orchestrator's baseline/explore basis (see collectors/_common.py + collectors/explore.py, both read
-# output_throughput). Set E2E_METRIC=total for total (input+output)/s. Same key is read for
-# baseline+cand so the accept RATIO is consistent; metric_basis records which was used.
-_metric = (os.environ.get("E2E_METRIC") or "output").strip().lower()
-_is_total = _metric in ("total", "total_token", "total_throughput")
-_TPUT_KEYS = (("total_token_throughput", "total_throughput", "total_token_throughput_tok_s")
-              if _is_total else
-              ("output_throughput", "output_token_throughput", "output_throughput_tok_s"))
-def read_tps(path):
-    xs = []
-    if not path: return xs
-    try:
-        with open(path) as fh:
-            for line in fh:
-                line = line.strip()
-                if not line: continue
-                try: d = json.loads(line)
-                except Exception: continue
-                v = pick(d, *_TPUT_KEYS)
-                if v is not None: xs.append(v)
-    except FileNotFoundError:
-        pass
-    return xs
-tps, ttft, tpot = [], [], []
-with open(runs_path) as fh:
-    for line in fh:
-        line = line.strip()
-        if not line: continue
-        try: d = json.loads(line)
-        except Exception: continue
-        v = pick(d, *_TPUT_KEYS)
-        if v is not None: tps.append(v)
-        t = pick(d, "median_ttft_ms", "mean_ttft_ms");   ttft.append(t) if t is not None else None
-        p = pick(d, "median_tpot_ms", "mean_tpot_ms");   tpot.append(p) if p is not None else None
-cold_tps = read_tps(cold_path)
-def med(xs): return statistics.median(xs) if xs else None
-def spread(xs):
-    if len(xs) < 2: return 0.0
-    m = med(xs); return round(100.0 * (max(xs)-min(xs)) / m, 2) if m else 0.0
-_tput_med = round(med(tps), 3) if tps else None
-_tput_spread = spread(tps)
-summ = {
-    # Canonical, metric-neutral throughput of the SELECTED basis (see metric_basis). Downstream should
-    # read this + metric_basis; the accept RATIO is basis-consistent (baseline+cand use the same metric).
-    "throughput_tok_s_median": _tput_med,
-    "throughput_tok_s_spread_pct": _tput_spread,
-    # Legacy output-named alias: populated ONLY in output mode (its literal meaning). In total mode it is
-    # None so nobody silently reads total throughput under an "output" name — read throughput_tok_s_median.
-    "output_throughput_tok_s_median": _tput_med if not _is_total else None,
-    "output_throughput_tok_s_spread_pct": _tput_spread if not _is_total else None,
-    "ttft_ms_median": round(med(ttft), 3) if ttft else None,
-    "tpot_ms_median": round(med(tpot), 3) if tpot else None,
-    "runs": len(tps),
-    "all_throughput": tps,
-    # Optional COLD full-round (BENCH_COLD_FINAL=1): a single fresh-server round with
-    # JIT/graph-capture costs included, for cold-to-cold parity vs Hyperloom's
-    # baseline_tput. None when the cold round was not run (default). The hot median
-    # above stays the primary metric so existing consumers are unaffected. Uses the
-    # SAME metric basis (E2E_METRIC) as the hot median for a consistent comparison.
-    "cold_output_throughput_tok_s": round(med(cold_tps), 3) if cold_tps else None,
-    "cold_runs": len(cold_tps),
-    # Aggregate tok/s (NOT divided by TP). Default matches Hyperloom/Magpie output_throughput protocol;
-    # E2E_METRIC=total switches to total (input+output) token throughput.
-    "metric_basis": ("aggregate_total_token_tok_s" if _is_total else "aggregate_output_tok_s"),
-    "measurement_mode": (
-        "isolated_server_replica"
-        if os.environ.get("GEAK_ISOLATED_REPLICA") == "1"
-        else "legacy_same_server"
-    ),
-    "effective_config_digest": os.environ.get("EFFECTIVE_CONFIG_DIGEST") or None,
-}
-with open(out_path, "w") as fh: json.dump(summ, fh, indent=2)
-print(f"E2E_SUMMARY {summ['metric_basis']}={summ['throughput_tok_s_median']} "
-      f"spread={summ['throughput_tok_s_spread_pct']}% "
-      f"ttft_ms={summ['ttft_ms_median']} tpot_ms={summ['tpot_ms_median']} runs={summ['runs']}")
-PY
+python3 "$SUMMARIZE" from-runs "$RESULT_JSONL" "$OUT_DIR/bench_summary.json" "$COLD_JSONL"
 
 echo ">>> Done. Summary: $OUT_DIR/bench_summary.json"

--- a/e2e_workflow/scripts/bench_e2e.sh
+++ b/e2e_workflow/scripts/bench_e2e.sh
@@ -2,12 +2,21 @@
 # Backend-agnostic e2e serving benchmark dispatcher for e2e_workflow.
 #
 # ONE script the Director, Profiler, Config Tuner, and e2e Integrator all share so every throughput
-# number is measured the SAME way (warm server, fixed ISL/OSL/conc, repeated, median reported). The
-# serving STACK (sglang / vllm / ...) is NOT baked in here — it lives in scripts/adapters/<backend>.sh.
-# This dispatcher owns only the stack-INDEPENDENT parts:
+# number is measured the SAME way (warm server, fixed ISL/OSL/conc, same lifecycle for both legs of
+# every comparison). The serving STACK (sglang / vllm / ...) is NOT baked in here — it lives in
+# scripts/adapters/<backend>.sh. This dispatcher owns only the stack-INDEPENDENT parts:
 #   * server lifecycle (launch / health-wait / cleanup), or reuse of a warm server (REUSE_SERVER=1),
-#   * warmup (never timed) + N timed repeats + optional bounded profiling trace,
-#   * median throughput + spread summary (one machine-readable line + JSON).
+#   * warmup (never timed) + N timed rounds + optional bounded profiling trace,
+#   * throughput summary (one machine-readable line + JSON).
+#
+# NUMBERS ARE ONLY COMPARABLE WITHIN ONE LIFECYCLE. warm_server reports a round against a server that
+# has already served a full one, so it differs from the cold-cache isolated_server/legacy number for
+# the SAME config by an amount whose sign and size are not predictable from the config alone: it rises
+# with prefix-cache reuse, and a workload with little shared prefix can land either way (measured on
+# DeepSeek-V4-Pro TP8, RANDOM_RANGE_RATIO=1.0 / ISL 8192: warm 826.9 vs isolated median 833.3 tok/s).
+# So never ratio a warm_server leg against an isolated_server one, and never compare a number produced
+# here against a pre-warm_server record (KB entries, old reports) — re-measure the reference instead.
+# `bench_summary.json.measurement_mode` says which lifecycle produced any given number.
 # It is config-driven by env so an agent can vary ONE axis at a time. Nothing is model-specific.
 #
 # GEAK_REPEAT_MODE picks the measurement lifecycle:
@@ -65,17 +74,21 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# ---- summary emitter ----
-# Every lifecycle ends by writing bench_summary.json with bench_summarize.py.  Resolved up here,
-# before anything is launched: this script is COPIED into $EVAL_DIR (roles/director.md), and
-# discovering a missing sibling only after a full bench would throw away the very measurement it
-# was supposed to record.  Same staging rule as server_teardown.sh below.
-SUMMARIZE=""
-for _cand in "$HERE/bench_summarize.py" "${SKILL_DIR:-}/scripts/bench_summarize.py" \
-             "${WORKFLOW_DIR:-}/scripts/bench_summarize.py"; do
-  case "$_cand" in /scripts/bench_summarize.py) continue ;; esac   # unset SKILL_DIR/WORKFLOW_DIR
-  [ -f "$_cand" ] && { SUMMARIZE="$_cand"; break; }
-done
+# ---- staged siblings ----
+# This script is COPIED into $EVAL_DIR (roles/director.md), so its helper libraries resolve from $HERE
+# first, then the skill dir.  Both are resolved up here, before anything is launched: discovering a
+# missing sibling only after a full bench would throw away the very measurement it was meant to record.
+_stage_lookup() {   # _stage_lookup NAME -> print the first copy that exists; rc=1 if none
+  local _n="$1" _c
+  for _c in "$HERE/$_n" "${SKILL_DIR:-}/scripts/$_n" "${WORKFLOW_DIR:-}/scripts/$_n"; do
+    case "$_c" in /scripts/"$_n") continue ;; esac   # unset SKILL_DIR/WORKFLOW_DIR
+    [ -f "$_c" ] && { printf '%s\n' "$_c"; return 0; }
+  done
+  return 1
+}
+
+# Every lifecycle ends by writing bench_summary.json with bench_summarize.py.
+SUMMARIZE="$(_stage_lookup bench_summarize.py)"
 if [ -z "$SUMMARIZE" ]; then
   echo "!!! bench_summarize.py not found next to this script ($HERE) or under SKILL_DIR/WORKFLOW_DIR." >&2
   echo "    Stage it alongside bench_e2e.sh: cp \"\$SKILL_DIR/scripts/bench_summarize.py\" \"\$EVAL_DIR/\"" >&2
@@ -114,6 +127,28 @@ if [ "${GEAK_REPEAT_MODE:-legacy}" = "isolated_server" ] && [ "${PROFILE:-0}" = 
   GEAK_REPEAT_MODE=legacy
 fi
 
+# ---- sample count ----
+# Shared by both multi-sample lifecycles so they cannot drift apart: an explicit REPEATS wins, then
+# REPLICAS, then the purpose default (arg $1; every other purpose gets one sample).
+_resolve_samples() {   # _resolve_samples VALIDATION_DEFAULT NOUN MODE -> sets _samples
+  if [ -n "${REPEATS+x}" ]; then
+    _samples="$REPEATS"
+  elif [ -n "${REPLICAS+x}" ]; then
+    _samples="$REPLICAS"
+  else
+    case "$_purpose" in
+      validation) _samples="$1" ;;
+      parity|search|"") _samples=1 ;;
+      *) echo ">>> Unknown MEASUREMENT_PURPOSE='$_purpose'; using 1 $2." >&2; _samples=1 ;;
+    esac
+  fi
+  case "$_samples" in
+    ''|*[!0-9]*|0)
+      echo "!!! REPEATS must be a positive integer in $3 mode (got '$_samples')." >&2
+      exit 4 ;;
+  esac
+}
+
 # ---- warm-server measurement protocol (Hyperloom-aligned) ----
 # ONE server per leg: a full untimed round populates the prefix cache, then $ROUNDS timed rounds on
 # that same hot server (median).  Byte-for-byte baseline.py's warmup_round/measure_round, so both
@@ -124,23 +159,8 @@ fi
 # variance needs isolated_server.
 if [ "${GEAK_REPEAT_MODE:-legacy}" = "warm_server" ]; then
   _purpose="${MEASUREMENT_PURPOSE:-search}"
-  if [ -n "${REPEATS+x}" ]; then
-    _rounds="$REPEATS"
-  elif [ -n "${REPLICAS+x}" ]; then
-    _rounds="$REPLICAS"
-  else
-    case "$_purpose" in
-      validation|parity|search|"") _rounds=1 ;;
-      *)
-        echo ">>> Unknown MEASUREMENT_PURPOSE='$_purpose'; using 1 timed round." >&2
-        _rounds=1 ;;
-    esac
-  fi
-  case "$_rounds" in
-    ''|*[!0-9]*|0)
-      echo "!!! REPEATS must be a positive integer in warm-server mode (got '$_rounds')." >&2
-      exit 4 ;;
-  esac
+  _resolve_samples 1 "timed round" warm-server
+  _rounds="$_samples"
   REPEATS="$_rounds"
   BENCH_OUTER_WARMUP_FULL_ROUND=1   # round 1 is a FULL round, and it is discarded
   BENCH_COLD_FINAL=0                # a cold round would defeat the point of warming
@@ -149,13 +169,9 @@ if [ "${GEAK_REPEAT_MODE:-legacy}" = "warm_server" ]; then
   MEASUREMENT_PURPOSE="$_purpose"
   export REPEATS BENCH_OUTER_WARMUP_FULL_ROUND BENCH_COLD_FINAL \
          GEAK_ISOLATED_REPLICA WARM_SERVER_ROUNDS MEASUREMENT_PURPOSE
-  if [ "$_rounds" = "1" ]; then
-    echo "Measurement: warm_server  purpose=$_purpose  timed_rounds=1" \
-         "(Hyperloom lifecycle: 1 server, round 1 = full warmup discarded, round 2 = the reported number)"
-  else
-    echo "Measurement: warm_server  purpose=$_purpose  timed_rounds=$_rounds" \
-         "(1 server, 1 discarded full warmup round, median of the timed rounds)"
-  fi
+  echo "Measurement: warm_server  purpose=$_purpose  timed_rounds=$_rounds" \
+       "(Hyperloom lifecycle: 1 server, round 1 = full warmup discarded," \
+       "$([ "$_rounds" = 1 ] && echo "round 2 = the reported number)" || echo "median of the $_rounds timed rounds)")"
   GEAK_REPEAT_MODE=legacy
 fi
 if [ "${GEAK_REPEAT_MODE:-legacy}" = "isolated_server" ]; then
@@ -169,24 +185,8 @@ if [ "${GEAK_REPEAT_MODE:-legacy}" = "isolated_server" ]; then
     exit 4
   fi
   _purpose="${MEASUREMENT_PURPOSE:-search}"
-  if [ -n "${REPEATS+x}" ]; then
-    _requested="$REPEATS"
-  elif [ -n "${REPLICAS+x}" ]; then
-    _requested="$REPLICAS"
-  else
-    case "$_purpose" in
-      validation) _requested=3 ;;
-      parity|search|"") _requested=1 ;;
-      *)
-        echo ">>> Unknown MEASUREMENT_PURPOSE='$_purpose'; using 1 isolated replica." >&2
-        _requested=1 ;;
-    esac
-  fi
-  case "$_requested" in
-    ''|*[!0-9]*|0)
-      echo "!!! REPEATS must be a positive integer in isolated-server mode (got '$_requested')." >&2
-      exit 4 ;;
-  esac
+  _resolve_samples 3 "isolated replica" isolated-server
+  _requested="$_samples"
 
   _aggregate_out="${OUT_DIR:-$(pwd)/e2e_bench_out}"
   mkdir -p "$_aggregate_out"
@@ -563,17 +563,10 @@ SERVER_PID=""
 # any role-authored capture script share ONE identity-verified kill. The old cleanup resolved
 # the pgid AT KILL TIME and group-killed whenever it differed from ours — a recycled pid then
 # resolves to a stranger's group, which is how a teardown reaches the caller's orchestrator.
-#
-# Same staging rule as SUMMARIZE above, but the failure mode is worse: without the library
-# `source` fails, the EXIT trap binds a missing function, and the server is left holding its
-# VRAM and port after the serving-GPU lock is released, so the next launch OOMs. A benchmark
-# that cannot stop what it starts must not start it.
-TEARDOWN_LIB=""
-for _cand in "$HERE/server_teardown.sh" "${SKILL_DIR:-}/scripts/server_teardown.sh" \
-             "${WORKFLOW_DIR:-}/scripts/server_teardown.sh"; do
-  case "$_cand" in /scripts/server_teardown.sh) continue ;; esac   # unset SKILL_DIR/WORKFLOW_DIR
-  [ -f "$_cand" ] && { TEARDOWN_LIB="$_cand"; break; }
-done
+# Missing it is worse than a missing summarizer: `source` fails, the EXIT trap binds a missing
+# function, and the server keeps its VRAM and port after the serving-GPU lock is released, so the
+# next launch OOMs. A benchmark that cannot stop what it starts must not start it.
+TEARDOWN_LIB="$(_stage_lookup server_teardown.sh)"
 if [ -z "$TEARDOWN_LIB" ]; then
   echo "!!! server_teardown.sh not found next to this script ($HERE) or under SKILL_DIR/WORKFLOW_DIR." >&2
   echo "    It carries the server-kill contract; without it the EXIT trap is a no-op and the" >&2

--- a/e2e_workflow/scripts/bench_summarize.py
+++ b/e2e_workflow/scripts/bench_summarize.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Write bench_summary.json + the E2E_SUMMARY line for bench_e2e.sh.
+
+Two input shapes, ONE acceptance contract:
+
+  --from-runs      one server's per-round rows (bench_runs.jsonl).  Used by the legacy and
+                   warm_server lifecycles.  With WARM_SERVER_ROUNDS set, a "round" is a sample.
+  --from-replicas  one isolated_server leg's replica_*/selected_summary.json files, each already
+                   summarized by a nested bench_e2e.sh run.  A "replica" is a sample.
+
+Both emit status / requested_* / successful_* / usable_for_acceptance / observed_median, because
+every caller (director:validate, the integrator A/B) reads one shape whichever lifecycle produced
+the number.  Keeping the two emitters in one file is the point: when they lived in two heredocs
+inside bench_e2e.sh, adding a contract field to one and not the other produced two different
+bench_summary.json shapes with nothing to catch it.
+
+Throughput basis: OUTPUT-only tok/s by default, matching the Hyperloom orchestrator's
+baseline/explore collectors (they read output_throughput).  E2E_METRIC=total switches to total
+(input+output).  Baseline and candidate read the same key, so the accept RATIO is basis-consistent;
+metric_basis records which was used.  Values are aggregate, NOT divided by TP.
+"""
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+
+TOTAL_KEYS = ("total_token_throughput", "total_throughput", "total_token_throughput_tok_s")
+OUTPUT_KEYS = ("output_throughput", "output_token_throughput", "output_throughput_tok_s")
+
+
+def _is_total():
+    return (os.environ.get("E2E_METRIC") or "output").strip().lower() in (
+        "total", "total_token", "total_throughput")
+
+
+def _num(d, *keys):
+    for k in keys:
+        if k in d and isinstance(d[k], (int, float)):
+            return float(d[k])
+    return None
+
+
+def _med3(xs):
+    return round(statistics.median(xs), 3) if xs else None
+
+
+def _spread_pct(xs):
+    """Max-min as a % of the median. 0.0 for a single sample: no spread, not unknown."""
+    if len(xs) < 2:
+        return 0.0
+    m = statistics.median(xs)
+    return round(100.0 * (max(xs) - min(xs)) / m, 2) if m else 0.0
+
+
+def _contract(requested, successful, observed, usable):
+    """The fields every caller gates on, spelled the same way in both modes."""
+    return {
+        "requested_replicas": requested,
+        "successful_replicas": successful,
+        "status": "complete" if successful == requested and requested > 0 else "incomplete",
+        "usable_for_acceptance": usable,
+        "observed_median": observed,
+    }
+
+
+def _emit(summary, out_path, tail):
+    with open(out_path, "w") as fh:
+        json.dump(summary, fh, indent=2)
+    print(f"E2E_SUMMARY {summary.get('metric_basis') or 'unknown'}="
+          f"{summary['throughput_tok_s_median']} "
+          f"spread={summary['throughput_tok_s_spread_pct']}% " + tail)
+
+
+def from_runs(args):
+    keys = TOTAL_KEYS if _is_total() else OUTPUT_KEYS
+
+    def read(path):
+        xs = []
+        try:
+            with open(path) as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        d = json.loads(line)
+                    except ValueError:
+                        continue
+                    v = _num(d, *keys)
+                    if v is not None:
+                        xs.append(v)
+        except FileNotFoundError:
+            pass
+        return xs
+
+    tps, ttft, tpot = [], [], []
+    with open(args.runs) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+            except ValueError:
+                continue
+            v = _num(d, *keys)
+            if v is not None:
+                tps.append(v)
+            for src, dst in ((("median_ttft_ms", "mean_ttft_ms"), ttft),
+                             (("median_tpot_ms", "mean_tpot_ms"), tpot)):
+                x = _num(d, *src)
+                if x is not None:
+                    dst.append(x)
+    cold = read(args.cold) if args.cold else []
+    med, spread = _med3(tps), _spread_pct(tps)
+    total = _is_total()
+    summary = {
+        # Canonical, metric-neutral throughput of the SELECTED basis. Downstream reads this +
+        # metric_basis. The output_*-named pair below is a legacy alias, populated ONLY in output
+        # mode so nobody silently reads total throughput under an "output" name.
+        "throughput_tok_s_median": med,
+        "throughput_tok_s_spread_pct": spread,
+        "output_throughput_tok_s_median": None if total else med,
+        "output_throughput_tok_s_spread_pct": None if total else spread,
+        "ttft_ms_median": _med3(ttft),
+        "tpot_ms_median": _med3(tpot),
+        "runs": len(tps),
+        "all_throughput": tps,
+        # Optional diagnostic cold round (BENCH_COLD_FINAL=1): one fresh-server round with
+        # JIT/graph-capture costs included, same metric basis as the hot median. None by default.
+        "cold_output_throughput_tok_s": _med3(cold),
+        "cold_runs": len(cold),
+        "metric_basis": "aggregate_total_token_tok_s" if total else "aggregate_output_tok_s",
+        "measurement_mode": ("isolated_server_replica"
+                             if os.environ.get("GEAK_ISOLATED_REPLICA") == "1"
+                             else "legacy_same_server"),
+        "effective_config_digest": os.environ.get("EFFECTIVE_CONFIG_DIGEST") or None,
+    }
+    tail = (f"ttft_ms={summary['ttft_ms_median']} tpot_ms={summary['tpot_ms_median']} "
+            f"runs={summary['runs']} ")
+    warm = os.environ.get("WARM_SERVER_ROUNDS")
+    if warm:
+        try:
+            requested = int(warm)
+        except ValueError:
+            requested = 0
+        summary["measurement_mode"] = "warm_server"
+        summary["measurement_purpose"] = os.environ.get("MEASUREMENT_PURPOSE") or None
+        summary.update(_contract(requested, len(tps), med,
+                                 bool(len(tps) == requested and requested > 0 and med)))
+        # A round and a replica are both "one sample" to the contract, but only these names say
+        # which one this leg actually took.
+        summary["requested_rounds"] = requested
+        summary["successful_rounds"] = len(tps)
+        # Samples from ONE server bound client noise; boot-to-boot variance needs isolated_server.
+        summary["dispersion_basis"] = "within_server_rounds"
+        tail += (f"status={summary['status']} "
+                 f"usable_for_acceptance={str(summary['usable_for_acceptance']).lower()} ")
+    _emit(summary, args.out, tail + f"measurement_mode={summary['measurement_mode']}")
+
+
+def from_replicas(args):
+    summaries, replicas = [], []
+    for path in sorted(glob.glob(os.path.join(args.dir, "replica_*", "selected_summary.json"))):
+        rdir = os.path.dirname(path)
+        index = int(os.path.basename(rdir).split("_")[-1])
+        if index > args.requested:      # a stale replica dir from a longer previous run
+            continue
+        with open(path) as fh:
+            summaries.append(json.load(fh))
+        try:
+            attempt = int(open(os.path.join(rdir, "selected_attempt")).read().strip())
+        except (OSError, ValueError):
+            attempt = None
+        replicas.append({"replica": index, "attempt": attempt,
+                         "throughput_tok_s": summaries[-1].get("throughput_tok_s_median")})
+
+    def col(key):
+        return [float(s[key]) for s in summaries
+                if isinstance(s.get(key), (int, float)) and not isinstance(s.get(key), bool)]
+
+    tps = col("throughput_tok_s_median")
+    med, spread = _med3(tps), _spread_pct(tps)
+    bases = {s.get("metric_basis") for s in summaries if s.get("metric_basis")}
+    basis = next(iter(bases)) if len(bases) == 1 else None
+    is_output = basis == "aggregate_output_tok_s"
+    summary = {
+        "requested": args.requested,
+        "successful": args.successful,
+        **_contract(args.requested, args.successful, med,
+                    args.successful == args.requested and med is not None),
+        "measurement_mode": "isolated_server",
+        "measurement_purpose": args.purpose,
+        "effective_config_digest": args.digest or None,
+        "throughput_tok_s_median": med,
+        "throughput_tok_s_spread_pct": spread,
+        "output_throughput_tok_s_median": med if is_output else None,
+        "output_throughput_tok_s_spread_pct": spread if is_output else None,
+        "ttft_ms_median": _med3(col("ttft_ms_median")),
+        "tpot_ms_median": _med3(col("tpot_ms_median")),
+        "runs": args.successful,
+        "all_throughput": tps,
+        "metric_basis": basis,
+        "replicas": replicas,
+    }
+    _emit(summary, os.path.join(args.dir, "bench_summary.json"),
+          f"requested={args.requested} successful={args.successful} "
+          f"status={summary['status']} "
+          f"usable_for_acceptance={str(summary['usable_for_acceptance']).lower()} "
+          "measurement_mode=isolated_server")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="mode", required=True)
+    r = sub.add_parser("from-runs")
+    r.add_argument("runs"); r.add_argument("out"); r.add_argument("cold", nargs="?")
+    r.set_defaults(fn=from_runs)
+    p = sub.add_parser("from-replicas")
+    p.add_argument("dir"); p.add_argument("requested", type=int)
+    p.add_argument("successful", type=int); p.add_argument("purpose")
+    p.add_argument("digest", nargs="?", default="")
+    p.set_defaults(fn=from_replicas)
+    a = ap.parse_args(argv)
+    a.fn(a)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e_workflow/scripts/bench_summarize.py
+++ b/e2e_workflow/scripts/bench_summarize.py
@@ -171,7 +171,8 @@ def from_replicas(args):
         with open(path) as fh:
             summaries.append(json.load(fh))
         try:
-            attempt = int(open(os.path.join(rdir, "selected_attempt")).read().strip())
+            with open(os.path.join(rdir, "selected_attempt")) as fh:
+                attempt = int(fh.read().strip())
         except (OSError, ValueError):
             attempt = None
         replicas.append({"replica": index, "attempt": attempt,

--- a/e2e_workflow/scripts/test_tuning_skillset_phase.js
+++ b/e2e_workflow/scripts/test_tuning_skillset_phase.js
@@ -234,8 +234,12 @@ if (role) {
     ok(role.includes(key), `role consumes ${key}`);
   }
   ok(/never edit anything inside it/i.test(role), 'role forbids editing the vendored tree');
-  ok(/engagement/i.test(role) && /isolated-server A\/B/i.test(role),
-    'role carries engagement proof and the isolated-server A/B contract');
+  // The A/B contract is now lifecycle-agnostic: the role must NOT name a lifecycle of its own, it
+  // must pass MEASUREMENT_MODE through. Naming one is how this role used to override the run default.
+  ok(/engagement/i.test(role) && /pre\/post A\/B/i.test(role),
+    'role carries engagement proof and the pre/post A/B contract');
+  ok(/MEASUREMENT_MODE/.test(role) && !/isolated-server A\/B/i.test(role),
+    'role defers the lifecycle to MEASUREMENT_MODE instead of pinning isolated-server');
   // The point of vendoring whole is that the METHOD stays in the skillset. The role must route into it
   // and must not grow into a paraphrase of the loop, which is the failure mode this guards.
   ok(/[Rr]ead them and use them/.test(role),

--- a/e2e_workflow/scripts/tests/test_bench_e2e_teardown_lookup.py
+++ b/e2e_workflow/scripts/tests/test_bench_e2e_teardown_lookup.py
@@ -73,6 +73,10 @@ class BenchTeardownLookupTest(unittest.TestCase):
             OUT_DIR=os.path.join(self.tmp, "out"),
             REPEATS="1",
             PROFILE="0",
+            # The two cases that get past the gate walk on into the serving-GPU mutex, which is
+            # a real /tmp lock shared with whatever benchmark is live on this box -- without this
+            # the suite blocks for SERVING_LOCK_WAIT behind an unrelated run and reads as a hang.
+            SERVING_GPU_LOCK_DISABLE="1",
         )
         run_env.update(env)
         return subprocess.run(

--- a/e2e_workflow/scripts/tests/test_bench_e2e_teardown_lookup.py
+++ b/e2e_workflow/scripts/tests/test_bench_e2e_teardown_lookup.py
@@ -26,6 +26,7 @@ import unittest
 SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BENCH = os.path.join(SCRIPTS_DIR, "bench_e2e.sh")
 LIB = os.path.join(SCRIPTS_DIR, "server_teardown.sh")
+SUMMARIZE = os.path.join(SCRIPTS_DIR, "bench_summarize.py")
 ADAPTERS = os.path.join(SCRIPTS_DIR, "adapters")
 
 BASH = shutil.which("bash")
@@ -42,6 +43,7 @@ class BenchTeardownLookupTest(unittest.TestCase):
         # Stage exactly what roles/director.md stages, minus the file under test.
         shutil.copy(BENCH, os.path.join(self.eval_dir, "bench_e2e.sh"))
         shutil.copytree(ADAPTERS, os.path.join(self.eval_dir, "adapters"))
+        shutil.copy(SUMMARIZE, os.path.join(self.eval_dir, "bench_summarize.py"))
 
         # A stub backend adapter (sourced at the top, long before the gate) so a run
         # that gets PAST the gate stops immediately at the launch instead of spending
@@ -105,6 +107,17 @@ class BenchTeardownLookupTest(unittest.TestCase):
         self.assertNotEqual(proc.returncode, MISSING_LIB_RC, proc.stderr[-2000:])
         self.assertIn("teardown contract:", proc.stdout + proc.stderr)
         self.assertIn("STUB_LAUNCH_REACHED", proc.stdout, "never reached the launch")
+
+    def test_missing_summarizer_refuses_before_the_launch(self):
+        """Same staging rule for the summary emitter: a run that cannot RECORD its
+        measurement must not spend a server booting to take one."""
+        self.stage_lib(self.eval_dir)
+        os.remove(os.path.join(self.eval_dir, "bench_summarize.py"))
+        proc = self.run_bench()
+        self.assertEqual(proc.returncode, MISSING_LIB_RC, proc.stderr[-2000:])
+        self.assertIn("bench_summarize.py not found", proc.stderr)
+        self.assertIn("cp ", proc.stderr)
+        self.assertNotIn("STUB_LAUNCH_REACHED", proc.stdout, "launched anyway")
 
     def test_empty_skill_dir_does_not_resolve_to_an_absolute_path(self):
         """With SKILL_DIR="" the candidate degrades to /scripts/server_teardown.sh; a

--- a/e2e_workflow/scripts/tests/test_bench_summarize.py
+++ b/e2e_workflow/scripts/tests/test_bench_summarize.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Unit tests for bench_summarize.py -- the writer of bench_summary.json.
+
+Run:  python3 -m unittest discover -s e2e_workflow/scripts/tests -v
+
+WHY THESE EXIST: this file used to be two Python heredocs inside bench_e2e.sh, one per
+lifecycle, and nothing checked that they agreed. Every acceptance decision in the product
+reads their output -- the director's validate step, the integrator's A/B, the orchestrator
+handoff -- so a renamed key or a status that says "complete" on a short round is a wrong
+accept, not a crash. The keys and the E2E_SUMMARY line are therefore pinned here.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SUMMARIZE = os.path.join(SCRIPTS_DIR, "bench_summarize.py")
+
+
+def _run(args, env=None):
+    e = dict(os.environ)
+    e.pop("E2E_METRIC", None)
+    e.pop("WARM_SERVER_ROUNDS", None)
+    e.pop("GEAK_ISOLATED_REPLICA", None)
+    e.pop("MEASUREMENT_PURPOSE", None)
+    e.pop("EFFECTIVE_CONFIG_DIGEST", None)
+    e.update(env or {})
+    proc = subprocess.run([sys.executable, SUMMARIZE] + args,
+                          env=e, capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+class FromRunsTest(unittest.TestCase):
+    """bench_runs.jsonl -> summary. The legacy and warm_server lifecycles."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="summarize_runs_")
+        self.runs = os.path.join(self.tmp, "bench_runs.jsonl")
+        self.out = os.path.join(self.tmp, "bench_summary.json")
+
+    def write_runs(self, path, tputs):
+        with open(path, "w", encoding="utf-8") as fh:
+            for i, t in enumerate(tputs):
+                fh.write(json.dumps({"output_throughput": t,
+                                     "total_token_throughput": t * 9,
+                                     "median_ttft_ms": 40.0 + i,
+                                     "median_tpot_ms": 8.0 + i}) + "\n")
+            # A malformed tail must be skipped, not abort the summary: losing the whole
+            # measurement to one truncated line is the expensive failure here.
+            fh.write("\n{not json}\n")
+
+    def summarize(self, tputs, cold=None, env=None):
+        self.write_runs(self.runs, tputs)
+        args = [self.runs, self.out]
+        if cold is not None:
+            cold_path = os.path.join(self.tmp, "cold.jsonl")
+            self.write_runs(cold_path, cold)
+            args.append(cold_path)
+        line = _run(["from-runs"] + args, env)
+        with open(self.out, encoding="utf-8") as fh:
+            return json.load(fh), line
+
+    def test_median_spread_and_basis(self):
+        s, line = self.summarize([100.0, 103.5, 107.0])
+        self.assertEqual(s["throughput_tok_s_median"], 103.5)
+        self.assertEqual(s["throughput_tok_s_spread_pct"], 6.76)
+        self.assertEqual(s["runs"], 3)
+        self.assertEqual(s["all_throughput"], [100.0, 103.5, 107.0])
+        self.assertEqual(s["metric_basis"], "aggregate_output_tok_s")
+        self.assertEqual(s["measurement_mode"], "legacy_same_server")
+        self.assertIn("E2E_SUMMARY aggregate_output_tok_s=103.5", line)
+        self.assertIn("measurement_mode=legacy_same_server", line)
+
+    def test_single_round_reports_zero_spread_not_null(self):
+        """0.0 means 'no spread'; None would read as 'unknown' and gate differently."""
+        s, _ = self.summarize([100.0])
+        self.assertEqual(s["throughput_tok_s_spread_pct"], 0.0)
+
+    def test_total_metric_nulls_the_output_named_alias(self):
+        """Nobody may read total throughput under an output_* name."""
+        s, line = self.summarize([100.0, 110.0], env={"E2E_METRIC": "total"})
+        self.assertEqual(s["metric_basis"], "aggregate_total_token_tok_s")
+        self.assertEqual(s["throughput_tok_s_median"], 945.0)
+        self.assertIsNone(s["output_throughput_tok_s_median"])
+        self.assertIsNone(s["output_throughput_tok_s_spread_pct"])
+        self.assertIn("aggregate_total_token_tok_s=945.0", line)
+
+    def test_cold_round_is_separate_and_absent_by_default(self):
+        s, _ = self.summarize([100.0, 110.0])
+        self.assertIsNone(s["cold_output_throughput_tok_s"])
+        self.assertEqual(s["cold_runs"], 0)
+        s, _ = self.summarize([100.0, 110.0], cold=[50.0, 60.0])
+        self.assertEqual(s["cold_output_throughput_tok_s"], 55.0)
+        self.assertEqual(s["cold_runs"], 2)
+        self.assertEqual(s["throughput_tok_s_median"], 105.0, "cold leaked into the hot median")
+
+    def test_isolated_replica_labels_itself(self):
+        s, _ = self.summarize([100.0], env={"GEAK_ISOLATED_REPLICA": "1"})
+        self.assertEqual(s["measurement_mode"], "isolated_server_replica")
+
+    def test_warm_server_contract_complete(self):
+        s, line = self.summarize([100.0], env={
+            "WARM_SERVER_ROUNDS": "1", "MEASUREMENT_PURPOSE": "validation",
+            "EFFECTIVE_CONFIG_DIGEST": "abc123"})
+        self.assertEqual(s["measurement_mode"], "warm_server")
+        self.assertEqual(s["measurement_purpose"], "validation")
+        self.assertEqual(s["requested_rounds"], 1)
+        self.assertEqual(s["successful_rounds"], 1)
+        # Rounds and replicas are both "one sample" to the contract; callers read either.
+        self.assertEqual(s["requested_replicas"], 1)
+        self.assertEqual(s["successful_replicas"], 1)
+        self.assertEqual(s["status"], "complete")
+        self.assertTrue(s["usable_for_acceptance"])
+        self.assertEqual(s["observed_median"], 100.0)
+        self.assertEqual(s["dispersion_basis"], "within_server_rounds")
+        self.assertEqual(s["effective_config_digest"], "abc123")
+        self.assertIn("status=complete usable_for_acceptance=true", line)
+
+    def test_short_warm_run_is_not_usable_for_acceptance(self):
+        """2 of 3 rounds still has a median -- accepting on it is the bug."""
+        s, line = self.summarize([100.0, 110.0], env={"WARM_SERVER_ROUNDS": "3"})
+        self.assertEqual(s["status"], "incomplete")
+        self.assertFalse(s["usable_for_acceptance"])
+        self.assertEqual(s["successful_rounds"], 2)
+        self.assertIn("usable_for_acceptance=false", line)
+
+    def test_unparseable_round_count_fails_closed(self):
+        s, _ = self.summarize([100.0], env={"WARM_SERVER_ROUNDS": "notanint"})
+        self.assertEqual(s["status"], "incomplete")
+        self.assertFalse(s["usable_for_acceptance"])
+
+    def test_no_warm_rounds_emits_no_contract_fields(self):
+        """The legacy shape must not grow a status the caller would trust."""
+        s, line = self.summarize([100.0])
+        for k in ("status", "usable_for_acceptance", "requested_rounds", "observed_median"):
+            self.assertNotIn(k, s)
+        self.assertNotIn("status=", line)
+
+
+class FromReplicasTest(unittest.TestCase):
+    """replica_*/selected_summary.json -> summary. The isolated_server lifecycle."""
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="summarize_reps_")
+
+    def add(self, index, tput, basis="aggregate_output_tok_s", attempt=1):
+        rdir = os.path.join(self.dir, "replica_%d" % index)
+        os.makedirs(rdir, exist_ok=True)
+        with open(os.path.join(rdir, "selected_summary.json"), "w", encoding="utf-8") as fh:
+            json.dump({"throughput_tok_s_median": tput, "ttft_ms_median": 40.0 + index,
+                       "tpot_ms_median": 8.0 + index, "metric_basis": basis}, fh)
+        with open(os.path.join(rdir, "selected_attempt"), "w", encoding="utf-8") as fh:
+            fh.write(str(attempt))
+
+    def summarize(self, requested, successful, purpose="validation", digest="d1"):
+        line = _run(["from-replicas", self.dir, str(requested), str(successful), purpose, digest])
+        with open(os.path.join(self.dir, "bench_summary.json"), encoding="utf-8") as fh:
+            return json.load(fh), line
+
+    def test_complete_leg(self):
+        for i, t in enumerate([104.0, 108.0, 112.0], start=1):
+            self.add(i, t, attempt=i)
+        s, line = self.summarize(3, 3)
+        self.assertEqual(s["measurement_mode"], "isolated_server")
+        self.assertEqual(s["measurement_purpose"], "validation")
+        self.assertEqual(s["throughput_tok_s_median"], 108.0)
+        self.assertEqual(s["output_throughput_tok_s_median"], 108.0)
+        self.assertEqual(s["status"], "complete")
+        self.assertTrue(s["usable_for_acceptance"])
+        self.assertEqual(s["observed_median"], 108.0)
+        self.assertEqual([r["replica"] for r in s["replicas"]], [1, 2, 3])
+        self.assertEqual([r["attempt"] for r in s["replicas"]], [1, 2, 3])
+        self.assertIn("requested=3 successful=3 status=complete", line)
+
+    def test_missing_replica_is_incomplete(self):
+        self.add(1, 104.0)
+        self.add(2, 108.0)
+        s, line = self.summarize(3, 2)
+        self.assertEqual(s["status"], "incomplete")
+        self.assertFalse(s["usable_for_acceptance"])
+        self.assertIn("usable_for_acceptance=false", line)
+
+    def test_stale_replica_dir_from_a_longer_previous_run_is_ignored(self):
+        """A leftover replica_9 must not contribute to a 3-replica leg's median."""
+        for i, t in enumerate([104.0, 108.0, 112.0], start=1):
+            self.add(i, t)
+        self.add(9, 9999.0)
+        s, _ = self.summarize(3, 3)
+        self.assertEqual(s["throughput_tok_s_median"], 108.0)
+        self.assertNotIn(9999.0, s["all_throughput"])
+
+    def test_mixed_metric_basis_refuses_to_name_one(self):
+        """Two bases in one leg means the median is not comparable; say so."""
+        self.add(1, 104.0)
+        self.add(2, 108.0, basis="aggregate_total_token_tok_s")
+        self.add(3, 112.0)
+        s, _ = self.summarize(3, 3)
+        self.assertIsNone(s["metric_basis"])
+        self.assertIsNone(s["output_throughput_tok_s_median"])
+
+    def test_no_replicas_at_all(self):
+        s, _ = self.summarize(3, 0)
+        self.assertIsNone(s["throughput_tok_s_median"])
+        self.assertEqual(s["status"], "incomplete")
+        self.assertFalse(s["usable_for_acceptance"])
+        self.assertEqual(s["replicas"], [])
+
+
+class ContractParityTest(unittest.TestCase):
+    """The reason the two emitters live in one file: one contract, spelled once."""
+
+    def test_both_modes_emit_the_same_gate_fields(self):
+        gate = {"status", "requested_replicas", "successful_replicas",
+                "usable_for_acceptance", "observed_median",
+                "throughput_tok_s_median", "metric_basis", "measurement_mode",
+                "measurement_purpose", "effective_config_digest"}
+
+        tmp = tempfile.mkdtemp(prefix="summarize_parity_")
+        runs = os.path.join(tmp, "bench_runs.jsonl")
+        with open(runs, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps({"output_throughput": 100.0}) + "\n")
+        out = os.path.join(tmp, "bench_summary.json")
+        _run(["from-runs", runs, out], {"WARM_SERVER_ROUNDS": "1",
+                                        "MEASUREMENT_PURPOSE": "validation"})
+        with open(out, encoding="utf-8") as fh:
+            warm = json.load(fh)
+
+        rep_dir = os.path.join(tmp, "iso")
+        rdir = os.path.join(rep_dir, "replica_1")
+        os.makedirs(rdir)
+        with open(os.path.join(rdir, "selected_summary.json"), "w", encoding="utf-8") as fh:
+            json.dump({"throughput_tok_s_median": 100.0,
+                       "metric_basis": "aggregate_output_tok_s"}, fh)
+        _run(["from-replicas", rep_dir, "1", "1", "validation", ""])
+        with open(os.path.join(rep_dir, "bench_summary.json"), encoding="utf-8") as fh:
+            iso = json.load(fh)
+
+        self.assertEqual(gate - set(warm), set(), "warm_server is missing contract fields")
+        self.assertEqual(gate - set(iso), set(), "isolated_server is missing contract fields")
+        for k in ("status", "usable_for_acceptance", "observed_median",
+                  "requested_replicas", "successful_replicas"):
+            self.assertEqual(warm[k], iso[k], "%s disagrees between lifecycles" % k)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/e2e_workflow/scripts/tests/test_bench_summarize.py
+++ b/e2e_workflow/scripts/tests/test_bench_summarize.py
@@ -9,6 +9,9 @@ reads their output -- the director's validate step, the integrator's A/B, the or
 handoff -- so a renamed key or a status that says "complete" on a short round is a wrong
 accept, not a crash. The keys and the E2E_SUMMARY line are therefore pinned here.
 """
+import contextlib
+import importlib.util
+import io
 import json
 import os
 import subprocess
@@ -19,19 +22,46 @@ import unittest
 SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SUMMARIZE = os.path.join(SCRIPTS_DIR, "bench_summarize.py")
 
+#: Env this module reads. Scrubbed before every call so a caller's shell cannot change
+#: what a test measures; `env=` re-adds the ones a test is actually about.
+_LIFECYCLE_ENV = ("E2E_METRIC", "WARM_SERVER_ROUNDS", "GEAK_ISOLATED_REPLICA",
+                  "MEASUREMENT_PURPOSE", "EFFECTIVE_CONFIG_DIGEST")
+
+
+def _load_summarize():
+    spec = importlib.util.spec_from_file_location("bench_summarize", SUMMARIZE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+summarizer = _load_summarize()
+
 
 def _run(args, env=None):
-    e = dict(os.environ)
-    e.pop("E2E_METRIC", None)
-    e.pop("WARM_SERVER_ROUNDS", None)
-    e.pop("GEAK_ISOLATED_REPLICA", None)
-    e.pop("MEASUREMENT_PURPOSE", None)
-    e.pop("EFFECTIVE_CONFIG_DIGEST", None)
-    e.update(env or {})
-    proc = subprocess.run([sys.executable, SUMMARIZE] + args,
-                          env=e, capture_output=True, text=True, timeout=60)
-    assert proc.returncode == 0, proc.stderr
-    return proc.stdout.strip()
+    """Drive the CLI in-process and return its stdout.
+
+    A subprocess reports as zero measured coverage even when every branch runs, which
+    under the repo's coverage gate is indistinguishable from a script nobody tested.
+    ``main()`` already takes argv, so nothing about the CLI contract needs a fork;
+    CliEntrypointTest keeps one real process for what only a process has.
+    """
+    overrides = dict(env or {})
+    saved = {name: os.environ.get(name) for name in set(_LIFECYCLE_ENV) | set(overrides)}
+    stdout = io.StringIO()
+    try:
+        for name in _LIFECYCLE_ENV:
+            os.environ.pop(name, None)
+        os.environ.update(overrides)
+        with contextlib.redirect_stdout(stdout):
+            summarizer.main(args)
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+    return stdout.getvalue().strip()
 
 
 class FromRunsTest(unittest.TestCase):
@@ -88,6 +118,15 @@ class FromRunsTest(unittest.TestCase):
         self.assertIsNone(s["output_throughput_tok_s_median"])
         self.assertIsNone(s["output_throughput_tok_s_spread_pct"])
         self.assertIn("aggregate_total_token_tok_s=945.0", line)
+
+    def test_a_missing_cold_file_does_not_abort_the_summary(self):
+        """The cold round is discarded evidence; losing it must not cost the timed rounds."""
+        self.write_runs(self.runs, [100.0, 110.0])
+        _run(["from-runs", self.runs, self.out, os.path.join(self.tmp, "absent.jsonl")])
+        with open(self.out, encoding="utf-8") as fh:
+            s = json.load(fh)
+        self.assertEqual(s["throughput_tok_s_median"], 105.0)
+        self.assertEqual(s["cold_runs"], 0)
 
     def test_cold_round_is_separate_and_absent_by_default(self):
         s, _ = self.summarize([100.0, 110.0])
@@ -244,6 +283,43 @@ class ContractParityTest(unittest.TestCase):
         for k in ("status", "usable_for_acceptance", "observed_median",
                   "requested_replicas", "successful_replicas"):
             self.assertEqual(warm[k], iso[k], "%s disagrees between lifecycles" % k)
+
+
+class CliEntrypointTest(unittest.TestCase):
+    """The one place a real process is required.
+
+    Every other test drives ``main(argv)`` directly. That covers the parsing and the
+    emitters, but not the two things `bench_e2e.sh` actually depends on: that running the
+    file as a program works at all, and that a bad invocation exits non-zero instead of
+    writing a `bench_summary.json` nobody asked for.
+    """
+
+    def _spawn(self, args):
+        env = dict(os.environ)
+        for name in _LIFECYCLE_ENV:
+            env.pop(name, None)
+        return subprocess.run([sys.executable, SUMMARIZE] + args,
+                              env=env, capture_output=True, text=True, timeout=60)
+
+    def test_running_the_file_as_a_program_emits_the_summary(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runs = os.path.join(tmp, "bench_runs.jsonl")
+            with open(runs, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps({"output_throughput": 100.0,
+                                     "total_token_throughput": 900.0,
+                                     "median_ttft_ms": 40.0,
+                                     "median_tpot_ms": 8.0}) + "\n")
+            out = os.path.join(tmp, "bench_summary.json")
+            proc = self._spawn(["from-runs", runs, out])
+
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("E2E_SUMMARY", proc.stdout)
+            self.assertTrue(os.path.exists(out))
+
+    def test_an_unusable_invocation_exits_non_zero(self):
+        proc = self._spawn(["no-such-subcommand"])
+
+        self.assertNotEqual(proc.returncode, 0)
 
 
 if __name__ == "__main__":

--- a/e2e_workflow/scripts/tests/test_bench_warm_server_lifecycle.py
+++ b/e2e_workflow/scripts/tests/test_bench_warm_server_lifecycle.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Lifecycle tests for bench_e2e.sh GEAK_REPEAT_MODE=warm_server.
+
+Warm mode is the Hyperloom-aligned protocol: ONE server per leg, one FULL
+untimed round to populate the prefix cache, then N timed rounds on that hot
+server.  What these tests pin down is the part that is easy to regress
+silently -- that the warmup is a full round, that it is discarded, that only
+one server is ever launched, and that the summary still carries the same
+acceptance contract (status / successful_replicas / usable_for_acceptance)
+the isolated-server aggregate publishes.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BENCH = os.path.join(SCRIPTS_DIR, "bench_e2e.sh")
+BASH = shutil.which("bash")
+
+
+@unittest.skipIf(BASH is None, "bash is required to exercise the shell dispatcher")
+class BenchWarmServerLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="bench_warm_")
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.events = os.path.join(self.tmp, "events.jsonl")
+        self.counter = os.path.join(self.tmp, "call_counter")
+        self.adapter = os.path.join(self.tmp, "fake_adapter.sh")
+        # Each bench call gets a distinct throughput (call_index * 100) so a
+        # test can tell exactly WHICH calls landed in the timed median.
+        with open(self.adapter, "w", encoding="utf-8") as fh:
+            fh.write(
+                textwrap.dedent(
+                    r"""
+                    adapter_default_port() { echo 18081; }
+                    adapter_launch() {
+                      printf '{"event":"launch"}\n' >> "$EVENT_LOG"
+                      ${SERVER_LAUNCH_PREFIX:-} sleep 300 &
+                      SERVER_PID=$!
+                    }
+                    adapter_health() { return 0; }
+                    adapter_bench() {
+                      local nump="$1" maxc="$2" n
+                      n=$(( $(cat "$CALL_COUNTER" 2>/dev/null || echo 0) + 1 ))
+                      printf '%s' "$n" > "$CALL_COUNTER"
+                      printf '{"event":"bench","call":%s,"nump":%s,"conc":%s}\n' \
+                        "$n" "$nump" "$maxc" >> "$EVENT_LOG"
+                      case ",${FAIL_CALLS:-}," in
+                        *",$n,"*) return 9 ;;
+                      esac
+                      printf '{"output_throughput":%s,"median_ttft_ms":%s,"median_tpot_ms":%s}\n' \
+                        "$((n * 100))" "$((n * 10))" "$n" >> "$RESULT_JSONL"
+                    }
+                    """
+                ).lstrip()
+            )
+
+    def run_bench(self, *, purpose="search", repeats=None, expect_rc=0, **extra_env):
+        out_dir = os.path.join(self.tmp, f"out_{len(os.listdir(self.tmp))}")
+        env = dict(os.environ)
+        env.update(
+            ADAPTER=self.adapter,
+            BACKEND="fake",
+            MODEL=os.path.join(self.tmp, "model"),
+            OUT_DIR=out_dir,
+            EVENT_LOG=self.events,
+            CALL_COUNTER=self.counter,
+            GEAK_REPEAT_MODE="warm_server",
+            MEASUREMENT_PURPOSE=purpose,
+            NUM_PROMPTS="7",
+            CONC="3",
+            PROFILE="0",
+            REUSE_SERVER="0",
+            SERVING_GPU_LOCK_DISABLE="1",
+            SERVER_STOP_GRACE_S="0",
+        )
+        env.pop("REPEATS", None)
+        if repeats is not None:
+            env["REPEATS"] = str(repeats)
+        env.update({key: str(value) for key, value in extra_env.items()})
+        proc = subprocess.run(
+            [BASH, BENCH], env=env, capture_output=True, text=True, timeout=60
+        )
+        self.assertEqual(proc.returncode, expect_rc, proc.stderr)
+        summary_path = os.path.join(out_dir, "bench_summary.json")
+        summary = None
+        if os.path.exists(summary_path):
+            with open(summary_path, encoding="utf-8") as fh:
+                summary = json.load(fh)
+        return proc, summary, self.read_events()
+
+    def read_events(self):
+        if not os.path.exists(self.events):
+            return []
+        with open(self.events, encoding="utf-8") as fh:
+            return [json.loads(line) for line in fh if line.strip()]
+
+    def test_validation_is_hyperloom_two_passes_and_reports_the_second(self):
+        # Hyperloom's protocol exactly: one boot, warmup_round discarded,
+        # measure_round on the re-attached hot server IS the number.
+        proc, summary, events = self.run_bench(purpose="validation")
+        # ONE boot -- this is the whole point of the mode.
+        self.assertEqual(sum(e["event"] == "launch" for e in events), 1)
+        benches = [e for e in events if e["event"] == "bench"]
+        # Exactly 2 passes, and the warmup is a FULL round (NUM_PROMPTS, not CONC).
+        self.assertEqual([e["nump"] for e in benches], [7, 7])
+        self.assertEqual(summary["measurement_mode"], "warm_server")
+        self.assertEqual(summary["measurement_purpose"], "validation")
+        self.assertEqual(summary["dispersion_basis"], "within_server_rounds")
+        # The warmup (call 1 -> 100) must NOT be in the timed results: the
+        # SECOND pass (call 2 -> 200) is the reported number.
+        self.assertEqual(summary["all_throughput"], [200.0])
+        self.assertEqual(summary["throughput_tok_s_median"], 200.0)
+        self.assertEqual(summary["observed_median"], 200.0)
+        self.assertIn("measurement_mode=warm_server", proc.stdout)
+
+    def test_acceptance_contract_matches_the_isolated_aggregate(self):
+        _, summary, _ = self.run_bench(purpose="validation")
+        self.assertEqual(summary["requested_rounds"], 1)
+        self.assertEqual(summary["successful_rounds"], 1)
+        # Same field names the isolated-server aggregate publishes, so
+        # director:validate reads one shape regardless of lifecycle.
+        self.assertEqual(summary["requested_replicas"], 1)
+        self.assertEqual(summary["successful_replicas"], 1)
+        self.assertEqual(summary["status"], "complete")
+        self.assertTrue(summary["usable_for_acceptance"])
+
+    def test_search_defaults_to_one_timed_round(self):
+        _, summary, events = self.run_bench(purpose="search")
+        self.assertEqual(sum(e["event"] == "launch" for e in events), 1)
+        self.assertEqual(sum(e["event"] == "bench" for e in events), 2)  # warmup + 1
+        self.assertEqual(summary["requested_rounds"], 1)
+        self.assertEqual(summary["all_throughput"], [200.0])
+
+    def test_explicit_replicas_overrides_purpose_default(self):
+        _, summary, events = self.run_bench(purpose="validation", REPLICAS=2)
+        self.assertEqual(summary["requested_rounds"], 2)
+        self.assertEqual(sum(e["event"] == "bench" for e in events), 3)  # warmup + 2
+
+    def test_explicit_repeats_overrides_purpose_default(self):
+        _, summary, _ = self.run_bench(purpose="validation", repeats=2)
+        self.assertEqual((summary["requested_rounds"], summary["successful_rounds"]), (2, 2))
+
+    def test_failed_timed_round_is_incomplete_but_keeps_the_observable_median(self):
+        # Call 1 is the warmup; fail the second TIMED round (call 3).
+        _, summary, events = self.run_bench(
+            purpose="validation", REPLICAS=3, FAIL_CALLS="3"
+        )
+        self.assertEqual(summary["requested_rounds"], 3)
+        self.assertEqual(summary["successful_rounds"], 2)
+        self.assertEqual(summary["status"], "incomplete")
+        # A degraded leg stays observable but must never be silently promoted.
+        self.assertFalse(summary["usable_for_acceptance"])
+        self.assertEqual(summary["all_throughput"], [200.0, 400.0])
+        # Still only one boot: warm mode never re-launches mid-leg.
+        self.assertEqual(sum(e["event"] == "launch" for e in events), 1)
+
+    def test_failed_full_warmup_aborts_instead_of_reporting_a_cold_number(self):
+        proc, summary, _ = self.run_bench(
+            purpose="validation", FAIL_CALLS="1", expect_rc=2
+        )
+        self.assertIsNone(summary)
+        self.assertIn("warmup failed", proc.stderr)
+
+    def test_rejects_a_non_positive_round_count(self):
+        proc, _, _ = self.run_bench(purpose="validation", repeats=0, expect_rc=4)
+        self.assertIn("positive integer", proc.stderr)
+
+    def test_caller_policy_overrides_the_mode_the_role_forwarded(self):
+        # The validating role forwarded isolated_server (e.g. it echoed the
+        # globally exported alignment mode); the caller's pin must still win.
+        _, summary, events = self.run_bench(
+            purpose="validation",
+            GEAK_REPEAT_MODE="isolated_server",
+            GEAK_VALIDATION_REPEAT_MODE="warm_server",
+        )
+        self.assertEqual(summary["measurement_mode"], "warm_server")
+        self.assertEqual(sum(e["event"] == "launch" for e in events), 1)
+
+    def test_caller_policy_does_not_touch_non_validation_purposes(self):
+        _, summary, events = self.run_bench(
+            purpose="search",
+            GEAK_REPEAT_MODE="isolated_server",
+            GEAK_VALIDATION_REPEAT_MODE="warm_server",
+            REPEATS=1,
+        )
+        self.assertEqual(summary["measurement_mode"], "isolated_server")
+
+    def test_naming_no_mode_at_all_still_gets_the_hyperloom_lifecycle(self):
+        # A caller that forgot to forward MEASUREMENT_MODE must not silently get
+        # a differently-measured number than the rest of the run.
+        out_dir = os.path.join(self.tmp, "out_default")
+        env = dict(os.environ)
+        env.update(
+            ADAPTER=self.adapter, BACKEND="fake",
+            MODEL=os.path.join(self.tmp, "model"), OUT_DIR=out_dir,
+            EVENT_LOG=self.events, CALL_COUNTER=self.counter,
+            MEASUREMENT_PURPOSE="search", NUM_PROMPTS="7", CONC="3", PROFILE="0",
+            REUSE_SERVER="0", SERVING_GPU_LOCK_DISABLE="1", SERVER_STOP_GRACE_S="0",
+        )
+        env.pop("GEAK_REPEAT_MODE", None)
+        env.pop("REPEATS", None)
+        proc = subprocess.run(
+            [BASH, BENCH], env=env, capture_output=True, text=True, timeout=60
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        with open(os.path.join(out_dir, "bench_summary.json"), encoding="utf-8") as fh:
+            summary = json.load(fh)
+        self.assertEqual(summary["measurement_mode"], "warm_server")
+        # warmup + 1 timed, one boot.
+        benches = [e for e in self.read_events() if e["event"] == "bench"]
+        self.assertEqual([e["nump"] for e in benches], [7, 7])
+
+    def test_repeats_zero_keeps_the_legacy_capture_lifecycle(self):
+        # REPEATS=0 is "warmup only, no timed round" -- the shape-capture /
+        # profile-window call sites.  The warm-mode default must not turn that
+        # into a hard "positive integer" reject.
+        out_dir = os.path.join(self.tmp, "out_capture")
+        env = dict(os.environ)
+        env.update(
+            ADAPTER=self.adapter, BACKEND="fake",
+            MODEL=os.path.join(self.tmp, "model"), OUT_DIR=out_dir,
+            EVENT_LOG=self.events, CALL_COUNTER=self.counter,
+            MEASUREMENT_PURPOSE="search", NUM_PROMPTS="7", CONC="3", PROFILE="0",
+            REPEATS="0", REUSE_SERVER="0", SERVING_GPU_LOCK_DISABLE="1",
+            SERVER_STOP_GRACE_S="0",
+        )
+        env.pop("GEAK_REPEAT_MODE", None)
+        proc = subprocess.run(
+            [BASH, BENCH], env=env, capture_output=True, text=True, timeout=60
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertNotIn("positive integer", proc.stderr)
+        # Short CONC warmup only -- no full round, no timed round.
+        benches = [e for e in self.read_events() if e["event"] == "bench"]
+        self.assertEqual([e["nump"] for e in benches], [3])
+
+    def test_unknown_purpose_falls_back_to_one_round(self):
+        proc, summary, _ = self.run_bench(purpose="nonsense")
+        self.assertEqual(summary["requested_rounds"], 1)
+        self.assertIn("Unknown MEASUREMENT_PURPOSE", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/e2e_workflow/scripts/tests/test_inferencex_client_warmup_parity.py
+++ b/e2e_workflow/scripts/tests/test_inferencex_client_warmup_parity.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Warmup/seed parity tests for the InferenceX bench CLIENT adapter.
+
+The point of BENCH_CLIENT=inferencex is that GEAK drives the EXACT client
+Hyperloom drives, with the same dataset semantics.  Two of those semantics are
+not defaults and must be forced whenever the lifecycle is a Hyperloom-aligned
+one: ``--num-warmups 2*CONC`` (Hyperloom's per-call warmup, versus the adapter's
+own 8-request fallback) and ``--seed 0``.
+
+Both the isolated_server and the warm_server lifecycles are Hyperloom-aligned,
+but they announce themselves differently -- isolated_server sets
+GEAK_ISOLATED_REPLICA=1, while warm_server sets it to 0 (its outer warmup round
+MUST run) and exports WARM_SERVER_ROUNDS instead.  Gating only on the replica
+flag silently dropped warm_server back to 8 warmups whenever the caller did not
+export NUM_WARMUPS, which is exactly what a direct bench_e2e.sh invocation does.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CLIENT = os.path.join(SCRIPTS_DIR, "adapters", "clients", "inferencex.sh")
+BASH = shutil.which("bash")
+
+
+@unittest.skipIf(BASH is None, "bash is required to exercise the shell adapter")
+class InferencexClientWarmupParityTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="ix_client_")
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.argv_log = os.path.join(self.tmp, "argv.json")
+        self.bench_py = os.path.join(self.tmp, "benchmark_serving.py")
+        with open(self.bench_py, "w", encoding="utf-8") as fh:
+            fh.write("")
+        # PYTHON_BIN shim: record the argv of the bench invocation, then write
+        # the result file the adapter expects so it reaches its success path.
+        # The adapter also calls PYTHON_BIN with -c to re-dump that file; the
+        # shim forwards anything that is not the bench script to real python3.
+        self.python_bin = os.path.join(self.tmp, "python_shim.sh")
+        with open(self.python_bin, "w", encoding="utf-8") as fh:
+            fh.write(
+                textwrap.dedent(
+                    r"""
+                    #!/usr/bin/env bash
+                    if [ "$1" != "%(bench)s" ]; then exec python3 "$@"; fi
+                    python3 - "$@" <<'PY'
+                    import json, sys
+                    argv = sys.argv[1:]
+                    with open("%(log)s", "w") as fh:
+                        json.dump(argv, fh)
+                    out_dir = argv[argv.index("--result-dir") + 1]
+                    name = argv[argv.index("--result-filename") + 1]
+                    with open(out_dir + "/" + name, "w") as fh:
+                        json.dump({"output_throughput": 1.0}, fh)
+                    PY
+                    """
+                ).lstrip() % {"bench": self.bench_py, "log": self.argv_log}
+            )
+        os.chmod(self.python_bin, 0o755)
+
+    def run_bench(self, *, conc=64, **extra_env):
+        out_dir = os.path.join(self.tmp, f"out_{len(os.listdir(self.tmp))}")
+        os.makedirs(out_dir)
+        env = dict(os.environ)
+        env.update(
+            INFERENCEX_BENCH_SERVING=self.bench_py,
+            PYTHON_BIN=self.python_bin,
+            MODEL=os.path.join(self.tmp, "model"),
+            BASE_URL="http://127.0.0.1:1/v1",
+            ISL="8192",
+            OSL="1024",
+            OUT_DIR=out_dir,
+            PROFILE_DIR=out_dir,
+            RESULT_JSONL=os.path.join(out_dir, "results.jsonl"),
+        )
+        for key in ("NUM_WARMUPS", "SEED", "GEAK_ISOLATED_REPLICA",
+                    "WARM_SERVER_ROUNDS", "RANDOM_RANGE_RATIO"):
+            env.pop(key, None)
+        env.update({key: str(value) for key, value in extra_env.items()})
+        script = f'. "{CLIENT}"; adapter_bench 192 {conc} 0'
+        proc = subprocess.run(
+            [BASH, "-c", script], env=env, capture_output=True, text=True, timeout=60
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        with open(self.argv_log, encoding="utf-8") as fh:
+            argv = json.load(fh)
+        return {argv[i]: argv[i + 1] for i in range(len(argv) - 1)}
+
+    def test_warm_server_gets_hyperloom_warmups_without_an_explicit_num_warmups(self):
+        """The regression: warm_server sets ISOLATED_REPLICA=0, not 1."""
+        flags = self.run_bench(conc=64, GEAK_ISOLATED_REPLICA=0,
+                               WARM_SERVER_ROUNDS=3)
+        self.assertEqual(flags["--num-warmups"], "128")  # 2 * CONC
+        self.assertEqual(flags["--seed"], "0")
+
+    def test_isolated_server_still_gets_hyperloom_warmups(self):
+        flags = self.run_bench(conc=64, GEAK_ISOLATED_REPLICA=1)
+        self.assertEqual(flags["--num-warmups"], "128")
+        self.assertEqual(flags["--seed"], "0")
+
+    def test_warm_server_forces_seed_zero_over_a_caller_override(self):
+        """Dataset identity is the whole point; a stray SEED must not win."""
+        flags = self.run_bench(conc=64, GEAK_ISOLATED_REPLICA=0,
+                               WARM_SERVER_ROUNDS=3, SEED=1234,
+                               NUM_WARMUPS=8)
+        self.assertEqual(flags["--num-warmups"], "128")
+        self.assertEqual(flags["--seed"], "0")
+
+    def test_warmups_track_concurrency(self):
+        flags = self.run_bench(conc=16, GEAK_ISOLATED_REPLICA=0,
+                               WARM_SERVER_ROUNDS=1)
+        self.assertEqual(flags["--num-warmups"], "32")
+
+    def test_legacy_lifecycle_keeps_the_adapter_default(self):
+        """Neither flag set => no Hyperloom alignment claimed, no forcing."""
+        flags = self.run_bench(conc=64, SEED=1234)
+        self.assertEqual(flags["--num-warmups"], "8")
+        self.assertEqual(flags["--seed"], "1234")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -1874,36 +1874,72 @@ def _safe_ratio(num: float | None, den: float | None) -> float | None:
     return round(n / d, 4) if (n > 0 and d > 0) else None
 
 
-def read_orchestrator_hot_baseline(h: dict) -> float:
-    """Read Hyperloom's HOT baseline throughput from its ``state.json`` (best-effort).
+def read_orchestrator_baseline_lifecycle(h: dict) -> tuple[float, str]:
+    """Read Hyperloom's baseline anchor AND its thermal state from ``state.json``.
 
-    Hyperloom's double-run baseline records BOTH a COLD round (``baseline_tput`` —
-    the leaderboard denominator, forwarded to us as ``handoff.raw_baseline_tput``)
-    and a HOT round (``baseline_hot_tput``). Only the cold one rides in the handoff,
-    so for a hot-to-hot cross-check we read the hot one straight off ``state.json``.
+    Hyperloom does NOT keep a cold and a hot baseline side by side. Its double-run
+    baseline runs one full warmup round, DISCARDS it, and anchors on the round
+    measured against the now-hot server — so ``state.baseline_tput`` (the
+    leaderboard denominator, forwarded to us as ``handoff.raw_baseline_tput``) IS
+    the hot number. There is no ``baseline_hot_tput`` key anywhere in Hyperloom;
+    reading one only ever returned nothing.
+
+    What varies is whether the double run happened at all, and Hyperloom records
+    that in two fields written by the same writeback that promotes the anchor:
+
+    * ``baseline_warm_runtime_sec`` — the measure round's wall-clock. Set only on
+      the double-run path and explicitly zeroed when a later baseline lands
+      without one, so ``> 0`` is positive evidence that a warmup round preceded
+      the anchor.
+    * ``baseline_measure_round_dropped`` — True when the budget could not fund
+      the hot pass and the session had to keep the COLD figure as its anchor.
+
     ``state.json`` lives at the SESSION dir (an ancestor of ``exp_root``); probe a
-    couple of levels up. Returns 0.0 when unavailable (standalone / no orchestrator),
-    so the alignment metrics simply degrade to None instead of raising.
+    couple of levels up.
+
+    Returns:
+        ``(hot_tput, lifecycle)``. ``lifecycle`` is one of ``hot_measure_round``,
+        ``cold_single_round`` or ``unknown``, and ``hot_tput`` is 0.0 for anything
+        but the first — so the hot-to-hot alignment metrics degrade to None rather
+        than quietly dividing by a cold denominator. A standalone run with no
+        orchestrator gets ``(0.0, "unknown")``.
     """
     exp_root = str(h.get("exp_root") or "").strip()
     if not exp_root:
-        return 0.0
+        return 0.0, "unknown"
     p = Path(exp_root)
     for cand in (p / "state.json", p.parent / "state.json",
                  p.parent.parent / "state.json"):
         st = _read_json(cand)
         if not st:
             continue
-        v = st.get("baseline_hot_tput")
-        if not v:
-            base = st.get("baseline") if isinstance(st.get("baseline"), dict) else {}
-            v = base.get("baseline_hot_tput")
-        try:
-            if v and float(v) > 0:
-                return float(v)
-        except (TypeError, ValueError):
+        base = st.get("baseline") if isinstance(st.get("baseline"), dict) else {}
+        tput = _positive_finite_float(
+            st.get("baseline_tput") or base.get("baseline_tput")
+        )
+        if tput <= 0.0:
             continue
-    return 0.0
+        warm_sec = _positive_finite_float(
+            st.get("baseline_warm_runtime_sec")
+            or base.get("baseline_warm_runtime_sec")
+        )
+        dropped = bool(
+            st.get("baseline_measure_round_dropped")
+            or base.get("baseline_measure_round_dropped")
+        )
+        if warm_sec > 0.0 and not dropped:
+            return tput, "hot_measure_round"
+        return 0.0, "cold_single_round" if dropped else "unknown"
+    return 0.0, "unknown"
+
+
+def read_orchestrator_hot_baseline(h: dict) -> float:
+    """Hyperloom's baseline anchor, but only when it is a HOT measure round.
+
+    Thin wrapper over :func:`read_orchestrator_baseline_lifecycle`; see there for
+    why the hot number is ``baseline_tput`` and not a separate key.
+    """
+    return read_orchestrator_baseline_lifecycle(h)[0]
 
 
 def _wf_best_accepted_delta_pct(wf: dict) -> float:
@@ -2532,18 +2568,35 @@ def normalize_result(h: dict, wf: dict) -> dict:
 
     # ── cold/hot alignment metrics (double-check; never changes the primary
     # final_throughput_tok_s / throughput_speedup Hyperloom promotes) ─────────
-    # Hyperloom's leaderboard anchor baseline_tput is a COLD single round; GEAK's
-    # final is a HOT median, so the promoted cold-to-... comparison mixes thermal
-    # states. We surface every well-defined speedup so a reviewer can tell a real
-    # win from a warm/cold measurement artefact:
-    #   * hot_speedup      = GEAK hot final  / Hyperloom HOT baseline  (hot-to-hot, cross-harness)
+    # Hyperloom's leaderboard anchor baseline_tput is normally a HOT measure round
+    # (one discarded warmup round, then the timed round on that same server), and
+    # under MEASUREMENT_MODE=warm_server GEAK's final is measured the same way — so
+    # the promoted comparison is hot-to-hot. It is NOT hot when Hyperloom's budget
+    # forced it to keep the cold figure, which is what
+    # orchestrator_baseline_lifecycle reports. We surface every well-defined
+    # speedup so a reviewer can tell a real win from a warm/cold artefact:
+    #   * hot_speedup      = GEAK hot final  / Hyperloom HOT baseline  (hot-to-hot, cross-harness;
+    #                        None when Hyperloom's anchor was not a hot measure round)
     #   * hot_geak_speedup = GEAK hot final  / GEAK  hot baseline      (within-GEAK, harness-internal)
-    #   * cold_speedup     = GEAK cold final / Hyperloom COLD baseline (cold-to-cold, matches leaderboard state)
+    #   * cold_speedup     = GEAK cold final / Hyperloom's anchor      (GEAK-cold over whatever
+    #                        Hyperloom promoted; read it with the lifecycle field, since a hot
+    #                        anchor makes this a cold-over-hot ratio, not a cold-to-cold one)
     #   * cold_geak_speedup= GEAK cold final / GEAK  cold baseline     (within-GEAK cold, if measured)
     # The cold numbers are populated only when BENCH_COLD_FINAL=1 added a cold
     # round to bench_e2e.sh (else None). All ratios are None when an input is
     # missing, so a standalone / orchestrator-less run carries the block harmlessly.
-    orch_hot_baseline = read_orchestrator_hot_baseline(h)
+    orch_state_hot_baseline, orch_baseline_lifecycle = read_orchestrator_baseline_lifecycle(h)
+    # Prefer the handoff's anchor over the one re-read from state.json so
+    # hot_speedup stays the SAME pairing Hyperloom promotes: a re-baseline that
+    # lands after our handoff was minted moves state.json but not the handoff,
+    # and silently reporting the newer number would make the two ratios in this
+    # block disagree for no visible reason. state.json only supplies the verdict
+    # on what the anchor is, plus the value when the handoff carries none.
+    orch_hot_baseline = (
+        (orch_baseline or orch_state_hot_baseline)
+        if orch_baseline_lifecycle == "hot_measure_round"
+        else 0.0
+    )
     geak_hot_final = geak_final
     geak_hot_baseline = geak_baseline
     geak_cold_final = final_summary.get("cold_output_throughput_tok_s")
@@ -2567,7 +2620,15 @@ def normalize_result(h: dict, wf: dict) -> dict:
         "geak_hot_baseline_tok_s": geak_hot_baseline or None,
         "geak_cold_final_tok_s": geak_cold_final,
         "geak_cold_baseline_tok_s": geak_cold_baseline,
-        "orchestrator_cold_baseline_tok_s": orch_baseline or None,   # == handoff.raw_baseline_tput (leaderboard anchor)
+        # == handoff.raw_baseline_tput (the leaderboard anchor). Kept under the
+        # historical "cold" key for the consumers that already read it, but the
+        # anchor is hot whenever orchestrator_baseline_lifecycle says so.
+        "orchestrator_cold_baseline_tok_s": orch_baseline or None,
+        "orchestrator_baseline_tok_s": orch_baseline or None,
+        # hot_measure_round | cold_single_round | unknown — read off Hyperloom's
+        # state.json, so it says what the anchor above ACTUALLY is.
+        "orchestrator_baseline_lifecycle": orch_baseline_lifecycle,
+        # The same anchor, exposed only when it is provably a hot measure round.
         "orchestrator_hot_baseline_tok_s": orch_hot_baseline or None,
         "hot_speedup": _safe_ratio(geak_hot_final, orch_hot_baseline),
         "hot_geak_speedup": _safe_ratio(geak_hot_final, geak_hot_baseline),

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -326,14 +326,25 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
         "initial_extra_server_args": initial_server_args,
         "initial_extra_env": initial_env,
         "initial_overlay_pythonpath": initial_overlay,
-        # One fresh replica matches Hyperloom's compute-warm/cache-cold
-        # lifecycle: the client keeps internal kernel/graph warmups but skips
-        # the outer full-round replay. Three independent servers are reserved
-        # for final validation; the shell dispatcher owns retries/degradation.
-        "measurement_mode": "isolated_server",
+        # ONE protocol for the whole run, and it is Hyperloom's (warmup_round discarded,
+        # measure_round on the re-attached hot server), so the headline GEAK reports and the
+        # number Hyperloom rebenches are the same measurement.  Mixing lifecycles across phases
+        # was worse than either alone: a cache-cold search A/B is not comparable to a cache-warm
+        # validation, yet gains were carried between them.  It is also 2 boots instead of the
+        # 6-12 cold boots isolated validation serializes behind the serving-GPU lock, which on a
+        # large model overruns the final reserve and kills the run mid-bench.
+        # Trade: within-server samples bound CLIENT noise, not boot-to-boot variance.  Anything
+        # that must gate on the latter pins measurement_mode=isolated_server, which brings the
+        # *_replicas knobs below back into play.
+        "measurement_mode": "warm_server",
         "parity_replicas": 1,
         "search_replicas": 1,
         "validation_replicas": 3,
+        # validation_rounds=1 is the whole of Hyperloom's protocol, not a truncation: two client
+        # passes on one server, report the second.  A 3-round median would be a different
+        # statistic from the one it rebenches against.
+        "validation_measurement_mode": "warm_server",
+        "validation_rounds": 1,
         # Hyperloom already did config/param search in EXPLORE; do not double-run.
         "config_tune": "false",
         # Produce the final/ bundle (final_launch.sh + overlay) so the caller can
@@ -398,10 +409,9 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
     # subset of {setup,profile,config,tune,head,kernel,final} (default unset => "all").
     if h.get("phases"):
         ps_args["phases"] = str(h["phases"])
-    # Legacy A/B repeat override. Isolated-server handoffs use the purpose-specific
-    # replica counts above; retain this pass-through for explicitly legacy runs.
-    if h.get("e2e_repeats") is not None:
-        ps_args["e2e_repeats"] = int(h["e2e_repeats"])
+    # No timed-repeat pass-through: the round count belongs to the lifecycle, not the handoff, so
+    # an `e2e_repeats` key from a stale caller is ignored rather than allowed to pull one leg off
+    # the lifecycle the rest of the run used.
     # Standalone tuning-skillset phase (workflow default ON). This is NOT the
     # config_tune sweep disabled above: Hyperloom's EXPLORE searched server
     # flags/env, whereas this phase runs the vendored tuning skillset's own loop
@@ -1406,8 +1416,8 @@ def apply_bench_protocol(h: dict) -> dict:
     ``num_prompts``, ``num_warmups`` and ``seed``. We export each provided key.
     For schema-v2 Hyperloom handoffs, the actual wrapper lifecycle is
     authoritative over stale metadata: fixed seed/range and 2*CONC client
-    warmups run inside the single measured invocation, while the separate
-    outer full-round replay is skipped.
+    warmups, run on one server per leg whose first full round is a discarded
+    warmup (Hyperloom's warmup_round/measure_round).
 
     IMPORTANT: only keys actually present in the handoff are exported. When
     ``bench_protocol`` is absent (e.g. GEAK run standalone, no external
@@ -1431,10 +1441,10 @@ def apply_bench_protocol(h: dict) -> dict:
     if int(h.get("schema_version", 1) or 1) >= 2 and isinstance(
         h.get("baseline_env_spec"), dict
     ):
-        # Cache-cold parity uses one measured client invocation on a fresh
-        # server. InferenceX still receives 2*concurrency internal warmups,
-        # which repeat prompt[0] to warm kernels/graphs without pre-populating
-        # the remaining timed prompts in the prefix cache.
+        # Warm-server parity: one server per leg, a discarded full warmup round, then the timed
+        # round(s) on that hot server -- Hyperloom's warmup_round/measure_round lifecycle.
+        # InferenceX still receives 2*concurrency internal warmups, which repeat prompt[0] to warm
+        # kernels/graphs; the outer full round is what populates the prefix cache.
         # Some historical handoffs recorded an older small NUM_WARMUPS value;
         # keep the observed 2*concurrency client behavior while changing only
         # whether the separate outer full replay runs.
@@ -1444,7 +1454,11 @@ def apply_bench_protocol(h: dict) -> dict:
             "NUM_WARMUPS": str(2 * conc),
             "SEED": "0",
             "RANDOM_RANGE_RATIO": "1",
-            "GEAK_REPEAT_MODE": "isolated_server",
+            "GEAK_REPEAT_MODE": "warm_server",
+            # Pinned as env too (bench_e2e.sh honours it for MEASUREMENT_PURPOSE=validation only)
+            # so pinning measurement_mode=isolated_server for search cannot drag validation off
+            # Hyperloom's protocol, and so a role forwarding the global mode cannot drop it.
+            "GEAK_VALIDATION_REPEAT_MODE": "warm_server",
             "REPLICA_RETRIES": "1",
         }
         # NUM_PROMPTS was the one protocol knob this block did not align, and

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -340,11 +340,10 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
         "parity_replicas": 1,
         "search_replicas": 1,
         "validation_replicas": 3,
-        # validation_rounds=1 is the whole of Hyperloom's protocol, not a truncation: two client
-        # passes on one server, report the second.  A 3-round median would be a different
-        # statistic from the one it rebenches against.
+        # warm_server IS Hyperloom's protocol, not a truncation of a longer one: two client passes
+        # on one server, report the second.  A 3-round median would be a different statistic from
+        # the one it rebenches against, so the round count is not a knob here.
         "validation_measurement_mode": "warm_server",
-        "validation_rounds": 1,
         # Hyperloom already did config/param search in EXPLORE; do not double-run.
         "config_tune": "false",
         # Produce the final/ bundle (final_launch.sh + overlay) so the caller can

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -2033,6 +2033,7 @@ def _positive_finite_float(value: Any) -> float:
 def _build_baseline_alignment(
     same_config_divergence_pct: float | None,
     recipe_aligned: bool = True,
+    same_config_reference_status: str = "",
 ) -> dict[str, Any]:
     """Classify cross-harness alignment using only the same-config metric.
 
@@ -2043,9 +2044,22 @@ def _build_baseline_alignment(
     evidence about the launch recipe, not about the box or the bench client.
     Saying that in the status keeps the number from being read as "GEAK
     measured slow".
+
+    ``same_config_reference_status`` is the orchestrator's own verdict on the
+    same-config reference it forwarded (handoff ``same_config_reference_status``).
+    A bare ``"unavailable"`` reads as "GEAK failed to compute it"; when the
+    orchestrator shipped ``orchestrator_best_tput_same_config: 0.0`` with an
+    ``unverified`` status, the number was never measured upstream and no amount
+    of GEAK-side work can produce it. Naming that in the status is the
+    difference between a fixable gap and a silent dead end.
     """
+    reference_status = str(same_config_reference_status or "").strip().lower()
     if same_config_divergence_pct is None:
-        status = "unavailable"
+        status = (
+            "unavailable_reference_unverified"
+            if reference_status and reference_status != "verified"
+            else "unavailable"
+        )
     elif abs(same_config_divergence_pct) > SAME_CONFIG_DIVERGENCE_WARN_PCT:
         status = "warning" if recipe_aligned else "warning_recipe_unaligned"
     else:
@@ -2057,6 +2071,9 @@ def _build_baseline_alignment(
         "warning_threshold_pct": SAME_CONFIG_DIVERGENCE_WARN_PCT,
         "raw_session_divergence_is_measurement_signal": False,
         "recipe_aligned_with_orchestrator": recipe_aligned,
+        # Verbatim from the handoff ("" on orchestrator-less runs), so a reader
+        # can tell WHOSE side the missing reference is on.
+        "same_config_reference_status": reference_status or None,
     }
 
 
@@ -2500,6 +2517,10 @@ def normalize_result(h: dict, wf: dict) -> dict:
     orch_same_cfg = _positive_finite_float(
         h.get("orchestrator_best_tput_same_config")
     )
+    # The orchestrator's verdict on the reference above. "verified" means it
+    # really re-measured GEAK's seed config; anything else means the 0.0 is an
+    # absence, not a measurement.
+    orch_same_cfg_status = str(h.get("same_config_reference_status") or "").strip().lower()
     raw_session_divergence_pct = _divergence_pct(geak_baseline, orch_baseline)
     same_config_divergence_pct = _divergence_pct(geak_baseline, orch_same_cfg)
 
@@ -2523,7 +2544,7 @@ def normalize_result(h: dict, wf: dict) -> dict:
         ),
     }
     baseline_alignment = _build_baseline_alignment(
-        same_config_divergence_pct, recipe_aligned
+        same_config_divergence_pct, recipe_aligned, orch_same_cfg_status
     )
     baseline_basis = {
         # GEAK's own measured baseline (Hyperloom-accepted config = fair engagement baseline; gating uses this).
@@ -2631,6 +2652,22 @@ def normalize_result(h: dict, wf: dict) -> dict:
         # The same anchor, exposed only when it is provably a hot measure round.
         "orchestrator_hot_baseline_tok_s": orch_hot_baseline or None,
         "hot_speedup": _safe_ratio(geak_hot_final, orch_hot_baseline),
+        # WHOSE gain hot_speedup contains. Its denominator is Hyperloom's RAW
+        # session baseline, which predates the config Hyperloom itself accepted
+        # before handing GEAK the seed. So whenever the orchestrator did not
+        # verify a same-config reference, hot_speedup carries Hyperloom's own
+        # explore gain on top of (or instead of) anything GEAK did: a session
+        # with accepted_kernels == [] and hot_geak_speedup == 1.0 still reports
+        # a hot_speedup well above 1. Measured on MiniMax-M3-MXFP4
+        # 20260904T002558Z-3de91cb3: hot_speedup 1.186 against zero accepted
+        # kernels. Read hot_geak_speedup for what GEAK actually contributed.
+        "hot_speedup_denominator": "raw_session_baseline",
+        "hot_speedup_includes_orchestrator_config_gain": True,
+        # The same hot-to-hot ratio against the orchestrator's throughput on
+        # GEAK's OWN seed config -- the only pairing in this block whose
+        # numerator and denominator share a config. None when the orchestrator
+        # never verified that reference.
+        "hot_speedup_same_config": _safe_ratio(geak_hot_final, orch_same_cfg),
         "hot_geak_speedup": _safe_ratio(geak_hot_final, geak_hot_baseline),
         "cold_speedup": _safe_ratio(geak_cold_final, orch_baseline),
         "cold_geak_speedup": _safe_ratio(geak_cold_final, geak_cold_baseline),
@@ -2994,6 +3031,27 @@ def _render_baseline_alignment_section(result: dict[str, Any]) -> str:
     stack = result.get("serving_stack") or {}
     launcher = str(stack.get("launcher") or "unknown")
     recipe_aligned = bool(alignment.get("recipe_aligned_with_orchestrator", True))
+    # "unavailable" alone reads as "GEAK failed to compute it". Say whose side
+    # the gap is on when the orchestrator itself never verified the reference.
+    reference_caveat = (
+        [
+            "",
+            (
+                "The same-config number above is missing because the upstream "
+                "orchestrator shipped it `"
+                f"{alignment.get('same_config_reference_status') or 'unverified'}"
+                "` — it never re-measured GEAK's seed config, so there is no "
+                "reference to diverge from. This is an upstream handoff gap, not "
+                "a GEAK measurement failure, and nothing on the GEAK side can "
+                "fill it in. Until it is verified, read `hot_geak_speedup` (not "
+                "`hot_speedup`) for GEAK's own contribution: `hot_speedup` is "
+                "measured against the raw session baseline and therefore still "
+                "carries the orchestrator's own accepted-config gain."
+            ),
+        ]
+        if status == "unavailable_reference_unverified"
+        else []
+    )
     recipe_caveat = (
         []
         if recipe_aligned
@@ -3027,6 +3085,7 @@ def _render_baseline_alignment_section(result: dict[str, Any]) -> str:
             f"- Same-config divergence: {same_config_divergence}",
             f"- Alignment status: `{status}` (warning threshold: ±{threshold})",
             f"- Server launch recipe: `{launcher}`",
+            *reference_caveat,
             *recipe_caveat,
             "",
             "Raw-session audit comparison:",

--- a/interface/test_run_e2e_alignment.py
+++ b/interface/test_run_e2e_alignment.py
@@ -17,9 +17,11 @@ alignment_metrics):
     same-config metric.
   * ``raw_session_baseline_divergence_pct`` = GEAK baseline vs the orchestrator
     RAW baseline (conflates config gain + residue) — audit only.
-  * ``cold_speedup`` = GEAK cold final / orchestrator COLD baseline — the exact
-    number Hyperloom promotes as its (cross-harness) PROVISIONAL gain, so it must
-    equal current_best.tput / baseline_tput.
+  * ``cold_speedup`` = GEAK cold final / the orchestrator anchor Hyperloom
+    promotes, so it must equal current_best.tput / baseline_tput. Note the
+    anchor is normally a HOT measure round (Hyperloom discards its warmup
+    round); ``orchestrator_baseline_lifecycle`` says which, and
+    ``hot_speedup`` is the hot-to-hot pairing.
 
 Run: python3 -m pytest GEAK/interface/test_run_e2e_alignment.py -v
 """

--- a/interface/test_run_e2e_alignment.py
+++ b/interface/test_run_e2e_alignment.py
@@ -314,7 +314,14 @@ def test_map_args_consumes_schema_v2_effective_config(tmp_path: Path) -> None:
     assert "SGLANG_USE_AITER=1" in ps["initial_extra_env"]
     assert ps["initial_overlay_pythonpath"] == f"{overlay}:{snapshot}"
     assert len(ps["effective_config_digest"]) == 64
-    assert ps["measurement_mode"] == "isolated_server"
+    # ONE lifecycle for the whole run, and it is Hyperloom's: 1 boot per leg,
+    # a discarded full warmup round, then the timed round.  validation_rounds=1
+    # means exactly two client passes with the second one reported, which is
+    # what warmup_round/measure_round does.
+    assert ps["measurement_mode"] == "warm_server"
+    assert ps["validation_measurement_mode"] == "warm_server"
+    assert ps["validation_rounds"] == 1
+    # Only consulted if a caller pins validation back to isolated_server.
     assert ps["validation_replicas"] == 3
 
 

--- a/interface/test_run_e2e_alignment.py
+++ b/interface/test_run_e2e_alignment.py
@@ -492,3 +492,159 @@ def test_promoted_final_is_hot_and_cold_stays_a_diagnostic(tmp_path: Path) -> No
     assert am["cold_speedup"] == pytest.approx(geak_cold_final / orch_cold, abs=1e-4)
     hot_over_cold = am["geak_hot_final_tok_s"] / orch_cold
     assert am["cold_speedup"] < hot_over_cold
+
+
+# --- Regression: an unverified upstream same-config reference -----------------
+#
+# Anchored on the real Hyperloom run MiniMax-M3-MXFP4/20260904T002558Z-3de91cb3,
+# which handed GEAK `orchestrator_best_tput_same_config: 0.0` with
+# `same_config_reference_status: "unverified"` and zero accepted kernels. The
+# session still reported hot_speedup ~1.19 -- entirely Hyperloom's OWN explore
+# gain, because hot_speedup's denominator is the RAW session baseline
+# (3693.71 tok/s hot measure round) and its numerator is the post-explore
+# accepted config (measured on-hardware at 4379.15 tok/s under warm_server).
+
+
+def _minimax_handoff(
+    *,
+    status: str | None = "unverified",
+    exp_root: Path | None = None,
+) -> dict:
+    h = {
+        "workload": {"isl": 8192, "osl": 1024, "conc": 64},
+        "raw_baseline_tput": 3693.7114118953027,
+        "orchestrator_best_tput_same_config": 0.0,
+    }
+    if status is not None:
+        h["same_config_reference_status"] = status
+    if exp_root is not None:
+        # Hyperloom's double-run baseline: a full warmup round it discarded,
+        # then the hot measure round that became state.baseline_tput. Without
+        # this verdict the hot-to-hot pairings correctly degrade to None.
+        (exp_root / "state.json").write_text(
+            json.dumps({
+                "baseline_tput": 3693.7114118953027,
+                "baseline_warm_runtime_sec": 53.23,
+                "baseline_measure_round_dropped": False,
+            }),
+            encoding="utf-8",
+        )
+        h["exp_root"] = str(exp_root)
+    return h
+
+
+def test_unverified_same_config_reference_is_named_as_upstream_gap(
+    tmp_path: Path,
+) -> None:
+    """A 0.0 reference the orchestrator called unverified is not GEAK's failure."""
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    wf = _wf(eval_dir, base=4379.154, final=4379.154, speedup=1.0)
+
+    out = rx.normalize_result(_minimax_handoff(), wf)
+    al = out["baseline_alignment"]
+
+    assert al["status"] == "unavailable_reference_unverified"
+    assert al["same_config_reference_status"] == "unverified"
+    # The reference really is absent -- the new status must not invent one.
+    assert out["baseline_basis"]["current_best_same_config_divergence_pct"] is None
+    json.dumps(out, allow_nan=False)
+
+
+def test_verified_and_missing_status_keep_the_plain_unavailable_status(
+    tmp_path: Path,
+) -> None:
+    """Only a non-"verified" upstream verdict earns the sharper status."""
+    cases = (
+        ("verified", "unavailable"),
+        ("VERIFIED", "unavailable"),
+        (None, "unavailable"),
+        ("", "unavailable"),
+        ("unverified", "unavailable_reference_unverified"),
+        ("stale", "unavailable_reference_unverified"),
+    )
+    for index, (status, expected) in enumerate(cases):
+        eval_dir = tmp_path / f"e2e_{index}"
+        eval_dir.mkdir()
+        out = rx.normalize_result(
+            _minimax_handoff(status=status),
+            _wf(eval_dir, base=4379.154, final=4379.154, speedup=1.0),
+        )
+        al = out["baseline_alignment"]
+        assert al["status"] == expected, (status, al["status"])
+        # Normalized to lowercase, None when the handoff said nothing at all.
+        assert al["same_config_reference_status"] == (
+            status.lower() if status else None
+        )
+
+
+def test_hot_speedup_declares_its_denominator_and_config_gain(
+    tmp_path: Path,
+) -> None:
+    """hot_speedup must self-label as raw-baseline-relative, not GEAK-only."""
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    (eval_dir / "baseline").mkdir()
+    (eval_dir / "validation" / "final").mkdir(parents=True)
+    # GEAK's own warm_server measurement of the seeded (already-accepted) config:
+    # the discarded cold outer round + the hot median, both real numbers.
+    (eval_dir / "baseline" / "bench_summary.json").write_text(
+        json.dumps({"output_throughput_tok_s_median": 4379.154,
+                    "cold_output_throughput_tok_s": 2580.58}),
+        encoding="utf-8",
+    )
+    (eval_dir / "validation" / "final" / "bench_summary.json").write_text(
+        json.dumps({"output_throughput_tok_s_median": 4379.154,
+                    "cold_output_throughput_tok_s": 2580.58}),
+        encoding="utf-8",
+    )
+    wf = _wf(eval_dir, base=4379.154, final=4379.154, speedup=1.0)
+
+    out = rx.normalize_result(_minimax_handoff(exp_root=tmp_path), wf)
+    am = out["alignment_metrics"]
+
+    # GEAK accepted nothing here, and hot_geak_speedup says so honestly...
+    assert am["hot_geak_speedup"] == pytest.approx(1.0, abs=1e-4)
+    # ...while hot_speedup is ~1.19 purely from Hyperloom's own config gain.
+    assert am["hot_speedup"] == pytest.approx(4379.154 / 3693.7114118953027,
+                                             abs=1e-3)
+    assert am["hot_speedup"] > 1.15
+    # Which is exactly why the block must say whose gain that is.
+    assert am["hot_speedup_denominator"] == "raw_session_baseline"
+    assert am["hot_speedup_includes_orchestrator_config_gain"] is True
+    # The only same-config pairing -- absent, because upstream never verified it.
+    assert am["hot_speedup_same_config"] is None
+    json.dumps(out, allow_nan=False)
+
+
+def test_unverified_reference_caveat_reaches_the_rendered_report(
+    tmp_path: Path,
+) -> None:
+    """The status is useless if only the JSON carries the explanation."""
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    out = rx.normalize_result(
+        _minimax_handoff(),
+        _wf(eval_dir, base=4379.154, final=4379.154, speedup=1.0),
+    )
+    section = rx._render_baseline_alignment_section(out)
+
+    assert "unavailable_reference_unverified" in section
+    assert "upstream handoff gap" in section
+    assert "hot_geak_speedup" in section
+    # Idempotent, like the rest of the section.
+    assert rx._render_baseline_alignment_section(out) == section
+
+
+def test_verified_reference_report_has_no_unverified_caveat(
+    tmp_path: Path,
+) -> None:
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    out = rx.normalize_result(
+        _minimax_handoff(status="verified"),
+        _wf(eval_dir, base=4379.154, final=4379.154, speedup=1.0),
+    )
+    section = rx._render_baseline_alignment_section(out)
+
+    assert "upstream handoff gap" not in section

--- a/interface/test_run_e2e_alignment.py
+++ b/interface/test_run_e2e_alignment.py
@@ -316,13 +316,13 @@ def test_map_args_consumes_schema_v2_effective_config(tmp_path: Path) -> None:
     assert "SGLANG_USE_AITER=1" in ps["initial_extra_env"]
     assert ps["initial_overlay_pythonpath"] == f"{overlay}:{snapshot}"
     assert len(ps["effective_config_digest"]) == 64
-    # ONE lifecycle for the whole run, and it is Hyperloom's: 1 boot per leg,
-    # a discarded full warmup round, then the timed round.  validation_rounds=1
-    # means exactly two client passes with the second one reported, which is
-    # what warmup_round/measure_round does.
+    # ONE lifecycle for the whole run, and it is Hyperloom's: 1 boot per leg, a discarded
+    # full warmup round, then the timed round -- exactly two client passes with the second
+    # one reported, which is what warmup_round/measure_round does.  The round count is not
+    # a separate knob; it is what warm_server means.
     assert ps["measurement_mode"] == "warm_server"
     assert ps["validation_measurement_mode"] == "warm_server"
-    assert ps["validation_rounds"] == 1
+    assert "validation_rounds" not in ps
     # Only consulted if a caller pins validation back to isolated_server.
     assert ps["validation_replicas"] == 3
 

--- a/interface/test_run_e2e_dispatch.py
+++ b/interface/test_run_e2e_dispatch.py
@@ -1578,15 +1578,30 @@ class TestNumericHelpers(_RunE2ECase):
 
 
 class TestOrchestratorHotBaseline(_RunE2ECase):
-    def test_absent_exp_root_is_zero(self):
-        self.assertEqual(rx.read_orchestrator_hot_baseline({}), 0.0)
-        self.assertEqual(rx.read_orchestrator_hot_baseline({"exp_root": "  "}), 0.0)
+    """Hyperloom's anchor is ``baseline_tput``; whether it is HOT is told by
+    ``baseline_warm_runtime_sec`` (the measure round's wall-clock, written only on
+    the double-run path) and ``baseline_measure_round_dropped``."""
+
+    def test_absent_exp_root_is_unknown(self):
+        self.assertEqual(rx.read_orchestrator_baseline_lifecycle({}), (0.0, "unknown"))
+        self.assertEqual(
+            rx.read_orchestrator_baseline_lifecycle({"exp_root": "  "}),
+            (0.0, "unknown"),
+        )
 
     def test_hot_baseline_found_two_levels_up(self):
         session = self.tmp / "session"
         exp_root = session / "run" / "geak"
         exp_root.mkdir(parents=True)
-        self.write_json(session / "state.json", {"baseline_hot_tput": 612.5})
+        self.write_json(session / "state.json", {
+            "baseline_tput": 612.5,
+            "baseline_warm_runtime_sec": 176.4,
+            "baseline_measure_round_dropped": False,
+        })
+        self.assertEqual(
+            rx.read_orchestrator_baseline_lifecycle({"exp_root": str(exp_root)}),
+            (612.5, "hot_measure_round"),
+        )
         self.assertEqual(
             rx.read_orchestrator_hot_baseline({"exp_root": str(exp_root)}), 612.5
         )
@@ -1594,16 +1609,43 @@ class TestOrchestratorHotBaseline(_RunE2ECase):
     def test_nested_baseline_block_is_read(self):
         exp_root = self.tmp / "geak"
         exp_root.mkdir(parents=True)
-        self.write_json(exp_root / "state.json",
-                        {"baseline": {"baseline_hot_tput": "701.25"}})
+        self.write_json(exp_root / "state.json", {"baseline": {
+            "baseline_tput": "701.25",
+            "baseline_warm_runtime_sec": "88.0",
+        }})
         self.assertEqual(
-            rx.read_orchestrator_hot_baseline({"exp_root": str(exp_root)}), 701.25
+            rx.read_orchestrator_baseline_lifecycle({"exp_root": str(exp_root)}),
+            (701.25, "hot_measure_round"),
+        )
+
+    def test_dropped_measure_round_is_cold_and_not_offered_as_hot(self):
+        """Budget could not fund the hot pass, so the anchor is the cold round —
+        dividing GEAK's hot final by it would return the warm-up as speedup."""
+        exp_root = self.tmp / "geak"
+        exp_root.mkdir(parents=True)
+        self.write_json(exp_root / "state.json", {
+            "baseline_tput": 500.0,
+            "baseline_warm_runtime_sec": 0.0,
+            "baseline_measure_round_dropped": True,
+        })
+        self.assertEqual(
+            rx.read_orchestrator_baseline_lifecycle({"exp_root": str(exp_root)}),
+            (0.0, "cold_single_round"),
+        )
+
+    def test_single_round_baseline_is_unknown_not_hot(self):
+        exp_root = self.tmp / "geak"
+        exp_root.mkdir(parents=True)
+        self.write_json(exp_root / "state.json", {"baseline_tput": 500.0})
+        self.assertEqual(
+            rx.read_orchestrator_baseline_lifecycle({"exp_root": str(exp_root)}),
+            (0.0, "unknown"),
         )
 
     def test_unusable_values_degrade_to_zero(self):
         exp_root = self.tmp / "geak"
         exp_root.mkdir(parents=True)
-        self.write_json(exp_root / "state.json", {"baseline_hot_tput": "not-a-number"})
+        self.write_json(exp_root / "state.json", {"baseline_tput": "not-a-number"})
         self.assertEqual(
             rx.read_orchestrator_hot_baseline({"exp_root": str(exp_root)}), 0.0
         )
@@ -1612,7 +1654,8 @@ class TestOrchestratorHotBaseline(_RunE2ECase):
         exp_root = self.tmp / "geak"
         exp_root.mkdir(parents=True)
         self.assertEqual(
-            rx.read_orchestrator_hot_baseline({"exp_root": str(exp_root)}), 0.0
+            rx.read_orchestrator_baseline_lifecycle({"exp_root": str(exp_root)}),
+            (0.0, "unknown"),
         )
 
 

--- a/interface/test_run_e2e_dispatch.py
+++ b/interface/test_run_e2e_dispatch.py
@@ -10,7 +10,7 @@ the path that actually *launches* the optimizer, so a break there is invisible
 until a real 12-hour GPU run dies. This module covers:
 
   - handoff -> workflow args (``map_args``): the optional knobs (launch_recipe,
-    phases, e2e_repeats, carried state, time_budget_s), the minted-vs-pinned
+    phases, carried state, time_budget_s), the minted-vs-pinned
     eval_dir, and the TraceLens artifact bridge. A dropped knob here silently
     re-runs a phase that was meant to be resumed, or mints a second abandoned
     eval_dir beside the authoritative one.
@@ -239,8 +239,14 @@ class TestMapArgs(_RunE2ECase):
         return h
 
     def test_optional_workflow_knobs_are_forwarded_verbatim(self):
-        """launch_recipe / phases / e2e_repeats / carried state are the resume
-        channel: dropping one silently re-runs a phase the caller pinned."""
+        """launch_recipe / phases / carried state are the resume channel:
+        dropping one silently re-runs a phase the caller pinned.
+
+        `e2e_repeats` is deliberately NOT in that channel. The timed-round count
+        is a property of the measurement lifecycle (GEAK_REPEAT_MODE +
+        MEASUREMENT_PURPOSE), so a handoff carrying it must be ignored rather
+        than allowed to pull one leg off the lifecycle the rest of the run used.
+        """
         h = self._handoff(
             eval_dir=str(self.tmp / "e2e_pinned"),
             launch_recipe="/recipes/launch_vllm.sh",
@@ -251,7 +257,7 @@ class TestMapArgs(_RunE2ECase):
         ps = rx.map_args(h, timeout_s=3600)
         self.assertEqual(ps["launch_script"], "/recipes/launch_vllm.sh")
         self.assertEqual(ps["phases"], "final")
-        self.assertEqual(ps["e2e_repeats"], 1)
+        self.assertNotIn("e2e_repeats", ps)
         self.assertEqual(ps["state"], {"headQueue": [{"short_name": "h0"}]})
         self.assertEqual(ps["time_budget_s"], 3600)
         self.assertEqual(ps["eval_dir"], str(self.tmp / "e2e_pinned"))
@@ -1073,7 +1079,8 @@ class TestBenchProtocol(_RunE2ECase):
         self.assertEqual(exported["NUM_WARMUPS"], "128")
         self.assertEqual(exported["SEED"], "0")
         self.assertEqual(exported["RANDOM_RANGE_RATIO"], "1")
-        self.assertEqual(exported["GEAK_REPEAT_MODE"], "isolated_server")
+        self.assertEqual(exported["GEAK_REPEAT_MODE"], "warm_server")
+        self.assertEqual(exported["GEAK_VALIDATION_REPEAT_MODE"], "warm_server")
         self.assertEqual(exported["REPLICA_RETRIES"], "1")
         # A pinned count is the caller telling us what it measured.
         self.assertNotIn("NUM_PROMPTS_ADAPTIVE", exported)

--- a/perf_knowledge/workflows/optimize_e2e_model.md
+++ b/perf_knowledge/workflows/optimize_e2e_model.md
@@ -90,9 +90,17 @@ negative but sub-threshold → compound later), `rejected` (parity fail / no eng
 regression).
 
 **Tight 2-launch A/B protocol:** one reference block then one candidate block, back-to-
-back on the same GPU, each running `E2E_REPEATS` (default 7) timed repeats on ONE server
-(do NOT relaunch per repeat). Compute `ref_med, cand_med, ref_max, cand_min, delta%` from
-all per-repeat rows.
+back on the same GPU. Each block is ONE `bench_e2e.sh` invocation in the run's
+`MEASUREMENT_MODE`; that mode owns the round count, there is no separate repeats knob.
+Under the `warm_server` default each block is one server, one full round discarded as
+warmup, and one timed round that IS the number (Hyperloom's protocol) — so `ref_med`/
+`ref_max` and `cand_med`/`cand_min` collapse to that single value per leg, and the
+non-overlap clause of the acceptance rule degenerates into `cand > ref`. `delta% >
+NOISE_BAND_PCT` is what carries the decision; the drift protection comes from the two
+blocks being back-to-back in the same session, not from within-leg spread. If you need a
+genuine non-overlap test, pin that leg to `isolated_server` (each replica a fresh server,
+so the spread bounds boot-to-boot variance) and say so in the trial notes, since the
+number is then not comparable to the run's other numbers.
 
 ### 7. Finalize (combined stack)
 Assemble all `accepted` + `stack` changes into one config/overlay.

--- a/perf_knowledge/workflows/optimize_e2e_model.md
+++ b/perf_knowledge/workflows/optimize_e2e_model.md
@@ -92,15 +92,12 @@ regression).
 **Tight 2-launch A/B protocol:** one reference block then one candidate block, back-to-
 back on the same GPU. Each block is ONE `bench_e2e.sh` invocation in the run's
 `MEASUREMENT_MODE`; that mode owns the round count, there is no separate repeats knob.
-Under the `warm_server` default each block is one server, one full round discarded as
-warmup, and one timed round that IS the number (Hyperloom's protocol) — so `ref_med`/
-`ref_max` and `cand_med`/`cand_min` collapse to that single value per leg, and the
-non-overlap clause of the acceptance rule degenerates into `cand > ref`. `delta% >
-NOISE_BAND_PCT` is what carries the decision; the drift protection comes from the two
-blocks being back-to-back in the same session, not from within-leg spread. If you need a
-genuine non-overlap test, pin that leg to `isolated_server` (each replica a fresh server,
-so the spread bounds boot-to-boot variance) and say so in the trial notes, since the
-number is then not comparable to the run's other numbers.
+Under the `warm_server` default each block is a single timed round, so `ref_med`/`ref_max`
+and `cand_med`/`cand_min` collapse to one value per leg and the non-overlap clause
+degenerates into `cand > ref`: `delta% > NOISE_BAND_PCT` is what carries the decision, and
+the drift protection comes from the two blocks being back-to-back, not from within-leg
+spread. For a genuine non-overlap test pin that leg to `isolated_server` and say so in the
+trial notes (see the `bench_e2e.sh` header on mixing lifecycles).
 
 ### 7. Finalize (combined stack)
 Assemble all `accepted` + `stack` changes into one config/overlay.


### PR DESCRIPTION
GEAK's validation measured throughput as the median of 3 isolated-server replicas, while the Hyperloom orchestrator that rebenches the very same kernel measures one warm round: boot the server, run a full untimed round, report the second pass. Two different statistics over the same kernel is how the two sides ended up disagreeing about whether a win was real.

## Why

This is not hypothetical. From GEAK's own KB (`e2e_workflow/knowledge/learned/moe-fp8-blockscale-tune-gfx950.md`), Qwen3.5-122B-A10B-FP8, TP=2, gfx950/MI355, fp8 block[128,128] MoE at 21.4% of GPU time:

| measurement | verdict |
|---|---|
| milestone interleaved A/B | **+1.36%**, ranges **non-overlapping**, byte-exact parity 12/12 |
| Director **same-session** A/B | **+0.16%** (1.0016x), ranges **overlapping** -> `validated_no_win` |

The difference was the baseline moving underneath the comparison: base median rose from 2405.9 (warm-start) to 2451.5 (same-session), so most of the apparent gain was drift, not the kernel. Note that the *wrong* answer was the more convincing-looking one — non-overlapping ranges plus byte-exact parity. It also shows byte-exact parity is not evidence of a throughput win.

One lifecycle for every throughput number is the fix.

## What changes

* `warm_server` becomes the default lifecycle in `bench_e2e.sh`, and the default for the search, parity and validation purposes in `e2e_workflow.js` / `run_e2e.py`. `REPEATS` defaults to 1: one timed round **is** the protocol, not a truncation of it. Carve-outs for `REPEATS=0` (shape capture) and `PROFILE=1`, which produce no throughput number and so have no lifecycle to align.
* `isolated_server` stays available for boot-to-boot dispersion, opt-in only, with its own `validation_measurement_mode` / `validation_replicas` knobs so an operator can make the final arbitration stricter than the search that fed it.
* Delete `E2E_REPEATS`. It was prompt-only — no role doc or script ever read it.
* Extract the two summary emitters out of `bench_e2e.sh` into `scripts/bench_summarize.py` (from-runs / from-replicas). They were duplicated heredocs with no test, and every acceptance decision in the product reads their output; a contract field added to one and not the other produced two `bench_summary.json` shapes with nothing to catch it. `bench_e2e.sh` 1053 -> 851 lines.
* Docs and role prompts updated to describe the protocol the code actually runs, instead of the old ">=3 repeats, median + spread".

## Verified

**Unit:** 1967 tests pass over the CI file list at 97.52% coverage. The new emitter is byte-identical to the old heredocs over 12 replayed input shapes.

### On hardware, part 1 — protocol A/B

Same box, model, serving invariant and tuning bundle; `adapters/` and `bench_replica.sh` byte-identical between the two runs, so the lifecycle is the only variable. DeepSeek-V4-Pro, vLLM, TP=8, ISL 8192 / OSL 1024 / conc 64, 192 prompts:

| lifecycle | base | final | delta | wall-clock | cold boots |
|---|---|---|---|---|---|
| `isolated_server` x3 (before) | 833.298 | 879.030 | **+5.488%** | ~68 min | 6 |
| `warm_server` x1 (this PR's default) | 826.936 | 886.571 | **+7.212%** | **30.8 min** | 2 |

Same verdict, **2.2x faster**, 6 cold boots down to 2. Server boot alone was 466 s and 381 s of the two legs — that is what the extra replicas were re-paying.

### On hardware, part 2 — does the new lifecycle actually land on Hyperloom's number?

Part 1 shows the two GEAK lifecycles agree with each other. It does not show that either agrees with the orchestrator, which is the whole point of the change. So: replay a real Hyperloom session's accepted config under this PR's validate lifecycle, and compare against what Hyperloom itself measured for that same config.

Session `MiniMax-M3-MXFP4/20260904T002558Z-3de91cb3`. 8x MI355X, TP=8, vLLM `0.28.1rc1.dev87+g6d4562c59` — the exact nightly that session ran, not a nearby release tag. ISL 8192 / OSL 1024 / conc 64, 192 prompts, 128 warmups, `RANDOM_RANGE_RATIO=1`, `SEED=0`, `BENCH_CLIENT=inferencex` driving the same `benchmark_serving.py` Hyperloom drives. `GEAK_REPEAT_MODE=warm_server`, `MEASUREMENT_PURPOSE=validation`, 3 timed rounds.

| round | tok/s |
|---|---|
| full outer warmup (**discarded**) | 2580.58 |
| timed round 1 | 4373.87 |
| timed round 2 | 4409.18 |
| timed round 3 | 4379.15 |
| **median** | **4379.154** (spread **0.81%**) |

| comparison | result |
|---|---|
| GEAK `warm_server` median vs Hyperloom's own warm number for the same config (4405.70) | **-0.60%** |
| GEAK's *discarded* cold round vs the baseline the old `isolated_server` lifecycle shipped for this session (2645.44) | -2.45% |
| warm / cold on the same server | **1.697x** |

Three things follow. The new lifecycle lands within **0.60%** of the orchestrator — the first direct confirmation that the two harnesses now measure the same statistic. The old lifecycle's "baseline" reproduces to within 2.45% of this run's *thrown-away cold round*, which is what it was measuring all along; it understated by **41.1%**. And the run resolved the same kernels Hyperloom did (`AiterExperts`, `ROCM_AITER_FA`), so the residual is measurement, not a different stack.

`measurement_mode=warm_server`, `measurement_purpose=validation`, `successful_rounds=3`, `dispersion_basis=within_server_rounds`, `usable_for_acceptance=true`.

## The tradeoff, stated up front

The two deltas in part 1 are **1.72 pp apart**, and that gap is the honest cost of the change, so it should not be discovered in review.

One sample per leg means `spread = 0.0%` by construction — an absence of dispersion evidence, not a quiet box — and the `final_min > base_max` non-overlap test carries no information at all. The isolated legs measured 2.61% and 2.81% spread, so a low base draw and a high final draw compound to ~1.6 pp on their own, which accounts for the observed 1.72 pp. Read it as sampling, not as a bias between the protocols. (Given more than one timed round, `warm_server` does report dispersion: 0.81% *within* one server in part 2.)

`roles/director.md` handles this explicitly rather than hiding it: under `warm_server` the samples share one boot, so spread is narrower than true run-to-run spread; when `delta%` is within 2x the noise band and only non-overlap carries the win, the Director must say so in `notes` and prefer `validated_no_win`. At one sample it must record that the dispersion test was unavailable. `bench_summary.json` carries `measurement_mode` and `dispersion_basis` so any consumer can tell which lifecycle produced a number.

Numbers are comparable only within one lifecycle. The header warning originally claimed `warm_server` "reads systematically HIGHER"; the part-1 run is a counterexample (warm 826.9 vs isolated median 833.3 — the other way, because `RANDOM_RANGE_RATIO=1.0` at ISL 8192 leaves almost no shared prefix to cache), while part 2 lands 1.70x above its own cold round. The rule is unchanged; the stated reason is now that the sign and size are not predictable from the config alone.

## Two defects this validation turned up, now fixed here

* **`adapters/clients/inferencex.sh` gated the Hyperloom warmup on the wrong signal.** The `2*CONC` warmup and `--seed 0` fire on `GEAK_ISOLATED_REPLICA=1`; `warm_server` deliberately sets that to `0` — its outer warmup round must run — and announces itself with `WARM_SERVER_ROUNDS` instead. Every `warm_server` bench therefore falls back to the adapter's 8-request default unless the caller exports `NUM_WARMUPS`. The orchestrated path does, which is why part 2 above is unaffected; a direct `bench_e2e.sh` invocation does not.
* **`hot_speedup` reported the orchestrator's gain as GEAK's.** Its denominator is Hyperloom's **raw** session baseline, which predates the config Hyperloom itself accepted before handing GEAK the seed. The MiniMax session is the proof: `accepted_kernels == []` and `hot_geak_speedup == 1.0`, yet `hot_speedup == 1.186`. The clean pairing needs `orchestrator_best_tput_same_config`, which that handoff shipped as `0.0` with `same_config_reference_status: "unverified"` — an upstream gap that surfaced as a bare `unavailable`, indistinguishable from a GEAK-side failure. It now reports `unavailable_reference_unverified` and the report names it as an upstream handoff gap, with `hot_speedup` labelling its own denominator.

There is also a defect **outside** this repo: that session's `baseline_config.with_envs.yaml` and `launch_evidence.json` do not record the AITER environment the baseline server demonstrably ran with, and `observed_server_identity` / `observed_server_launch_flags` are empty for every vLLM measurement. Replaying that record verbatim resolves the MXFP4 emulation path and measures 896 tok/s against the recorded 3694. Fixed upstream in Hyperloom, not here.

## Out of scope

An earlier revision of this branch also loosened the gsm8k accuracy gate (tol 0.01 -> 0.03, plus an absolute 0.5 floor). That has been **reverted** here. The argument stands on its own, but it is a gate-policy change rather than a measurement-protocol one, and bundling it would force this PR to be accepted or rejected as a unit. It will come back as its own PR with its own evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

