### PR TITLE
Admit a replayed oracle when the capture server does not boot

### DIFF
--- a/e2e_workflow/knowledge/shape_capture.md
+++ b/e2e_workflow/knowledge/shape_capture.md
@@ -34,6 +34,33 @@ input-shape signatures records `(args, kwargs) -> output` to `reference_io.pt`. 
 - **Determinism**: capture with temp=0 so re-running the reference is reproducible.
 - Bound the window (`--num-steps`) so capture is fast and the file stays small.
 
+## Step 1b — When the server does not boot: REPLAY the oracle, do not drop the task
+Capture needs a live server, and a live server is the least reliable part of the pipeline. When
+`meta.oracle_complete` is false or empty, the task is still recoverable: rebuild the operands from
+`regime.json` and produce the golden outputs by RUNNING the frozen real baseline in `baseline_src/`.
+Only the inputs are reconstructed; the values still come from the production kernel, so this is a
+replay, not a fabrication.
+
+```
+<task_dir>/
+  case_spec.py       # operands built through harness_lib from regime.json (dtype/KV layout/scales/pack_x)
+  _build_oracle.py   # imports baseline_src/, runs it on those operands, writes reference_io.pt
+  _oracle_info.json  # sha256 + determinism fingerprint + the case list
+```
+
+Four guards make it admissible — all four, or drop:
+1. every operand from `regime.json` via `harness_lib`, never from offline defaults;
+2. the golden output computed by calling `baseline_src/`, never hand-written and never a re-run of the
+   code under optimization;
+3. seeded operands rebuilt twice and asserted bit-identical, with the fingerprint in `meta.json` and
+   re-checked by `unittest.py` before it trusts the oracle (fail loud);
+4. `meta.json` carries `oracle_source: "capture" | "replay"` so the Validator and the dashboard can
+   tell the two apart.
+
+Prefer live capture whenever the server is up. Drop (`editable:false`) only when the regime itself
+cannot be rebuilt offline — an op that exists only fused in the compile graph, or routing-dependent
+MoE token counts. A server that fails to boot is not by itself a reason to drop the task.
+
 ## Step 2 — Emit an immutable, general unittest
 The unittest must be backend-agnostic: it loads `reference_io.pt`, calls whatever the CURRENT kernel
 entry point is on the recorded inputs, compares to the golden output (tolerance per dtype:

--- a/e2e_workflow/roles/kernel_extractor.md
+++ b/e2e_workflow/roles/kernel_extractor.md
@@ -231,11 +231,26 @@ freeze an out-of-regime oracle nobody should trust.
    > Shapes/weights arrive from TraceLens priors, the profiler trace, config M-buckets, AND live capture
    > (`meta.cases` oracle + `meta.shape_counts`). Resolve by PURPOSE, and let the deterministic tools own
    > the merge — never hand-pick:
-   > - **Correctness oracle (exact operands/dtype/LAYOUT): live capture ONLY.** If capture is
-   >   `meta.oracle_complete == false` or empty (server didn't boot / hook missed the seam / OOM), do NOT
-   >   freeze a partial oracle. For value-INDEPENDENT dense GEMM you may synth from config (`GEMM_SYNTH`);
-   >   for anything value/layout-dependent (quant / attn / swizzled-scale) **DROP (`editable:false`) —
-   >   never fabricate an oracle.** Capture is best-effort, never load-bearing.
+   > - **Correctness oracle (exact operands/dtype/LAYOUT).** Two sources are legitimate, in this order:
+   >   **(a) live capture** — real operands recorded off the running server; and, when capture is
+   >   `meta.oracle_complete == false` or empty (server didn't boot / hook missed the seam / OOM),
+   >   **(b) a REPLAYED oracle**: build the operands from `regime.json` and produce the golden outputs by
+   >   RUNNING the frozen real baseline in `baseline_src/`. (b) is not fabrication — the values still come
+   >   from the production kernel, only the inputs are reconstructed — and it is what every large authored
+   >   win in the campaign actually used. It is admissible ONLY with all four guards:
+   >     1. every operand built through `harness_lib` from `regime.json` (dtype, KV layout, scales,
+   >        `pack_x`, fp8 variant) — never from offline defaults, per the ONLINE REGIME section above;
+   >     2. the golden output computed by importing `baseline_src/` and calling it — never written by hand,
+   >        never a re-run of the candidate's own code path;
+   >     3. any seeded operand rebuilt twice and asserted bit-identical, with the fingerprint recorded in
+   >        `meta.json` and re-checked by `unittest.py` before it trusts the oracle (fail loud);
+   >     4. `meta.json` records `oracle_source: "capture" | "replay"` plus the usual sha, so the Validator
+   >        and the dashboard can tell the two apart. Prefer (a) whenever the server is up.
+   >   **Never fabricate an oracle** — hand-written expected values, or a "golden" output produced by the
+   >   code under optimization, remain forbidden under both (a) and (b). If the regime genuinely cannot be
+   >   rebuilt offline (op exists only fused in the compile graph, routing-dependent MoE token counts),
+   >   THEN drop (`editable:false`) and say so in `notes`. **A server that fails to boot is not by itself a
+   >   reason to drop the task.**
    > - **Which shapes exist (coverage): config M-buckets are the deterministic spine** (can't crash);
    >   live capture augments/corrects; profiler + TraceLens are hints you re-verify against capture. The
    >   mandatory both-regimes floor still applies even if a source missed decode.


### PR DESCRIPTION
## The rule

`e2e_workflow/roles/kernel_extractor.md`, SOURCE PRECEDENCE:

> **Correctness oracle (exact operands/dtype/LAYOUT): live capture ONLY.** If capture is
> `meta.oracle_complete == false` or empty (server didn't boot / hook missed the seam / OOM), do NOT
> freeze a partial oracle. ... for anything value/layout-dependent (quant / attn / swizzled-scale)
> **DROP (`editable:false`) — never fabricate an oracle.**

So a kernel task whose capture server fails to start is dropped. Attention is value- and
layout-dependent, so attention is always dropped.

## What the runs show

420 e2e kernel task dirs, all Hyperloom arenas, up to 30 Aug. A task counted as
`server DOWN` has no startup-complete line in any `_capture*` log.

| arena | era | server | tasks | produced `reference_io.pt` |
|---|---|---|---:|---|
| CI | < 17 Aug | DOWN | 197 | **84 (43%)** |
| CI | >= 17 Aug | DOWN | 135 | **38 (28%)** |
| LOCAL | >= 17 Aug | DOWN | 21 | **13 (62%)** |

A failed capture is not fatal today. Between 28% and 62% of those tasks got an oracle anyway.

They got it by reconstructing the operands from `regime.json` and running the **frozen real baseline**
in `baseline_src/` to produce the golden outputs. The files that do it:

```
case_spec.py  _build_oracle.py  _oracle_info.json    (gemma-4-26B-A4B-it)
case_lib.py   build_reference.py                     (Kimi-K3)
_extract_gen.py                                      (one other)
```

None of those names appears anywhere in this repo:

```
$ grep -rl -e case_spec -e _build_oracle -e build_reference -e case_lib -e _extract_gen \
      --include=*.py --include=*.md --include=*.js .
(no output)
```

Every extractor re-invents it. That is why the rate is 28–62% and not 0% or 100%.

## It is the path the wins came from

The campaign's authored kernel wins are attention kernels built this way — the exact class the rule
says to drop:

| kernel | gain | oracle |
|---|---:|---|
| `dsa_sparse_attn_prefill_main_kernel` | +29.99% | replayed |
| `_fwd_grouped_kernel_stage1` | +18.91% | `_build_oracle.py` + `case_spec.py` |
| `_fwd_grouped_kernel_stage1[full_attention]` | +10.38% | `_build_oracle.py` + `case_spec.py` |
| `decode_attention_grouped_mla` | — | `build_reference.py` + `case_lib.py` |

The rule as written forbids the work that produced the largest numbers on the board.

## Why it is not fabrication

The rule conflates two different things:

1. **Fabricating the golden output** — writing expected values by hand, or "checking" the candidate
   against a re-run of its own code path. Genuinely unsound. Still forbidden here.
2. **Replaying it** — rebuilding the inputs in-regime and computing the golden output by running the
   frozen production kernel. Only the inputs are reconstructed; the values come from the real kernel.

The doc already sanctions (2) 100 lines earlier, in the ONLINE REGIME section:

> Synthesis is fine — perf is value-independent and the oracle is a high-precision compute over the
> same in-regime inputs — but it MUST be DRIVEN BY the parsed regime.

This PR removes the contradiction and keeps the constraint that section already states.

## The change

`kernel_extractor.md` names the replayed oracle as source (b), after live capture, admissible only
with four guards:

1. operands built through `harness_lib` from `regime.json` — never offline defaults;
2. golden outputs produced by calling `baseline_src/` — never hand-written, never the candidate;
3. seeded operands rebuilt twice and asserted bit-identical, fingerprint in `meta.json`, re-checked by
   `unittest.py` before it trusts the oracle;
4. `meta.json` records `oracle_source: "capture" | "replay"`.

`shape_capture.md` gets the matching Step 1b with the file layout, so the extractor stops inventing it.

Live capture stays preferred whenever the server is up. Dropping stays correct when the regime itself
cannot be rebuilt offline — fused-only ops, routing-dependent MoE token counts. A server that fails to
boot is not one of those.

Guard 4 is the one that pays twice: it lets the Validator and the dashboard separate a captured oracle
from a replayed one, which the current artifacts cannot do at all.

## Not claimed

This does not explain why CI stopped producing authored kernels between 17 and 28 Aug. The rule is
dated `48cef4a`, 4 Jul, so it is chronic, not the dated regression. It is a standing defect that makes
every capture failure fatal; the dated cause is still open.
