### PR TITLE
kb: address e2e records by release version, apply what is recalled, and report both

### DIFF
--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -2509,6 +2509,13 @@ if (want('setup')) {
           measured_tok_s: v.measured_tok_s != null ? v.measured_tok_s : null,
           delta_pct: v.delta_pct != null ? v.delta_pct : null,
           parity: String(v.parity || ''), outcome: String(v.outcome || ''),
+          // What the merge and the repair did, in the same row as the number they produced. A
+          // reader who sees a neutral `delta_pct` needs to know whether the recorded value was the
+          // one that ran (`overrides`) and whether all of it ran (`applied_partial`); without them
+          // the row reads as a verdict on the record when it may be a verdict on the pairing.
+          overrides: Array.isArray(v.overrides) ? v.overrides : [],
+          applied_partial: v.applied_partial === true,
+          dropped_flags: Array.isArray(v.dropped_flags) ? v.dropped_flags : [],
           why: String(v.why || '').slice(0, 300),
         }));
         KB_RECALL.e2e.kernels = kernelVerdicts.map(v => ({

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -857,6 +857,43 @@ let KB_DIMS = null;        // the deployment dimensions the Director established
 let KB_REF_DIR = '';       // where Module A left its references; '' when it never ran
 let KB_REF_VERDICT = '';   // what we MEASURED about the offer, threaded into later roles' Inputs
 let KB_READ_PLANE = '';    // which plane ANSWERED the read, which `both` alone does not tell you
+// Everything this run RECALLED, in one report-ready object: which address was asked, what came back,
+// what re-measuring it HERE produced, and whether it was accepted. Threaded into the Report role's
+// Inputs because final_report.md was previously silent about recall altogether — a run that recalled
+// nothing and a run that recalled a 1.12x record and then rejected it wrote the same report, and the
+// second is the one a reader most needs to see.
+//
+// `asked` is filled in even when zero candidates come back. On an exact-lookup scheme a miss and a
+// never-recorded page are the SAME 404, so the ladder that was asked IS the finding: it is the only
+// artifact that distinguishes "no prior art" from "prior art exists one segment away".
+let KB_RECALL = { e2e: null, kernel: [] };
+
+// One collection point for the KERNEL plane's recall. Every nested kernel_workflow returns its own
+// `warm_start` block (kernel_lane.js), and until now all of it died inside the lane: the e2e report
+// could say a kernel was authored from scratch while the lane had in fact adopted a stored patch.
+// Called from the two bounded wrappers and the two direct workflow() sites, i.e. every lane call.
+function noteKernelKB(r, label) {
+  const w = r && r.warm_start;
+  if (w && typeof w === 'object') {
+    KB_RECALL.kernel.push({
+      lane: String(label || ''),
+      slug: String(w.slug || ''),
+      read_reason: String(w.read_reason || ''), match_tier: String(w.match_tier || ''),
+      filtered: w.filtered || null,
+      candidates: Array.isArray(w.candidates) ? w.candidates.length : 0,
+      adopted: !!w.adopted,
+      adopted_speedup: w.adopted ? (w.adopted_speedup != null ? w.adopted_speedup : null) : null,
+      // A lane that adopted a stored patch and then committed nothing of its own is where the kernel
+      // plane most often flatters itself, so carry the split rather than just the headline geomean.
+      incremental_speedup: w.incremental_speedup != null ? w.incremental_speedup : null,
+      rounds_committed: w.rounds_committed != null ? w.rounds_committed : null,
+      no_rounds_after_adopt: !!w.no_rounds_after_adopt,
+      final_geomean: r.final_geomean != null ? r.final_geomean : null,
+      validation_status: String(r.validation_status || ''),
+    });
+  }
+  return r;
+}
 
 const shq = (s) => "'" + String(s == null ? '' : s).replace(/'/g, "'\\''") + "'";
 
@@ -1687,7 +1724,10 @@ if (FAST_MODE && typeof setTimeout === 'function' && FAST_HEAD_DEADLINE_MS > 0) 
 // workflow() promise (identical to a direct call); on cap-expiry it resolves null so the caller's
 // existing null-guards treat it as "no kernel" and continue.
 function fastBoundedWorkflow(ref, wfArgs, label) {
-  const p = workflow(ref, laneArgs(wfArgs));
+  // noteKernelKB is a pass-through recorder: it returns `r` unchanged, so the caller's null-guards
+  // and result handling are untouched. It is attached here (and in deepBoundedWorkflow, and at the
+  // two direct workflow() sites) so EVERY lane call reports its kernel-plane recall exactly once.
+  const p = workflow(ref, laneArgs(wfArgs)).then((r) => noteKernelKB(r, label));
   if (!FAST_MODE || typeof setTimeout !== 'function' || !(FAST_HEAD_WF_MS > 0)) return p;
   let to;
   const guard = new Promise((resolve) => {
@@ -1738,7 +1778,7 @@ if (TIME_BUDGET_EFFECTIVE_MS != null && typeof setTimeout === 'function' && TIME
   }, TIME_BUDGET_EFFECTIVE_MS);
 }
 function deepBoundedWorkflow(ref, wfArgs, label) {
-  const p = workflow(ref, laneArgs(wfArgs));
+  const p = workflow(ref, laneArgs(wfArgs)).then((r) => noteKernelKB(r, label));
   if (!DEEP_MODE || typeof setTimeout !== 'function' || !(DEEP_HEAD_WF_MS > 0)) return p;
   let to;
   const guard = new Promise((resolve) => {
@@ -1788,6 +1828,7 @@ if (!MODEL_PATH && KERNEL_PATH) {
       budget: KERNEL_BUDGET, gpu_ids: GPU_IDS, task: TASK, exp_root: EXP_ROOT,
       apply_to_original: APPLY_TO_ORIGINAL,
     }));
+    noteKernelKB(r, 'single-kernel pass-through');
     passthru = { ran: true, kernel_eval_dir: r.eval_dir, final_patch: r.final_patch,
       final_geomean: r.final_geomean, validation_status: r.validation_status,
       note: (r.winner && r.winner.source) || '' };
@@ -1891,6 +1932,11 @@ if (want('setup')) {
       // cost of believing one is a 20-40min server launch, not a wasted lookup.
       log('[kb] warm start skipped: read_reason=missing_arch (the Director reported no gfx; a ' +
         'cross-arch config is not a candidate, it is a guess).');
+      // Still a recall FACT worth reporting: "we did not look, and here is why" is not the same
+      // report as "we looked and the store was empty", and the reader cannot tell them apart from
+      // an absent section.
+      KB_RECALL.e2e = { read_reason: 'missing_arch', tried: [], answered: '', match_tier: '',
+        plane: E2E_KB_PLANE, mode: E2E_WARM_START, candidates: 0, configs: [], kernels: [] };
     } else {
       const refsDir = `${EVAL_DIR}/kb_references`;
       const cacheDir = `${EVAL_DIR}/kb_cache`;
@@ -1930,6 +1976,17 @@ if (want('setup')) {
         `sorted_by=${resolved.sorted_by || resolved.ranked_by || '-'} ` +
         `champion_metric=${resolved.champion_metric || '-'} reason=${resolved.read_reason || '?'} ` +
         `candidates=${cands.length}`);
+      // Record the ASK before anything is benched. If this process dies mid-warm-start the report
+      // still knows which ladder was queried, and on a zero-candidate read this is the entire
+      // finding — see KB_RECALL's declaration for why the address matters more than the count.
+      KB_RECALL.e2e = {
+        read_reason: String(resolved.read_reason || ''),
+        tried: Array.isArray(resolved.tried) ? resolved.tried : [],
+        answered: String(resolved.canonical_id || ''),
+        match_tier: String(resolved.match_tier || ''),
+        plane: E2E_KB_PLANE, read_plane: KB_READ_PLANE, mode: E2E_WARM_START,
+        candidates: cands.length, configs: [], kernels: [],
+      };
       if (cands.length) KB_REF_DIR = refsDir;   // arms warmStartBlock() for the consumer roles
 
       // How many of the offers are worth a server launch. On a coarser rung the stored numbers were
@@ -2203,6 +2260,29 @@ if (want('setup')) {
       }
 
       const allVerdicts = verdicts.concat(kernelVerdicts);
+      // Same rows the measured_on_this_box.md tables carry, in machine form, so the Report role
+      // states the recall outcome from the orchestrator's own record rather than from whether an
+      // agent happened to open a reference file. Set OUTSIDE the `if (allVerdicts.length)` guard:
+      // an empty verdict list against a non-empty offer means "offered but not benched", which is
+      // itself a reportable outcome.
+      if (KB_RECALL.e2e) {
+        KB_RECALL.e2e.configs = verdicts.map(v => ({
+          direction: String(v.direction || 'unlabeled'), session_id: String(v.session_id || ''),
+          stored_tok_s: v.throughput_tok_s != null ? v.throughput_tok_s : null,
+          stored_speedup: v.speedup != null ? v.speedup : null,
+          measured_tok_s: v.measured_tok_s != null ? v.measured_tok_s : null,
+          delta_pct: v.delta_pct != null ? v.delta_pct : null,
+          parity: String(v.parity || ''), outcome: String(v.outcome || ''),
+          why: String(v.why || '').slice(0, 300),
+        }));
+        KB_RECALL.e2e.kernels = kernelVerdicts.map(v => ({
+          name: String(v.name || ''), kind: String(v.kind || ''),
+          kb_session_id: String(v.kb_session_id || ''),
+          stored_isolated: v.isolated_speedup != null ? v.isolated_speedup : null,
+          measured_delta_pct: v.measured_delta_pct != null ? v.measured_delta_pct : null,
+          outcome: String(v.outcome || ''), why: String(v.why || '').slice(0, 300),
+        }));
+      }
       if (allVerdicts.length) {
         const adoptedCfg = verdicts.filter(v => v.outcome === 'adopted');
         const adoptedKer = kernelVerdicts.filter(v => v.outcome === 'adopted');
@@ -3616,6 +3696,7 @@ while (want('kernel') && !TIME_DEADLINE_HIT && dispatched < BUDGET && (dispatche
           ' for this kernel; pick the fastest that passes the immutable unittest. ' + GRAPH_REQ + (TASK || ''),
         apply_to_original: 'false',
       }));
+      noteKernelKB(r, String(c.short_name || ext.op_kind || 'milestone'));
       kl = { ran: true, kernel_eval_dir: r.eval_dir, final_patch: r.final_patch,
         final_geomean: r.final_geomean, validation_status: r.validation_status,
         note: (r.winner && r.winner.source) || '' };
@@ -3899,8 +3980,15 @@ if (want('final')) {
 
   phase('Report');
   report = await safeAgent(
-    roleAgent('system_architect', 'report', 'Write architect_report.md AND the full final_report.md in English (with the Phases tree + artifacts tree modules).', {
+    roleAgent('system_architect', 'report',
+      'Write architect_report.md AND the full final_report.md in English (with the Phases tree + ' +
+      'artifacts tree modules). final_report.md MUST contain a "## Knowledge-base recall" section ' +
+      'built from KB_RECALL — see your role file. Write it even when nothing was recalled: report ' +
+      'the exact canonical ids that were tried and the read_reason. On an exact-lookup store a miss ' +
+      'and a never-recorded page are the same 404, so the address asked is the finding, and a reader ' +
+      'who cannot see it cannot tell "no prior art" from "prior art one segment away".', {
       EVAL_DIR, HISTORY: history, BASELINE_THROUGHPUT: BASELINE_TPUT, FINAL_THROUGHPUT: finalTput,
+      KB_RECALL,
       ACCEPTED_CONFIG: { flags: curFlags, env: curEnv }, ACCEPTED_KERNELS: allAccepted,
       ACCEPTED_HEADS: acceptedHeads, FLAGGED_HEADS: flaggedHeads, MILESTONES: milestone, BUDGET_USED: dispatched, BUDGET, MIN_KERNEL_TASKS,
       PROFILE_TOPN: profile ? profile.profile_topN_json : '', WORKLOAD, MODEL_NAME, SKILL_DIR: WORKFLOW_DIR,
@@ -4008,6 +4096,10 @@ const kbWarmStart = (E2E_WARM_START_ON && KB_DIMS) ? {
   // The gain that is genuinely THIS run's: everything after the warm start's own contribution. Null
   // when nothing was adopted, because then the ordinary speedup already answers the question.
   incremental_speedup: kbSeedTput ? Number((finalTput / kbSeedTput).toFixed(6)) : null,
+  // The full recall ledger, both planes. Same object the Report role was handed, so the prose in
+  // final_report.md and whatever a downstream consumer reads cannot disagree about what was
+  // recalled or how it fared.
+  recall: KB_RECALL,
 } : null;
 // Attribution block for the standalone tuning phase. Because the phase measured its OWN interleaved
 // pre/post legs, its contribution can be expressed both absolutely (delta%) and as a SHARE of the run's
@@ -4117,6 +4209,11 @@ const wfReturn = {
   // Conditional spread, never an unconditional key: with the feature off this contributes no own
   // property and both the returned object and the persisted file are byte-identical to before.
   ...(kbWarmStart ? { kb_warm_start: kbWarmStart } : {}),
+  // Emitted independently of kb_warm_start. kbWarmStart is null whenever KB_DIMS was never
+  // established (a preflight that produced no gfx), but the KERNEL lanes can still have recalled by
+  // then — folding recall only into kbWarmStart would drop exactly the runs where knowing what was
+  // recalled matters most. Absent entirely when nothing was recalled on either plane.
+  ...((KB_RECALL.e2e || KB_RECALL.kernel.length) ? { kb_recall: KB_RECALL } : {}),
   state: carryState,
 };
 

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -666,6 +666,16 @@ const SWEEP_SCHEMA = obj({
   trials: arrObj, accepted_flags: { type: 'string' }, accepted_env: { type: 'string' },
   best_throughput_tok_s: { type: 'number' }, throughput_speedup_vs_baseline: { type: 'number' },
   summary: { type: 'string' },
+  // Only the warm-start repair pass fills this, and it stays OUT of `required` so every ordinary
+  // sweep keeps validating unchanged. It is the structured half of "why did this not run here" —
+  // read in place of guessing at the free-text notes with a regex.
+  repair: obj({
+    attempted: { type: 'boolean' },
+    classification: { type: 'string' },   // upstream_gone | conflicts_with_baseline | env_unsupported | mixed | unknown
+    dropped_flags: { type: 'array', items: { type: 'string' } },
+    reason_by_flag: { type: 'object', additionalProperties: true },
+    launch_error: { type: 'string' },
+  }, []),
 }, ['accepted_flags', 'best_throughput_tok_s']);
 
 // `e2e_store.py resolve` output, passed through VERBATIM. Nothing is `required` and no field is
@@ -1865,6 +1875,117 @@ function applyOpIdentityGuard(queue, stage) {
 }
 
 // ===========================================================================
+// MERGING A RECOVERED CONFIGURATION INTO THE ONE THIS RUN WAS HANDED
+// ===========================================================================
+// A stored e2e record holds a WHOLE launch configuration, not a delta, because that is the only
+// form that can be replayed on a box whose baseline nobody recorded. Replaying it means combining
+// it with whatever baseline configuration THIS run was handed — under Hyperloom that is a full
+// flag string the run does not own (interface/run_e2e.py seeds `initial_extra_server_args` from
+// the EXPLORE result and then sets `config_tune: "false"`, so there is no later sweep to correct
+// anything either).
+//
+// That combination used to be a string concatenation performed by an agent, and it was wrong in a
+// way nothing could see. `adapters/sglang.sh` expands `$EXTRA_SERVER_ARGS` straight into argparse
+// and `$EXTRA_ENV` straight into `env`, and both resolve a repeated key by last-wins. So when the
+// baseline and the record each pin `--context-length`, WHICH ONE APPLIES is decided by the order
+// the agent happened to write them in. Lose that coin flip and the server runs the baseline
+// configuration twice: ~0% delta, no complaint in any log — the flag WAS honoured, just not with
+// the recorded value — and the record is filed as `rejected`. A record that wins gets recorded as
+// a loss, which is the one outcome the whole warm start exists to avoid.
+//
+// So the merge is arithmetic, done here, and it reports what it did. Same rule the launcher
+// already applies to one flag by hand (`adapters/sglang.sh`: don't add `--watchdog-timeout` if the
+// caller set one), generalized and moved to where the string is built instead of where it is used.
+// The output names every key exactly once, so last-wins never gets a vote.
+
+// Flags that legitimately appear more than once. Deliberately tiny: `--lora-path` is a list and
+// deduping it would silently drop adapters, while everything else in these configs is a scalar
+// where a second occurrence is a mistake we are here to remove. Grow it only with evidence.
+const REPEATABLE_FLAGS = new Set(['--lora-path', '--lora-paths']);
+
+const _looksLikeFlag = (t) => /^--?[A-Za-z]/.test(t);
+
+/** `--a 1 --b=2 --c` -> [{name,value,eq}]. Unrecognized tokens ride along under name=null. */
+function parseFlagString(s) {
+  const toks = String(s || '').trim().split(/\s+/).filter(Boolean);
+  const items = [];
+  for (let i = 0; i < toks.length; i++) {
+    const t = toks[i];
+    if (!_looksLikeFlag(t)) { items.push({ name: null, value: t, eq: false }); continue; }
+    const eq = t.indexOf('=');
+    if (eq > 0) { items.push({ name: t.slice(0, eq), value: t.slice(eq + 1), eq: true }); continue; }
+    // Everything up to the next flag is this flag's value; `--foo a b` stays one item so a
+    // multi-valued flag is overridden as a unit rather than half-overridden.
+    const vals = [];
+    while (i + 1 < toks.length && !_looksLikeFlag(toks[i + 1])) vals.push(toks[++i]);
+    items.push({ name: t, value: vals.length ? vals.join(' ') : null, eq: false });
+  }
+  return items;
+}
+
+const renderFlagItems = (items) => items.map(
+  (it) => (it.name == null ? it.value
+    : it.value == null ? it.name
+      : it.eq ? `${it.name}=${it.value}` : `${it.name} ${it.value}`)).join(' ').trim();
+
+/** `K=V K2=V2` -> [{name,value}]. A token that is not an assignment rides along under name=null. */
+function parseEnvString(s) {
+  return String(s || '').trim().split(/\s+/).filter(Boolean).map((t) => {
+    const m = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(t);
+    return m ? { name: m[1], value: m[2] } : { name: null, value: t };
+  });
+}
+
+const renderEnvItems = (items) => items.map(
+  (it) => (it.name == null ? it.value : `${it.name}=${it.value}`)).join(' ').trim();
+
+/**
+ * Key-by-key merge of a recovered configuration onto this run's baseline.
+ *
+ * The recovered value WINS on a collision — it is the thing being tested, and applying the
+ * baseline's value instead would test nothing. It wins IN PLACE, so the baseline's ordering
+ * survives and the output contains each key once.
+ *
+ * Returns `{ merged, overrides, added, unchanged }`. `overrides` is the part that has to reach a
+ * human and the tuner: it is the list of knobs where this box disagreed with the record, and it is
+ * the first thing to look at when a replay comes back neutral.
+ */
+function mergeConfig(baseline, recovered, { parse, render, repeatable }) {
+  const out = parse(baseline).map((it) => ({ ...it }));
+  const at = new Map();
+  out.forEach((it, i) => { if (it.name && !repeatable.has(it.name)) at.set(it.name, i); });
+  const overrides = [], added = [], unchanged = [];
+  for (const it of parse(recovered)) {
+    if (it.name == null || repeatable.has(it.name) || !at.has(it.name)) {
+      out.push({ ...it });
+      if (it.name != null) {
+        added.push(it.name);
+        if (!repeatable.has(it.name)) at.set(it.name, out.length - 1);
+      }
+      continue;
+    }
+    const i = at.get(it.name), prev = out[i];
+    if (String(prev.value == null ? '' : prev.value) === String(it.value == null ? '' : it.value)) {
+      unchanged.push(it.name);
+      continue;
+    }
+    overrides.push({ flag: it.name, baseline_value: prev.value, recalled_value: it.value });
+    out[i] = { ...it };
+  }
+  return { merged: render(out), overrides, added, unchanged };
+}
+
+const mergeFlags = (baseFlags, storedFlags) => mergeConfig(baseFlags, storedFlags,
+  { parse: parseFlagString, render: renderFlagItems, repeatable: REPEATABLE_FLAGS });
+const mergeEnv = (baseEnv, storedEnv) => mergeConfig(baseEnv, storedEnv,
+  { parse: parseEnvString, render: renderEnvItems, repeatable: new Set() });
+
+/** `--context-length 11264 -> 13312; MAX_MODEL_LEN 13312 -> 16384`, or "". For prompts and logs. */
+const describeOverrides = (overrides) => (overrides || []).map(
+  (o) => `${o.flag} ${o.baseline_value == null ? '(unset)' : o.baseline_value} -> ` +
+    `${o.recalled_value == null ? '(set)' : o.recalled_value}`).join('; ');
+
+// ===========================================================================
 // PHASE: Setup + Baseline profile + Strategize  (gated; else load carried state)
 // ===========================================================================
 // Module A's outputs. They are folded into the ORDINARY state variables at those variables' real
@@ -2019,21 +2140,29 @@ if (want('setup')) {
             outcome: 'skipped', why: 'the record carries no config to apply' });
           continue;
         }
-        const sweep = await safeAgent(
-          roleAgent('config_tuner', 'sweep',
-            'Validate ONE historical configuration recovered from the knowledge base. Treat it exactly ' +
-            'as you would a fresh direction: same isolated-server measurement, same parity check, same ' +
-            'swap-took-effect verification. TWO deviations from your role file, both deliberate:\n' +
-            '(1) Do NOT decompose this direction into one-axis-at-a-time trials. A stored config is an ' +
-            'ALREADY-COMPOUNDED whole that was accepted together on another box; benching its knobs ' +
-            'separately measures a configuration nobody has ever run, and the parts can each be ' +
-            'neutral while the whole is a win (or the reverse). Apply all of it, once, as a single ' +
-            'trial.\n' +
-            '(2) Verify the swap TOOK EFFECT before you believe a null result. This config came from a ' +
-            'different framework_version: a flag that was renamed or removed upstream is accepted ' +
-            'silently on the command line and then ignored, which is indistinguishable from "the ' +
-            'config made no difference". Grep the server log for each flag/env actually being ' +
-            'honoured, and if one is not, say so in the trial notes rather than reporting a clean no-op.',
+        // Key-by-key, not string-concatenated — see mergeConfig. The recorded value wins every
+        // collision; `overrides` is the list of knobs where this box and the record disagreed.
+        const mf = mergeFlags(curFlags, storedFlags);
+        const me = mergeEnv(curEnv, storedEnv);
+        const overrides = mf.overrides.concat(me.overrides);
+        if (overrides.length) {
+          log(`[kb] merge ${c.session_id || '?'}: the recorded config overrides ${overrides.length} ` +
+            `knob(s) this run's baseline already pins — ${describeOverrides(overrides)}. ` +
+            'The recorded value is the one under test, so it wins.');
+        }
+        // Nothing left to test. Not a verdict on the record and not worth a server launch: this
+        // run's baseline already IS the recorded configuration, so a bench would compare the
+        // baseline with itself and file the ~0% result as a loss. Left un-attested on purpose —
+        // `recalls` counts attempts on hardware, and this one never reached any.
+        if (mf.merged === renderFlagItems(parseFlagString(curFlags)) &&
+            me.merged === renderEnvItems(parseEnvString(curEnv))) {
+          verdicts.push({ ...c, measured_tok_s: null, delta_pct: null, parity: 'n/a',
+            outcome: 'skipped',
+            why: "this run's baseline already carries the whole recorded configuration" });
+          continue;
+        }
+        const runValidation = (brief, label) => safeAgent(
+          roleAgent('config_tuner', 'sweep', brief,
             {
               EVAL_DIR, MODEL_PATH, GPU_ID: GPU_LIST[0], WORKLOAD, BASELINE_THROUGHPUT: BASELINE_TPUT,
               NOISE_BAND_PCT: NOISE_BAND, E2E_REPEATS,
@@ -2041,18 +2170,100 @@ if (want('setup')) {
                 rank: 1,
                 direction: 'kb_warm_start:' + (c.direction || 'unlabeled'),
                 axis: 'compound (recovered configuration — do not split)',
-                flags: storedFlags, env: storedEnv,
+                // ALREADY MERGED with this run's baseline. Use verbatim; do not re-combine with
+                // CURRENT_FLAGS/CURRENT_ENV, or the collisions the merge just resolved come back.
+                flags: mf.merged, env: me.merged,
                 rationale: `Recorded under ${c.canonical_id || resolved.canonical_id} (session ` +
                   `${c.session_id || '?'}), where it measured ${c.throughput_tok_s != null ? c.throughput_tok_s : '?'}` +
                   ` tok/s (${c.speedup != null ? c.speedup + 'x' : 'speedup not recorded'}) against a ` +
                   `baseline of ${c.baseline_throughput_tok_s != null ? c.baseline_throughput_tok_s : '?'} tok/s. ` +
-                  'That number is a HYPOTHESIS about this box, not a measurement of it.',
+                  'That number is a HYPOTHESIS about this box, not a measurement of it.' +
+                  (overrides.length
+                    ? ` NOTE: ${overrides.length} knob(s) in it disagree with this run's baseline and ` +
+                      `the recorded value was taken — ${describeOverrides(overrides)}. If the result is ` +
+                      'neutral, check these first: they are where the recorded config and this box ' +
+                      'were asked to be two different things.'
+                    : ''),
               }],
+              MERGE_OVERRIDES: overrides, MERGE_ADDED: mf.added.concat(me.added),
               CURRENT_FLAGS: curFlags, CURRENT_ENV: curEnv, CURRENT_OVERLAY: curOverlay,
               MEASUREMENT_PURPOSE: 'search', REPLICAS: SEARCH_REPLICAS,
               SKILL_DIR: WORKFLOW_DIR,
             }),
-          { phase: 'WarmStart', label: `warm_start:validate:${c.session_id || 'cand'}`, schema: SWEEP_SCHEMA });
+          { phase: 'WarmStart', label, schema: SWEEP_SCHEMA });
+
+        let sweep = await runValidation(
+          'Validate ONE historical configuration recovered from the knowledge base. Treat it exactly ' +
+          'as you would a fresh direction: same isolated-server measurement, same parity check, same ' +
+          'swap-took-effect verification. THREE deviations from your role file, all deliberate:\n' +
+          '(1) Do NOT decompose this direction into one-axis-at-a-time trials. A stored config is an ' +
+          'ALREADY-COMPOUNDED whole that was accepted together on another box; benching its knobs ' +
+          'separately measures a configuration nobody has ever run, and the parts can each be ' +
+          'neutral while the whole is a win (or the reverse). Apply all of it, once, as a single ' +
+          'trial.\n' +
+          "(2) The direction's `flags`/`env` are ALREADY MERGED with this run's baseline, key by key. " +
+          'Pass them VERBATIM to bench_e2e.sh. Do NOT append CURRENT_FLAGS/CURRENT_ENV to them — those ' +
+          'are shown to you only so you can see what was overridden, and re-combining them puts the ' +
+          'duplicate keys back and hands the outcome to argparse last-wins.\n' +
+          '(3) Verify the swap TOOK EFFECT before you believe a null result. This config came from a ' +
+          'different framework_version: a flag that was renamed or removed upstream is accepted ' +
+          'silently on the command line and then ignored, which is indistinguishable from "the ' +
+          'config made no difference". Grep the server log for each flag/env actually being ' +
+          'honoured, and if one is not, say so in the trial notes rather than reporting a clean no-op. ' +
+          'MERGE_OVERRIDES lists the knobs where the record and this box disagreed — check those in ' +
+          'the log first.',
+          `warm_start:validate:${c.session_id || 'cand'}`);
+
+        // ONE repair attempt, and only when the server produced no number at all.
+        //
+        // A recovered config is replayed on a box whose baseline it has never met, and the first
+        // launch is where that shows up: a flag deleted upstream makes argparse exit before the
+        // model loads, and a knob this run's baseline pins for a reason it did not record can be
+        // incompatible with the recorded value. Both used to end the same way — measured 0, one
+        // shot spent, `not_reproduced` filed against the record. The first of those really is the
+        // record's fault. The second is not, and a record that keeps meeting incompatible
+        // baselines was being retired for it.
+        //
+        // So: hand the launch failure back, make the tuner say WHICH of the two it is, let it
+        // adapt the minimum needed, and bench once more. Exactly once — a repair loop against a
+        // config that cannot run here burns server launches to learn nothing new — and through the
+        // SAME accept gate, with no allowance made for having been repaired.
+        let repair = null;
+        if (!((sweep && sweep.best_throughput_tok_s) || 0)) {
+          const repaired = await runValidation(
+            'A recovered configuration was applied to this box and the server produced NO ' +
+            'measurement — it failed to launch, failed to become healthy, or died before the bench. ' +
+            'This is the ONE repair attempt; there is no second.\n\n' +
+            'Read your own launch log from the attempt you just made. Then, for each knob that came ' +
+            'from the record (MERGE_OVERRIDES and MERGE_ADDED name them), classify it:\n' +
+            '  - `upstream_gone`: this build does not have the flag/env at all — argparse rejected ' +
+            'it, or it is absent from `--help`. This is the RECORD being stale.\n' +
+            "  - `conflicts_with_baseline`: the build has it, but the value cannot hold together with " +
+            "something this run's baseline pins (a length above the served context, a memory " +
+            'fraction the rest of the config cannot fit under, a backend the baseline excludes). ' +
+            'This is the PAIRING failing, and says nothing about the record.\n' +
+            '  - `env_unsupported`: the build ignores or rejects the env var.\n' +
+            'Then drop or adapt the MINIMUM needed to get a running server — keep as much of the ' +
+            'recorded configuration as will run, and never drop a knob you did not have to — and ' +
+            'bench that once, exactly as before.\n\n' +
+            'Return the same JSON, plus a `repair` object: `{"attempted": true, "classification": ' +
+            '"upstream_gone|conflicts_with_baseline|env_unsupported|mixed|unknown", ' +
+            '"dropped_flags": ["--flag", ...], "reason_by_flag": {"--flag": "why"}, ' +
+            '"launch_error": "<the line that actually killed it>"}`. If the server still will not ' +
+            'come up, say so and return `best_throughput_tok_s: 0` — an honest "cannot run here" is ' +
+            'worth more than a number from a configuration that is no longer the record.',
+            `warm_start:repair:${c.session_id || 'cand'}`);
+          if (repaired) {
+            repair = (repaired.repair && typeof repaired.repair === 'object') ? repaired.repair : {};
+            sweep = repaired;
+          }
+          log(`[kb] repair ${c.session_id || '?'}: ` + (repair
+            ? `classified ${repair.classification || 'unknown'}` +
+              `${(repair.dropped_flags || []).length ? `, dropped ${(repair.dropped_flags || []).join(' ')}` : ''}` +
+              `${(sweep && sweep.best_throughput_tok_s) ? ', server came up' : ', still no measurement'}`
+            : 'the repair attempt itself produced nothing'));
+        }
+        const dropped = (repair && Array.isArray(repair.dropped_flags)) ? repair.dropped_flags : [];
         const trial = (sweep && (sweep.trials || [])[0]) || {};
         const measured = (sweep && sweep.best_throughput_tok_s) || 0;
         const parity = String(trial.parity || trial.output_parity || '');
@@ -2063,30 +2274,46 @@ if (want('setup')) {
         const accept = trial.kept === true && measured > BASELINE_TPUT &&
           deltaPct > NOISE_BAND && parity !== 'fail';
         if (accept) {
-          curFlags = sweep.accepted_flags || storedFlags || curFlags;
-          curEnv = sweep.accepted_env || storedEnv || curEnv;
+          curFlags = sweep.accepted_flags || mf.merged || curFlags;
+          curEnv = sweep.accepted_env || me.merged || curEnv;
           kbSeedTput = measured;
           log(`[kb] ADOPTED ${c.session_id || '?'} (${c.direction || 'unlabeled'}): ` +
-            `${measured} tok/s, +${deltaPct.toFixed(2)}% vs baseline ${BASELINE_TPUT} (noise band ${NOISE_BAND}%).`);
+            `${measured} tok/s, +${deltaPct.toFixed(2)}% vs baseline ${BASELINE_TPUT} (noise band ${NOISE_BAND}%)` +
+            `${dropped.length ? `, with ${dropped.join(' ')} dropped to make it run here` : ''}.`);
         }
-        // THREE outcomes, not two. "ran and lost" and "could not be made to run" were both spelled
-        // `rejected`, and they mean opposite things to the record: a loss is one box's verdict on a
-        // real configuration, while a config that never took effect says the record is missing
-        // something — a flag renamed upstream, an env the build does not honour. Only the second is
-        // evidence for retiring it, and the store now counts them separately (kb/attest.py).
-        const notes = String(trial.notes || (sweep && sweep.summary) || '');
+        // FOUR outcomes. "ran and lost", "could not be made to run" and "does not fit this box"
+        // mean three different things to the record: a loss is one box's verdict on a real
+        // configuration; a config that never took effect says the record is missing something — a
+        // flag renamed upstream, an env the build does not honour; a config that collides with a
+        // baseline this run did not choose says nothing about the record at all. Only the middle
+        // one is evidence for retiring it, and the store counts all three apart (kb/attest.py).
+        //
+        // `note` and `notes` are both read: the role file's return schema spells it `note`, and
+        // reading only `notes` meant the per-trial text never reached this regex at all.
+        const notes = String(trial.notes || trial.note || (sweep && sweep.summary) || '');
         const inert = /\b(?:not (?:honou?red|recognized|recognised|applied|supported)|unrecognized|unrecognised|ignored|no such option|unknown (?:option|argument|flag)|renamed|removed upstream|did not take effect)\b/i.test(notes);
-        const outcome = accept ? 'adopted' : (!measured || inert) ? 'not_reproduced' : 'rejected';
+        // The repair's structured verdict outranks the regex: it was reached by reading the launch
+        // error, while the regex is guessing at free text written for a human.
+        const conflicted = String((repair && repair.classification) || '') === 'conflicts_with_baseline';
+        const outcome = accept ? 'adopted'
+          : !measured ? (conflicted ? 'inapplicable' : 'not_reproduced')
+            : inert ? 'not_reproduced' : 'rejected';
         if (!accept) {
-          log(`[kb] ${outcome === 'not_reproduced' ? 'NOT REPRODUCED' : 'rejected'} ` +
+          log(`[kb] ${{ not_reproduced: 'NOT REPRODUCED', inapplicable: 'INAPPLICABLE HERE' }[outcome] || 'rejected'} ` +
             `${c.session_id || '?'} (${c.direction || 'unlabeled'}): ` +
             `measured ${measured || 'n/a'} tok/s vs baseline ${BASELINE_TPUT}` +
             `${measured ? ` (${deltaPct >= 0 ? '+' : ''}${deltaPct.toFixed(2)}%)` : ''}` +
             `${parity ? `, parity=${parity}` : ''}${inert ? ', the config never took effect' : ''}` +
+            `${outcome === 'inapplicable' ? ", it collides with this run's baseline and is no evidence against the record" : ''}` +
             ` — kept as a reference, not applied.`);
         }
         verdicts.push({ ...c, measured_tok_s: measured || null, delta_pct: measured ? deltaPct : null,
-          parity: parity || 'unknown', outcome, why: notes });
+          parity: parity || 'unknown', outcome, why: notes,
+          // What was actually put on the box, as opposed to what the record asked for. A reader
+          // comparing this run's number with the stored one needs both, and `applied_partial`
+          // is the difference between "the record lost" and "most of the record lost".
+          overrides, applied_partial: dropped.length > 0, dropped_flags: dropped,
+          repair_classification: String((repair && repair.classification) || '') });
         if (accept) break;   // adopt the first that passes; the rest stay references
       }
       // ---------------------------------------------------------------------
@@ -2229,7 +2456,7 @@ if (want('setup')) {
       // record, not against the e2e run that once used it, and the two have separate ledgers —
       // `experience_store.py attest` is where that verdict belongs.
       const attestable = verdicts.filter(v => v.session_id &&
-        ['adopted', 'rejected', 'not_reproduced'].includes(v.outcome));
+        ['adopted', 'rejected', 'not_reproduced', 'inapplicable'].includes(v.outcome));
       if (attestable.length) {
         const cmds = attestable.map(v =>
           `python3 ${shq(E2E_STORE_SCRIPT)} attest ${kbIdentityFlags()} ${kbPlaneFlags()} ` +
@@ -2237,7 +2464,16 @@ if (want('setup')) {
           `--outcome ${v.outcome === 'adopted' ? 'validated' : v.outcome} ` +
           (v.measured_tok_s ? `--measured-tok-s ${v.measured_tok_s} ` : '') +
           `--baseline-tok-s ${BASELINE_TPUT} --parity ${shq(v.parity || 'n/a')} ` +
-          `--note ${shq(String(v.why || '').slice(0, 200))} ` +
+          // The note carries what was actually run, not just why it ended: a bare "no win" against
+          // a partially-dropped config would read, three months later, as a verdict on the whole
+          // record. Overrides first — they are what a reader has to know to interpret the number.
+          `--note ${shq([
+            (v.overrides || []).length ? `overrode ${describeOverrides(v.overrides)}` : '',
+            (v.dropped_flags || []).length
+              ? `dropped ${(v.dropped_flags || []).join(' ')} to make it run here` +
+                `${v.repair_classification ? ` (${v.repair_classification})` : ''}` : '',
+            String(v.why || ''),
+          ].filter(Boolean).join('; ').slice(0, 400))} ` +
           `--measured-by ${shq('e2e_workflow:' + BACKEND)} --apply || true`);
         try {
           await safeAgent(
@@ -2290,7 +2526,8 @@ if (want('setup')) {
         // Split out of `rejected` for the reference section below, but deliberately still counted
         // inside it: for the roles that come next, "lost the A/B" and "never ran" are both "do not
         // re-propose this verbatim". The distinction matters to the STORE, not to the Architect.
-        const notReproduced = verdicts.filter(v => v.outcome === 'not_reproduced');
+        const notReproduced = verdicts.filter(
+          v => v.outcome === 'not_reproduced' || v.outcome === 'inapplicable');
         const md = [
           '# Warm start — MEASURED ON THIS BOX',
           '',
@@ -2332,9 +2569,12 @@ if (want('setup')) {
             '## REFERENCE ONLY — recalled but NOT reproduced here',
             '',
             'These were offered by the store and benched on this box, and either produced no number',
-            'at all or never took effect (a flag renamed upstream is accepted silently and then',
-            'ignored). They are NOT results. They are the closest thing this deployment has to a',
-            'record of what someone else got working, and their material is below so you can read',
+            'at all, never took effect (a flag renamed upstream is accepted silently and then',
+            "ignored), or collided with a knob this run's baseline already pins and could not be",
+            'applied here at all. They are NOT results — and the last of those is not evidence',
+            'against the record either, only against the pairing. They are the closest thing this',
+            'deployment has to a record of what someone else got working, and their material is',
+            'below so you can read',
             'what they actually did rather than guess from a direction label.',
             '',
             ...notReproduced.flatMap(v => {
@@ -2344,7 +2584,16 @@ if (want('setup')) {
                 .filter(k => k && k.patch).map(k => root ? `${root}/${k.patch}` : k.patch);
               return [
                 `### ${v.direction || 'unlabeled'} (session \`${v.session_id || '?'}\`)`,
-                `- why it did not reproduce: ${String(v.why || 'no measurement came back').slice(0, 300)}`,
+                `- why it did not reproduce: ${v.outcome === 'inapplicable'
+                  ? "it could not be applied to this run's baseline at all — " : ''}` +
+                  `${String(v.why || 'no measurement came back').slice(0, 300)}`,
+                ...((v.overrides || []).length
+                  ? [`- knobs where it disagreed with this run's baseline (recorded value was ` +
+                     `taken): ${describeOverrides(v.overrides)}`] : []),
+                ...((v.dropped_flags || []).length
+                  ? [`- dropped to get it running here: ${v.dropped_flags.join(' ')}` +
+                     `${v.repair_classification ? ` (${v.repair_classification})` : ''} — so the ` +
+                     'number above, if any, is for LESS than the record asked for'] : []),
                 `- stored claim: ${v.throughput_tok_s != null ? v.throughput_tok_s + ' tok/s' : '?'}` +
                   `${v.speedup != null ? ` (${v.speedup}x)` : ''}, recorded elsewhere`,
                 `- launch script: ${repro.launch

--- a/e2e_workflow/roles/config_tuner.md
+++ b/e2e_workflow/roles/config_tuner.md
@@ -38,7 +38,8 @@ Inputs: `EVAL_DIR`, `MODEL_PATH`, `BACKEND` (sglang|vllm), `GPU_ID`, `WORKLOAD`,
 each with target kernels + rationale), `CURRENT_FLAGS`/`CURRENT_ENV`/`CURRENT_OVERLAY`
 (the accepted stack so far),
 `MEASUREMENT_MODE`, `MEASUREMENT_PURPOSE`, `REPLICAS`, `EFFECTIVE_CONFIG_DIGEST`,
-`ENABLE_FP8` (bool; gates the FP8 axis), `SKILL_DIR`.
+`ENABLE_FP8` (bool; gates the FP8 axis), `SKILL_DIR`. On a warm-start replay you additionally get
+`MERGE_OVERRIDES` / `MERGE_ADDED` — see "A direction that arrives pre-merged" below.
 
 > The exact flags/env are **backend-specific** (e.g. sglang `--attention-backend` + `SGLANG_USE_AITER`
 > vs vllm `--attention-backend` enum + `VLLM_ROCM_USE_AITER`). The Architect's `CONFIG_DIRECTIONS`
@@ -48,14 +49,19 @@ each with target kernels + rationale), `CURRENT_FLAGS`/`CURRENT_ENV`/`CURRENT_OV
 > `BACKEND=<backend>` to bench_e2e.sh.
 
 For EACH direction, in the Architect's order:
-1. Build the candidate config = current accepted config + this ONE change.
+1. Build the candidate config = current accepted config + this ONE change. **Merge it key by key,
+   never by concatenation.** If the flag or env var is already in the current config, REPLACE its
+   value in place; do not let the same key appear twice. Two occurrences are resolved by argparse
+   (and by `env`) as last-wins, so a duplicated key hands the outcome to the order you happened to
+   write the string in, and the losing value vanishes with nothing in any log to say it did.
+   The only exception is a genuinely repeatable flag such as `--lora-path`.
 2. Launch + bench via the shared script:
    ```bash
    # SERVING config MUST match the run-wide invariant: TP=SERVING_TP GPU=SERVING_GPU (from your inputs).
    BACKEND="<backend>" OUT_DIR="$EVAL_DIR/config/<dir_id>" GPU="<SERVING_GPU>" TP="<SERVING_TP>" MODEL="$MODEL_PATH" \
    ISL=<isl> OSL=<osl> CONC=<conc> PROFILE=0 \
    GEAK_REPEAT_MODE="$MEASUREMENT_MODE" MEASUREMENT_PURPOSE=search REPLICAS="${REPLICAS:-1}" \
-   OVERLAY_PYTHONPATH="$CURRENT_OVERLAY" EXTRA_SERVER_ARGS="<current flags + this flag>" EXTRA_ENV="<current env + this env>" \
+   OVERLAY_PYTHONPATH="$CURRENT_OVERLAY" EXTRA_SERVER_ARGS="<current flags, merged with this flag>" EXTRA_ENV="<current env, merged with this env>" \
      bash "$EVAL_DIR/bench_e2e.sh" 2>&1 | tee "$EVAL_DIR/logs/cfg_<dir_id>.log"
    ```
 3. Read `bench_summary.json`. delta% = `(cand_median - current_median)/current_median*100`.
@@ -65,6 +71,32 @@ For EACH direction, in the Architect's order:
 6. (GEMM tuning is NOT a config axis — it lives in the head-kernel track now.)
 
 Record every trial (kept + rejected) in `EVAL_DIR/config/sweep_results.json`.
+
+### A direction that arrives pre-merged (warm-start replay)
+
+A direction whose `axis` says *compound (recovered configuration — do not split)* comes from the
+knowledge base, and the orchestrator has **already merged it with `CURRENT_FLAGS`/`CURRENT_ENV`, key
+by key**. Its `flags`/`env` are the complete strings to run.
+
+- **Pass them VERBATIM.** Do not append `CURRENT_FLAGS`/`CURRENT_ENV` — those are given to you only
+  so you can see what the merge changed. Re-combining puts the duplicate keys straight back.
+- `MERGE_OVERRIDES` is `[{flag, baseline_value, recalled_value}]`: the knobs where the record and
+  this run's baseline asked for different things, and where the **recorded** value was taken because
+  it is the thing under test. **This is the first place to look when the replay comes back neutral**
+  — a stored config that shows no delta on a box whose baseline already differs from it in four
+  knobs is usually telling you about the four knobs, not about the record.
+- `MERGE_ADDED` is what the record contributed that the baseline did not have at all.
+- Verify in the server log that the OVERRIDDEN knobs took the recorded value, not the baseline's.
+  "The flag was honoured" is not enough; a duplicate key is honoured too, just with the wrong value.
+
+If you are asked for a **repair** pass, the merged config produced no measurement at all. Read your
+own launch log, classify each recorded knob as `upstream_gone` (this build does not have it),
+`conflicts_with_baseline` (it has it, but the value cannot hold together with something the baseline
+pins) or `env_unsupported`, drop or adapt the **minimum** needed to get a running server, bench once,
+and return the `repair` object described below. Never drop a knob you did not have to: every one you
+drop makes the number you report about less of the record. If it still will not come up, say so and
+return `best_throughput_tok_s: 0` — an honest "cannot run here" beats a number from a configuration
+that is no longer the record.
 
 ### Scope: service-level switches ONLY (GEMM tuning is NOT done here)
 You handle pure server-level env/flags that need NO op isolation. **GEMM tuning (aiter per-shape DB,
@@ -96,6 +128,18 @@ Return JSON:
   "accepted_env": "<final kept extra env KEY=VAL ...>",
   "best_throughput_tok_s": 0.0,
   "throughput_speedup_vs_baseline": 1.0,
-  "summary": "what worked, what didn't, what to re-profile against"
+  "summary": "what worked, what didn't, what to re-profile against",
+  "repair": {
+    "attempted": true,
+    "classification": "upstream_gone|conflicts_with_baseline|env_unsupported|mixed|unknown",
+    "dropped_flags": ["--flag"],
+    "reason_by_flag": {"--flag": "why it had to go"},
+    "launch_error": "the line that actually killed the server"
+  }
 }
 ```
+
+`repair` belongs ONLY to a warm-start repair pass — omit the key entirely on every other sweep. It
+is read in place of guessing at your prose: `conflicts_with_baseline` is what tells the store that
+the record failed to fit THIS box rather than that the record is wrong, which is the difference
+between a note in its ledger and a step toward retiring it.

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -599,10 +599,14 @@ attempt, win or not. REQUIRED sections, in order:
    - **Configurations recalled** — table
      `stored direction | session | stored claim | re-measured here | Δ vs baseline | parity | outcome`,
      one row per `KB_RECALL.e2e.configs[]`. Outcomes are `adopted` / `rejected` / `not_reproduced` /
-     `skipped`, and you must NOT collapse them: `rejected` means it ran here and lost, while
+     `inapplicable` / `skipped`, and you must NOT collapse them: `rejected` means it ran here and lost;
      `not_reproduced` means it never took effect at all (a flag renamed upstream is accepted silently
-     and then ignored). Those mean opposite things about the record and only the second is evidence the
-     record is stale. Quote the `why` for anything that was not adopted.
+     and then ignored); `inapplicable` means it could not be put on this box's baseline in the first
+     place, which is a verdict on the pairing and not on the record. Those mean different things and
+     only `not_reproduced` is evidence the record is stale. Quote the `why` for anything that was not
+     adopted, and when a row carries `overrides` or `applied_partial`, say which knobs the recalled
+     configuration took over from this run's baseline and which ones had to be dropped to get a server
+     up — a Δ measured from a partly-applied configuration is not a measurement of the record.
    - **Kernels recalled** — table `kernel | kind | stored isolated× | re-measured e2e Δ% | outcome | why`
      from `KB_RECALL.e2e.kernels[]`, plus the kernel-lane rows from `KB_RECALL.kernel[]` showing
      `adopted`, `adopted_speedup`, `rounds_committed` and `incremental_speedup`. A lane that adopted a

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -440,7 +440,8 @@ Return JSON:
 
 Inputs: `EVAL_DIR`, full `HISTORY`, `BASELINE_THROUGHPUT`, `FINAL_THROUGHPUT`, accepted config +
 kernel changes, `MILESTONES`, `BUDGET_USED`, `BUDGET`, `MIN_KERNEL_TASKS`, `PROFILE_TOPN`, `WORKLOAD`,
-`MODEL_NAME`, `SKILL_DIR`, and — when the standalone tuning phase ran — `TUNING_RESULT` (see §2b).
+`MODEL_NAME`, `KB_RECALL` (see §2c), `SKILL_DIR`, and — when the standalone tuning phase ran —
+`TUNING_RESULT` (see §2b).
 
 Write TWO files:
 
@@ -579,6 +580,41 @@ attempt, win or not. REQUIRED sections, in order:
    Source: `EVAL_DIR/tuning/tuning_report.md` (+ `tuning/bench_pre`, `tuning/bench_post`,
    `tuning/env_audit.txt`, `tuning/claims_report.json`). Read the real files; never invent.
 
+2c. **🧠 Knowledge-base recall** — MANDATORY, ALWAYS present, even on a run that recalled nothing.
+   Built from the `KB_RECALL` input, which the orchestrator fills as the warm start runs; cross-check it
+   against `EVAL_DIR/kb_references/measured_on_this_box.md` and `EVAL_DIR/kb_identity.json` when they
+   exist, and say so if the two disagree rather than picking one silently.
+
+   Why it is mandatory even when empty: the e2e store is an EXACT-lookup scheme with no search. "This
+   deployment has no prior art" and "the prior art is filed one segment away under a slightly different
+   framework_version" produce the identical 404, and the ONLY artifact that tells them apart is the list
+   of canonical ids that were actually asked. A report that omits recall lets a silent identity drift
+   look like a cold start forever.
+
+   - **What was asked** — one line per plane. For the e2e plane: `KB_RECALL.e2e.tried` verbatim as a
+     bulleted list of canonical ids (all three rungs, most specific first), plus `read_reason`,
+     `match_tier`, which plane answered (`read_plane`), and the candidate count. For the kernel plane:
+     one row per lane from `KB_RECALL.kernel` with its `slug`, `read_reason`, `match_tier` and count.
+     If `read_reason` is `missing_arch`, say plainly that no lookup was performed and why.
+   - **Configurations recalled** — table
+     `stored direction | session | stored claim | re-measured here | Δ vs baseline | parity | outcome`,
+     one row per `KB_RECALL.e2e.configs[]`. Outcomes are `adopted` / `rejected` / `not_reproduced` /
+     `skipped`, and you must NOT collapse them: `rejected` means it ran here and lost, while
+     `not_reproduced` means it never took effect at all (a flag renamed upstream is accepted silently
+     and then ignored). Those mean opposite things about the record and only the second is evidence the
+     record is stale. Quote the `why` for anything that was not adopted.
+   - **Kernels recalled** — table `kernel | kind | stored isolated× | re-measured e2e Δ% | outcome | why`
+     from `KB_RECALL.e2e.kernels[]`, plus the kernel-lane rows from `KB_RECALL.kernel[]` showing
+     `adopted`, `adopted_speedup`, `rounds_committed` and `incremental_speedup`. A lane that adopted a
+     stored patch and then committed **0** rounds (`no_rounds_after_adopt`) MUST be labelled as inherited,
+     not as this run's work — its incremental is 1.0 by definition, not by measurement.
+   - **Was it accepted?** — one explicit sentence per recalled item, naming whether it reached the final
+     stack. If a recalled item WAS accepted, the headline speedup is partly INHERITED: state the split
+     (`kb_warm_start.adopted_throughput_tok_s` and `incremental_speedup`) in this section and again in
+     section 7, and never present an inherited gain as this run's optimization.
+   - A recalled record that lost here is a **lead, not a dead end** — say so, and give the reader the path
+     to its bundle so they can read what it actually did.
+
 3. **Head-kernel deep-dive** (the centerpiece) — for EACH head op a `####` sub-section titled
    `<id> — <op> (<pct>% GPU) — RESULT: <ACCEPTED +X% | no win | flagged>`, containing:
    - **GPU-time-share table**: rows `stock baseline` vs `accepted config`; columns `live kernel | backend |
@@ -645,6 +681,7 @@ Data sources (read the ACTUAL files, never invent): `director_e2e_validation.jso
 `overlay/cand_*/integrate_result.json`,
 `kernels/_exp/*/*/director_validation.json`, `kernels/*/opbench_result.json` (incl. its `backend_absent[]`),
 `env_report.json` (`absent_backends` → the BACKEND ABSENT section),
+`kb_identity.json` + `kb_references/measured_on_this_box.md` (→ the KNOWLEDGE-BASE RECALL section),
 `profile/round_*/profile_topN.{md,json}`, and artifact mtimes for the timeline.
 Read the actual files under `EVAL_DIR` for real numbers; do not invent. Return JSON (report_path points
 to architect_report.md; also mention `final_report.md` in `note` if the schema lacks a field):

--- a/e2e_workflow/scripts/e2e_store.py
+++ b/e2e_workflow/scripts/e2e_store.py
@@ -165,6 +165,10 @@ def _view(candidate, cid: str, tier: str, metric: str, champion_metric: str = ""
         "validations": ledger["validations"],
         "recalls": ledger["recalls"],
         "not_reproduced": ledger["not_reproduced"],
+        # Kept apart from `not_reproduced` all the way out to the reader. "the flag is gone
+        # upstream" and "this box's baseline already pins that knob" look identical in a single
+        # count and mean opposite things about whether the record is worth benching here.
+        "inapplicable": ledger["inapplicable"],
         "last_outcome": ledger["last_outcome"],
         "retire_hint": retire_hint(value),
         # How to actually run this again. Empty for records written before the field existed —
@@ -352,7 +356,9 @@ def _track_record_line(view: dict) -> str:
         return "never benched by anyone since it was recorded"
     parts = ["%d reproduced a win" % view["validations"] if view["validations"] else "",
              "%d could not be run at all" % view["not_reproduced"]
-             if view.get("not_reproduced") else ""]
+             if view.get("not_reproduced") else "",
+             "%d did not fit that box's baseline (no verdict on the record)" % view["inapplicable"]
+             if view.get("inapplicable") else ""]
     detail = ", ".join(p for p in parts if p) or "none reproduced a win"
     hint = view.get("retire_hint") or ""
     return "benched %dx since it was recorded — %s%s" % (
@@ -1506,13 +1512,18 @@ def main(argv=None) -> int:
     q.add_argument("--apply", action="store_true", help="actually write; default is a dry run")
 
     q = sub.add_parser("attest", help="count one attempt to RUN a stored record: validated | "
-                                      "failed | not_reproduced. Moves no score, no champion.")
+                                      "failed | not_reproduced | inapplicable. Moves no score, "
+                                      "no champion.")
     _identity_args(q)
     _plane_args(q)
     q.add_argument("--session-id", required=True, help="the session that was tried")
     q.add_argument("--outcome", required=True, choices=OUTCOMES,
                    help="validated = reproduced a win; failed = ran but did not win; "
-                        "not_reproduced = could not be made to run at all")
+                        "not_reproduced = could not be made to run at all; "
+                        "inapplicable = could not be applied to THIS box's baseline (a knob the "
+                        "record pins is already pinned to something else here) — counted, but "
+                        "kept out of the retire arithmetic, because it judges the pairing and "
+                        "not the record")
     q.add_argument("--measured-tok-s", default=None, help="what it did here, for the history entry")
     q.add_argument("--baseline-tok-s", default=None, help="what this box does without it")
     q.add_argument("--parity", default="", help="pass | fail | n/a on this box")

--- a/e2e_workflow/scripts/test_warm_start_merge.js
+++ b/e2e_workflow/scripts/test_warm_start_merge.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Regression guard for how a RECOVERED configuration is combined with the one this run was handed
+// (no GPU, no model, no KB needed).
+//
+// A stored e2e record is a whole launch configuration, and warm start replays it on top of whatever
+// baseline the run was given — under Hyperloom, a full flag string the run does not own. That
+// combination used to be a string concatenation written by an agent, and a duplicated key is
+// resolved by argparse (and by `env`) as last-wins. So which value applied depended on the order the
+// agent happened to write, and when the baseline won, the server ran the baseline configuration
+// twice: ~0% delta, nothing wrong in any log, and the record filed as `rejected`. A record that wins
+// recorded as a loss is the one outcome the warm start exists to prevent.
+//
+// The merge functions are EXTRACTED from the shipped source rather than reimplemented here, so this
+// cannot pass while e2e_workflow.js drifts.
+//
+// Run:  node e2e_workflow/scripts/test_warm_start_merge.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..'); // .../GEAK
+const src = fs.readFileSync(path.join(ROOT, 'e2e_workflow', 'e2e_workflow.js'), 'utf8');
+
+let failures = 0;
+const eq = (got, want, msg) => {
+  const a = JSON.stringify(got), b = JSON.stringify(want);
+  if (a !== b) { console.error('  FAIL:', msg, '\n    got: ', a, '\n    want:', b); failures++; }
+  else console.log('  ok:', msg);
+};
+
+const mStart = src.indexOf('const REPEATABLE_FLAGS');
+const mEnd = src.indexOf('// PHASE: Setup + Baseline profile', mStart);
+if (mStart < 0 || mEnd < 0) { console.error('FAIL: merge block not found in e2e_workflow.js'); process.exit(1); }
+const { mergeFlags, mergeEnv, describeOverrides } = new Function(
+  `${src.slice(mStart, mEnd)}\nreturn { mergeFlags, mergeEnv, describeOverrides };`)();
+
+// ------------------------------------------------------------------ the collision this exists for
+console.log('collisions');
+{
+  // The real pair: the Kimi-K3 record pins --context-length 13312, the run's baseline pins 11264.
+  const r = mergeFlags('--context-length 11264 --mem-fraction-static 0.96',
+    '--context-length 13312 --cuda-graph-max-bs 256');
+  eq(r.merged, '--context-length 13312 --mem-fraction-static 0.96 --cuda-graph-max-bs 256',
+    'the recorded value replaces the baseline IN PLACE, and what is new is appended');
+  eq((r.merged.match(/--context-length/g) || []).length, 1,
+    'the key appears exactly once, so last-wins never gets a vote');
+  eq(r.overrides, [{ flag: '--context-length', baseline_value: '11264', recalled_value: '13312' }],
+    'the disagreement is reported, not just resolved');
+  eq(r.added, ['--cuda-graph-max-bs'], 'what the record contributed outright is reported too');
+}
+{
+  const r = mergeEnv('TP=8 MAX_MODEL_LEN=13312', 'MAX_MODEL_LEN=16384 SGLANG_USE_AITER=1');
+  eq(r.merged, 'TP=8 MAX_MODEL_LEN=16384 SGLANG_USE_AITER=1', 'env merges by key, same rule');
+  eq(r.overrides, [{ flag: 'MAX_MODEL_LEN', baseline_value: '13312', recalled_value: '16384' }],
+    'env override reported');
+}
+
+// ------------------------------------------------------------------ the spellings that show up
+console.log('spellings');
+eq(mergeFlags('--foo=1 --bar 2', '--foo=3').merged, '--foo=3 --bar 2',
+  '`--flag=value` is the same key as `--flag value`');
+eq(mergeFlags('--tp 8', '--enable-torch-compile').merged, '--tp 8 --enable-torch-compile',
+  'a bare boolean flag is appended');
+eq(mergeFlags('--attention-backend triton', '--extra a b --tp 8').merged,
+  '--attention-backend triton --extra a b --tp 8',
+  'a multi-valued flag stays one item, so it is overridden whole or not at all');
+eq(mergeFlags('', '--tp 8').merged, '--tp 8', 'empty baseline');
+eq(mergeFlags('--tp 8', '').merged, '--tp 8', 'empty recovered config changes nothing');
+eq(mergeFlags('  --tp   8  ', '').merged, '--tp 8', 'whitespace is normalized');
+
+// ------------------------------------------------------------------ what must NOT be an override
+console.log('agreement is not an override');
+{
+  const r = mergeFlags('--disable-radix-cache --tp 8', '--disable-radix-cache');
+  eq(r.overrides, [], 'the two agreeing on a bare flag is not a disagreement');
+  eq(r.unchanged, ['--disable-radix-cache'], 'and it is reported as agreement');
+  eq(r.merged, '--disable-radix-cache --tp 8', 'nor is it duplicated');
+}
+eq(mergeEnv('A=1', 'A=1').overrides, [], 'the two agreeing on an env value is not a disagreement');
+eq(mergeFlags('--tp 8', '--tp 8').overrides, [], 'identical valued flag is not a disagreement');
+
+console.log('repeatable flags');
+{
+  const r = mergeFlags('--lora-path a=/a', '--lora-path b=/b');
+  eq(r.merged, '--lora-path a=/a --lora-path b=/b',
+    '--lora-path is a list; deduping it would silently drop an adapter');
+  eq(r.overrides, [], 'a repeatable flag is never an override');
+}
+
+console.log('prose');
+eq(describeOverrides([{ flag: '--x', baseline_value: '1', recalled_value: '2' }]), '--x 1 -> 2',
+  'overrides render for a human');
+eq(describeOverrides([{ flag: '--x', baseline_value: null, recalled_value: '2' }]), '--x (unset) -> 2',
+  'an absent baseline value says so rather than rendering empty');
+eq(describeOverrides([]), '', 'no overrides renders as nothing at all');
+
+// ------------------------------------------------- the orchestrator must USE what it merged
+console.log('wiring');
+{
+  const wStart = src.indexOf('const mf = mergeFlags(curFlags, storedFlags);');
+  const wEnd = src.indexOf('if (accept) break;', wStart);
+  const block = wStart < 0 ? '' : src.slice(wStart, wEnd);
+  eq(block.includes('flags: mf.merged, env: me.merged'), true,
+    'the direction handed to config_tuner carries the MERGED strings, not the raw stored ones');
+  eq(/storedFlags\s*\|\|\s*curFlags/.test(block), false,
+    'adoption falls back to the merged config, never to the unmerged stored one');
+  eq(block.includes("'inapplicable'"), true,
+    'a launch failure the repair blamed on the baseline is not counted against the record');
+}
+
+console.log(failures ? `\n${failures} FAILED` : '\nall passed');
+process.exit(failures ? 1 : 0);

--- a/kb/attest.py
+++ b/kb/attest.py
@@ -14,6 +14,9 @@ This module adds that ledger, under `value.attestations`, in one vocabulary both
     validations      of those, how many reproduced a win   <- the retire signal
     failures         of those, how many ran but did not win
     not_reproduced   of those, how many could not be made to run at all
+    inapplicable     of those, how many could not be applied to THIS box's baseline at all — a
+                     verdict on the pairing, not on the record, and so excluded from the retire
+                     arithmetic below
     last_outcome / last_at / last_by     the most recent attempt, for a reader in a hurry
     history          the last HISTORY_LIMIT attempts with their evidence
 
@@ -44,14 +47,24 @@ import time
 from kb.retract import existing_files
 from kb.store_local import KBStoreError
 
-# The three things that can happen when a record is taken off the shelf and run. They are counted
+# The four things that can happen when a record is taken off the shelf and run. They are counted
 # separately because they mean opposite things to a retire pass: `failed` says the claim did not
 # hold HERE (the record may still be right elsewhere), while `not_reproduced` says the record could
 # not even be applied — a much stronger signal that it is missing something it promised.
+#
+# `inapplicable` splits a case that used to be spelled `not_reproduced` and does not belong there.
+# A stored e2e config is a WHOLE launch configuration, and it is replayed on top of whatever
+# baseline configuration the reading run was handed — under Hyperloom, a full flag string this run
+# does not own. When the two pin the same knob to different values, the record could not be applied
+# HERE for a reason that says nothing at all about the record: it may be perfectly right on the box
+# it was written for and on the next box that reads it. Counting that as `not_reproduced` made the
+# environment, not the record, the thing being judged — and two such reads were enough to put a
+# retire hint on a record nobody had ever found anything wrong with.
 VALIDATED = "validated"
 FAILED = "failed"
 NOT_REPRODUCED = "not_reproduced"
-OUTCOMES = (VALIDATED, FAILED, NOT_REPRODUCED)
+INAPPLICABLE = "inapplicable"
+OUTCOMES = (VALIDATED, FAILED, NOT_REPRODUCED, INAPPLICABLE)
 
 # `history` is bounded because it rides inside every knowledge document, and the documents are
 # fetched one-per-candidate to rank a page. An unbounded audit log would make every read of a
@@ -66,8 +79,15 @@ _EVIDENCE_KEYS = ("measured_tok_s", "baseline_tok_s", "delta_pct", "measured_spe
                   "note", "canonical_id", "workload")
 
 
+# Every counter that is a BUCKET of `recalls`, in one place, because four call sites have to agree
+# on the list and three of them fail silently when they disagree: a key missing from
+# `attestations_of` reads as 0 forever, and one missing from `carry_attestations`'s emptiness test
+# drops a whole ledger on the next rewrite.
+BUCKETS = ("validations", "failures", "not_reproduced", "inapplicable")
+
+
 def empty_attestations() -> dict:
-    return {"recalls": 0, "validations": 0, "failures": 0, "not_reproduced": 0,
+    return {"recalls": 0, "validations": 0, "failures": 0, "not_reproduced": 0, "inapplicable": 0,
             "last_outcome": "", "last_at": "", "last_by": "", "history": []}
 
 
@@ -87,7 +107,7 @@ def attestations_of(value) -> dict:
     if not isinstance(raw, dict):
         return empty_attestations()
     ledger = empty_attestations()
-    for key in ("recalls", "validations", "failures", "not_reproduced"):
+    for key in ("recalls",) + BUCKETS:
         ledger[key] = _counter(raw.get(key))
     for key in ("last_outcome", "last_at", "last_by"):
         ledger[key] = str(raw.get(key) or "")
@@ -109,7 +129,7 @@ def carry_attestations(previous_value, fresh_value: dict) -> dict:
     if not isinstance(previous_value, dict) or "attestations" not in previous_value:
         return fresh_value
     ledger = attestations_of(previous_value)
-    if not any(ledger[k] for k in ("recalls", "validations", "failures", "not_reproduced")):
+    if not any(ledger[k] for k in ("recalls",) + BUCKETS):
         return fresh_value
     fresh_value["attestations"] = ledger
     return fresh_value
@@ -129,9 +149,13 @@ def record_attestation(value: dict, outcome: str, *, actor: str = "", evidence=N
                            % (outcome, ", ".join(OUTCOMES)))
     ledger = attestations_of(value)
     stamp = when or time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    # `inapplicable` increments `recalls` like the rest: the invariant that `recalls` is the sum of
+    # its buckets is what lets a reader check a ledger for consistency, and hiding an attempt would
+    # make a record that keeps failing to fit anywhere look untouched. It is subtracted where it
+    # actually matters instead — see `retire_hint`.
     ledger["recalls"] += 1
     ledger[{VALIDATED: "validations", FAILED: "failures",
-            NOT_REPRODUCED: "not_reproduced"}[outcome]] += 1
+            NOT_REPRODUCED: "not_reproduced", INAPPLICABLE: "inapplicable"}[outcome]] += 1
     ledger.update({"last_outcome": outcome, "last_at": stamp, "last_by": str(actor or "")})
     entry = {"at": stamp, "outcome": outcome}
     if actor:
@@ -154,8 +178,12 @@ def retire_hint(value) -> str:
     read path filters on it — a record with a hint is still offered, still ranked, still adoptable.
     """
     ledger = attestations_of(value)
-    tried = ledger["recalls"]
-    if not tried:
+    # Attempts that TESTED THE RECORD. An `inapplicable` read never got as far as putting the
+    # stored configuration on the box — the box's own baseline pinned a knob the record also pins,
+    # and the pair is what failed. Leaving those in the denominator meant a record could be retired
+    # for being read on the wrong machines, which is the opposite of what the counter is for.
+    tried = ledger["recalls"] - ledger["inapplicable"]
+    if tried <= 0:
         return ""
     if ledger["not_reproduced"] >= 2 and not ledger["validations"]:
         return ("%d attempts could not reproduce it at all and none ever succeeded — the record is "

--- a/kb/identity.py
+++ b/kb/identity.py
@@ -154,6 +154,31 @@ def _short_version(raw: str) -> str:
     return segment(m.group(1) if m else text, UNKNOWN_VERSION)
 
 
+# `0.5.15.post1.dev20260723+g6c9fd0adc5` -> `0.5.15`. Serving stacks are installed from git in these
+# images, so `sglang.__version__` carries a PEP 440 dev/local suffix that changes on every rebuild of
+# the SAME release. Keyed verbatim, a rebuilt wheel opens a fresh set of pages and the previous run's
+# result becomes unreachable — not degraded, invisible, because the lookup is exact and a miss is a
+# plain 404. A long opaque string is also one nobody transcribes correctly: a hand-filed record that
+# dropped the trailing `+g<hash>` was already enough to hide a real result from the next run on the
+# very SAME build. All three rungs missed at once, because framework_version sits in `base` and no
+# rung drops it. Rebuild drift and transcription drift are the same failure; both disappear once the
+# address is the release.
+#
+# Three components, not two: `0.5.15` and `0.5.17` are different SGLang releases with different
+# kernels, so cutting to `0.5` would merge results that genuinely do not transfer. The exact build
+# string still travels in the record's value, so only the address is coarse — same bargain as
+# kernel_identity's ROCm cut, one component wider.
+_RELEASE_VERSION = re.compile(r"\s*v?(\d+(?:\.\d+){0,2})")
+
+
+def _release_version(raw: str) -> str:
+    text = str(raw or "").strip()
+    if not text:
+        return UNKNOWN_VERSION
+    m = _RELEASE_VERSION.match(text)
+    return segment(m.group(1) if m else text, UNKNOWN_VERSION)
+
+
 def kernel_canonical_ids(identity: dict):
     """Both rungs, most specific first.
 
@@ -188,12 +213,16 @@ def e2e_identity(model: str, gfx: str, framework: str, framework_version: str, p
     `tp` sits AFTER precision and before the workload shape so the ladder can drop the measured
     point while keeping the deployment config. Anything unparseable folds to "" and simply removes
     the rung that would have carried it.
+
+    `framework_version` is cut to `<major>.<minor>.<patch>` — see _release_version. It is the one
+    dimension here that a rebuild can change without anything about the deployment changing, and
+    unlike the workload dims it cannot be dropped by a coarser rung.
     """
     return {
         "model": segment(model, UNKNOWN),
         "gpu": segment(gfx, UNKNOWN),
         "framework": segment(framework, UNKNOWN),
-        "framework_version": segment(framework_version, UNKNOWN_VERSION),
+        "framework_version": _release_version(framework_version),
         "precision": segment(precision, UNKNOWN),
         "tp": counted("tp", tp),
         "isl": counted("isl", isl),

--- a/kb/tests/test_attest.py
+++ b/kb/tests/test_attest.py
@@ -57,7 +57,8 @@ def test_a_counter_that_is_not_a_number_reads_as_zero():
 
 
 @pytest.mark.parametrize("outcome,field", [("validated", "validations"), ("failed", "failures"),
-                                           ("not_reproduced", "not_reproduced")])
+                                           ("not_reproduced", "not_reproduced"),
+                                           ("inapplicable", "inapplicable")])
 def test_each_outcome_increments_recalls_and_its_own_counter(outcome, field):
     value = record_attestation({}, outcome, actor="boxA")
     ledger = value["attestations"]
@@ -109,6 +110,45 @@ def test_retire_hint_stays_silent_until_there_is_a_pattern():
 def test_two_non_reproductions_with_no_win_is_a_hint():
     value = record_attestation(record_attestation({}, "not_reproduced"), "not_reproduced")
     assert "could not reproduce" in retire_hint(value)
+
+
+def test_a_config_that_never_fit_this_box_is_no_evidence_against_the_record():
+    """The reason `inapplicable` exists at all.
+
+    A stored e2e config is a whole launch configuration, replayed on top of a baseline the reading
+    run did not choose. When the two pin the same knob to different values it could not be applied
+    HERE, which says nothing about whether it is right anywhere. Spelled `not_reproduced`, two such
+    reads put a retire hint on a record nobody had found anything wrong with; spelled `inapplicable`
+    they stay out of the arithmetic however many times they happen.
+    """
+    value = {}
+    for _ in range(5):
+        value = record_attestation(value, "inapplicable")
+    assert value["attestations"]["recalls"] == 5        # the attempts are still counted...
+    assert retire_hint(value) == ""                     # ...they just do not judge the record
+
+
+def test_an_inapplicable_read_does_not_dilute_a_real_pattern():
+    """Removing them from the denominator must not also remove the signal that is there."""
+    value = record_attestation(record_attestation({}, "inapplicable"), "not_reproduced")
+    assert retire_hint(value) == ""                     # one real non-reproduction is not a case
+    value = record_attestation(value, "not_reproduced")
+    assert "could not reproduce" in retire_hint(value)  # two of them still is
+
+
+def test_a_ledger_of_only_inapplicable_reads_survives_a_rewrite():
+    """`carry_attestations` decides "is there anything here" from the bucket list; a bucket missing
+    from it drops the whole ledger on the next re-measurement, silently and well-formed."""
+    previous = record_attestation({}, "inapplicable")
+    fresh = carry_attestations(previous, {"direction": "tuned"})
+    assert fresh["attestations"]["inapplicable"] == 1
+
+
+def test_a_record_written_before_inapplicable_existed_reads_as_zero():
+    old = {"attestations": {"recalls": 3, "validations": 0, "failures": 3}}
+    ledger = attestations_of(old)
+    assert ledger["inapplicable"] == 0
+    assert "tried 3 times" in retire_hint(old)          # and its hint is unchanged
 
 
 def test_a_single_validation_clears_the_hint_however_many_failures():

--- a/kernel_workflow/scripts/experience_store.py
+++ b/kernel_workflow/scripts/experience_store.py
@@ -747,9 +747,9 @@ def _local_attestations(meta: dict) -> dict:
     that has never been recalled should carry no ledger at all — four zeroes and no ledger mean
     the same thing to a reader, and the shorter one does not imply somebody looked.
     """
-    from kb.attest import attestations_of
+    from kb.attest import BUCKETS, attestations_of
     ledger = attestations_of(meta if isinstance(meta, dict) else {})
-    counted = any(ledger[k] for k in ("recalls", "validations", "failures", "not_reproduced"))
+    counted = any(ledger[k] for k in ("recalls",) + BUCKETS)
     return ledger if counted else {}
 
 


### PR DESCRIPTION
Three halves of one problem: a warm start that silently finds nothing, one that finds
something and silently fails to apply it, and a report that cannot tell you either happened.

## 1. Addressing — `kb/identity.py`

`e2e_identity` keyed `framework_version` verbatim. Serving stacks are installed from git in these images, so `sglang.__version__` carries a PEP 440 dev/local suffix — `0.5.15.post1.dev20260723+g6c9fd0adc5` — that changes on **every rebuild of the same release**. A long opaque string is also one that gets hand-transcribed with a segment missing.

Either way the run opens a fresh set of pages and every earlier result becomes unreachable. Not degraded — **invisible**: the e2e store is an exact lookup with no search, so a miss and a never-recorded page are the same plain 404. And `framework_version` sits in the ladder's `base`, so no rung drops it:

```
...:sglang:0.5.15.post1.dev20260723+g6c9fd0adc5:mxfp4:tp_8:isl_8192:osl_1024:conc_64
...:sglang:0.5.15.post1.dev20260723+g6c9fd0adc5:mxfp4:tp_8
...:sglang:0.5.15.post1.dev20260723+g6c9fd0adc5:mxfp4
```

One changed character misses all three at once.

`_release_version` cuts the address to `<major>.<minor>.<patch>`:

```
0.5.15.post1.dev20260723+g6c9fd0adc5  ->  sglang:0.5.15
0.5.15.post1.dev20260723              ->  sglang:0.5.15
v0.5.15                               ->  sglang:0.5.15
0.26.0.dev0+g1234abc                  ->  vllm:0.26.0
```

**Three components, not two.** `0.5.15` and `0.5.17` are different releases with different kernels; cutting to `0.5` would merge results that genuinely do not transfer. The exact build string still travels in the record's *value*, so only the *address* is coarse — the same bargain as `kernel_identity`'s ROCm cut, one component wider.

Reader and writer share this single choke point, so they cannot drift apart.

## 2. Applying — `e2e_workflow.js`, `roles/config_tuner.md`, `kb/attest.py`

Finding the record is half of it. A stored e2e record holds a **whole launch configuration**, not a delta — the only form that can be replayed on a box whose baseline nobody wrote down. Replaying it therefore means combining it with the baseline *this* run was handed, and that combination was a string concatenation performed by an agent (`roles/config_tuner.md`: `EXTRA_SERVER_ARGS="<current flags + this flag>"`).

`adapters/sglang.sh` expands `$EXTRA_SERVER_ARGS` straight into argparse and `$EXTRA_ENV` straight into `env`, and both resolve a repeated key as **last-wins**. So when the baseline and the record each pin `--context-length`, which value applies is decided by the order the agent happened to write them in. Lose that coin flip and the server runs the baseline configuration twice: ~0% delta, nothing wrong in any log — the flag *was* honoured, just not with the recorded value — and the record is filed as `rejected`. **A record that wins gets recorded as a loss**, which is the one outcome the warm start exists to prevent.

Two more failures sit behind the same seam:

- A flag deleted upstream makes argparse exit before the model loads. One shot spent, `measured=0`, `not_reproduced` filed, no repair.
- `not_reproduced` meant both *"the flag is gone upstream"* (the record is stale) and *"it collides with a baseline this run did not choose"* (the record is fine). `kb/attest.py:retire_hint` retires on two of them, so **a good record could be retired for being read on the wrong machines**.

This is the default path, not an edge case, wherever a caller seeds the run with a full flag string it produced elsewhere and disables the exploratory sweep. The warm-start replay itself is **not** gated by `CONFIG_TUNE_ENABLED`; that flag gates only the exploratory ConfigSweep, so there is then no later phase that could correct any of it.

**Merge key by key, in the orchestrator, and report what it did.** `mergeFlags` / `mergeEnv` combine the recovered configuration with the run's baseline by flag name / env key. The recorded value wins every collision **in place**, so the baseline's ordering survives and the output names each key exactly once — last-wins never gets a vote. This generalizes the guard the launcher already applies by hand to one flag (`adapters/sglang.sh`: don't add `--watchdog-timeout` if the caller set one) and moves it to where the string is built instead of where it is used. Handles `--flag value`, `--flag=value`, bare flags, and multi-valued flags (kept whole, so a flag is overridden as a unit or not at all); a small explicit allow-list keeps genuinely repeatable flags (`--lora-path`) appended rather than deduped. What was overridden is **reported**, not just resolved — `MERGE_OVERRIDES` reaches the tuner, the run log, `measured_on_this_box.md`, the attestation note, and §2c below. A record the baseline already carries in full is now `skipped` instead of benched against itself.

**One repair attempt, and only when nothing came back.** When the merged configuration produces no measurement at all, the launch failure goes back to `config_tuner`, which classifies each recorded knob as `upstream_gone` / `conflicts_with_baseline` / `env_unsupported`, drops or adapts the **minimum** needed, and benches once more. Exactly once — a repair loop against a configuration that cannot run here spends server launches to learn nothing — and through the **same** accept gate, with no allowance made for having been repaired. If knobs had to be dropped, the verdict records `applied_partial` and which ones. `SWEEP_SCHEMA` gains an optional `repair` object, out of `required`, so every ordinary sweep keeps validating unchanged.

**`kb/attest.py` learns `inapplicable`.** A fourth outcome for *"could not be applied to THIS box's baseline"*. It counts toward `recalls` — the invariant that `recalls` is the sum of its buckets is what makes a ledger checkable, and hiding an attempt would make a record that keeps failing to fit look untouched — but it is **subtracted from the denominator `retire_hint` judges on**, because it is a verdict on the pairing and not on the record. The bucket list is now a single `BUCKETS` constant, since four call sites have to agree on it and three fail silently when they don't (a key missing from `attestations_of` reads as 0 forever; one missing from `carry_attestations`'s emptiness test drops a whole ledger on the next rewrite). Surfaced through `e2e_store.py`'s `_view()` and track-record line so a reader sees *"N did not fit that box's baseline (no verdict on the record)"* rather than N failures.

Also fixed here: the sweep result was read as `trial.notes` while the role's return schema spells it `note`, so the per-trial text never reached the "never took effect" check at all.

## 3. Reporting — `e2e_workflow.js`, `roles/system_architect.md`

`KB_RECALL` collects, on **both planes**, what was asked and how it fared:

- the exact canonical ids tried, the read reason, match tier, plane, candidate count — recorded *before* anything is benched, so a run that dies mid-warm-start still reports the ask;
- each recalled config re-measured against this box's own baseline (stored claim / measured here / Δ / parity / outcome), **plus what the merge and the repair did to it** (`overrides`, `applied_partial`, `dropped_flags`) — a Δ measured from a partly-applied configuration is not a measurement of the record, and the row now says so;
- each kernel lane's `warm_start` block — adopted vs incremental speedup, rounds committed, `no_rounds_after_adopt`. This previously died inside the lane, so an e2e report could describe a kernel as authored from scratch when the lane had in fact adopted a stored patch.

It is threaded into the Report role's inputs and emitted as `kb_recall` in the workflow return, **independently of `kb_warm_start`** — that object is null whenever KB dims were never established, but the kernel lanes can still have recalled by then, and those are exactly the runs where knowing what was recalled matters most.

`system_architect.md` gains a mandatory **`2c. Knowledge-base recall`** section, written **even when nothing came back**. On an exact-lookup store the addresses tried *are* the finding: without them a reader cannot tell "no prior art" from "prior art one segment away". The section refuses to collapse the outcomes into each other — `rejected` (ran and lost), `not_reproduced` (never took effect), `inapplicable` (never fit this box) say different things about the record, and only the middle one is evidence it is stale.

## Compatibility

- Records written before `inapplicable` existed read it as `0` and produce exactly the same retire hint as before. No migration.
- `repair` is optional in the sweep schema; existing sweeps are unaffected.
- `interface/run_e2e.py`, `adapters/sglang.sh` and `bench_e2e.sh` are unchanged.

## Verification

- identity normalization over dev / local / `v`-prefixed spellings of one release, and across sglang + vllm
- **new** `e2e_workflow/scripts/test_warm_start_merge.js` — 26 assertions, with the merge functions *extracted from the shipped source* rather than reimplemented, so it cannot pass while `e2e_workflow.js` drifts. Covers the collision case, both flag spellings, bare and multi-valued flags, agreement-is-not-an-override, repeatable flags, and that the orchestrator actually hands the merged strings to the tuner.
- **new** `kb/tests/test_attest.py` cases — the fourth outcome, the retire arithmetic (many `inapplicable` reads never retire; a real pattern still does), carry-forward of an `inapplicable`-only ledger, pre-existing documents.
- `kb/tests` + `e2e_workflow/scripts/tests/test_e2e_store.py` — 127 passed, 1 skipped
- `e2e_workflow/scripts/tests` — 1211 passed, 5 skipped, 77 subtests
- `kernel_workflow/scripts/tests/test_experience_store.py` — 83 passed
- all six `e2e_workflow/scripts/test_*.js`, and `node --check e2e_workflow/e2e_workflow.js`

Not yet exercised by a live run: the repair pass needs a real launch failure to fire.

## Note for reviewers

`main` already has a `2b` (tuning skillset). The recall section is numbered **`2c`** and the PHASE=report Inputs line carries both `KB_RECALL` (§2c) and `TUNING_RESULT` (§2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
