### PR TITLE
Measure the AgentX trace replay instead of a synthetic ISL/OSL sweep

### DIFF
--- a/.github/workflows/ci-l0-checks.yml
+++ b/.github/workflows/ci-l0-checks.yml
@@ -89,6 +89,7 @@ jobs:
             interface/test_run_e2e_tuning_result.py \
             interface/test_run_e2e_alignment.py \
             interface/test_run_e2e_dispatch.py \
+            interface/test_run_e2e_workload_comparability.py \
             interface/test_run_e2e_recipe_env.py \
             interface/test_run_e2e_margin.py \
             interface/test_run_e2e_measurement_basis.py \
@@ -126,6 +127,7 @@ jobs:
             e2e_workflow/scripts/tests/test_bench_replica_lifecycle.py \
             e2e_workflow/scripts/tests/test_bench_summarize.py \
             e2e_workflow/scripts/tests/test_inferencex_client_warmup_parity.py \
+            e2e_workflow/scripts/tests/test_agentx_client_canonicality.py \
             e2e_workflow/scripts/tests/test_roofline_skill.py \
             e2e_workflow/scripts/tests/test_vllm_adapter_profiler_config.py \
             geak/test_bootstrap.py

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -561,7 +561,14 @@ const FAST_PATH_FIRST = String(A.fast_path_first != null ? A.fast_path_first : '
 const ISL = parseInt(A.isl != null ? A.isl : 1024, 10);
 const OSL = parseInt(A.osl != null ? A.osl : 1024, 10);
 const CONC = parseInt(A.conc != null ? A.conc : 64, 10);
-const WORKLOAD = { isl: ISL, osl: OSL, conc: CONC };
+// On an AgentX trace replay there is no single ISL -- the corpus spans ~89k at
+// p50 past 500k at p99 -- so isl/osl describe the shape to OPTIMIZE FOR (the
+// average the orchestrator measured on its own baseline), not the shape anything
+// is measured at. The bench client replays the corpus and ignores them. Roles
+// must therefore use isl/osl for kernel/GEMM shape synthesis only, and never
+// treat them as a benchmark they can reproduce.
+const WORKLOAD_SHAPE_PROVENANCE = String(A.workload_shape_provenance || 'handoff_workload');
+const WORKLOAD = { isl: ISL, osl: OSL, conc: CONC, shape_provenance: WORKLOAD_SHAPE_PROVENANCE };
 // Seed config: when an external orchestrator (e.g. Hyperloom) already did
 // config/param search, it passes its accepted best flags/env so the GEAK
 // baseline is measured ON that config (fair engagement start), not the stack

--- a/e2e_workflow/scripts/adapters/clients/agentx.sh
+++ b/e2e_workflow/scripts/adapters/clients/agentx.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# AgentX trace-replay CLIENT adapter for bench_e2e.sh.  Sourced (not executed).
+#
+# Unlike Hyperloom's aiperf_client.sh, this adapter does NOT boot the server:
+# GEAK's magpie launcher already did that under MAGPIE_RUN_PHASE=server.  This
+# file ONLY redefines adapter_bench to drive aiperf's inferencex-agentx-mvp
+# scenario against the warm server at $BASE_URL, then map the export into the
+# canonical jsonl line bench_e2e.sh aggregates.
+#
+# Enable with:  BENCH_CLIENT=agentx  (run_e2e.py selects this automatically
+# when handoff.workload_spec.kind == agentx_trace_replay).
+#
+# Requires: aiperf on PATH (or AIPERF_BIN), INFERENCEX_PATH with map_aiperf.py
+# deployed under benchmarks/ (Hyperloom's AgentX runtime copies it there).
+
+adapter_bench() {
+  local NUMP="$1" MAXC="$2" PROF="${3:-0}"
+
+  # NUMP/ISL/OSL are owned by the trace corpus, not the synthetic sweep knobs
+  # bench_e2e.sh also exports for the inferencex/native clients.
+
+  if [ "$PROF" = "1" ] && declare -F adapter_bench_native >/dev/null; then
+    adapter_bench_native "$NUMP" "$MAXC" 1
+    return $?
+  fi
+
+  local py="${PYTHON_BIN:-python3}"
+  local ix_root="${INFERENCEX_PATH:-}"
+  local mapper=""
+  for cand in \
+    "${ix_root}/benchmarks/map_aiperf.py" \
+    "${ix_root}/assets/agentx/map_aiperf.py"; do
+    [ -n "$ix_root" ] && [ -f "$cand" ] && { mapper="$cand"; break; }
+  done
+  if [ -z "$mapper" ]; then
+    echo "!!! agentx client: map_aiperf.py not found under INFERENCEX_PATH=${ix_root:-<unset>}." >&2
+    return 5
+  fi
+
+  local port="${PORT:-8000}"
+  case "${BASE_URL:-}" in
+    *://*:*/*|*://*:*)
+      port="${BASE_URL##*:}"
+      port="${port%%/*}"
+      ;;
+  esac
+
+  local art_dir="${OUT_DIR:-${PROFILE_DIR:-$(pwd)}}/agentx_client_$$_${RANDOM}"
+  mkdir -p "$art_dir"
+  rm -rf "$art_dir"/*
+  mkdir -p "$art_dir"
+
+  local scenario="${GEAK_AGENTX_SCENARIO:-inferencex-agentx-mvp}"
+  local corpus="${AGENTX_DATASET:-${WEKA_LOADER_OVERRIDE:-semianalysis_cc_traces_weka_062126_256k}}"
+  local nent="${AGENTX_NUM_ENTRIES:-393}"
+  local conc="${CONC:-${MAXC:-8}}"
+  local full_dur="${GEAK_AGENTX_DURATION_S:-3600}"
+  local loop_dur="${GEAK_AGENTX_LOOP_DURATION_S:-900}"
+  local purpose="${MEASUREMENT_PURPOSE:-search}"
+  local duration="$loop_dur"
+  if [ "$purpose" = "parity" ] || [ "$purpose" = "validation" ]; then
+    duration="$full_dur"
+  fi
+
+  # ── Non-canonical workloads may run, but may never look submittable ────────
+  # Mirrors aiperf_client.sh: the SCENARIO cannot police this for us. It has no
+  # concept of corpus size, and its allowlist admits every dated weka variant,
+  # so a 50-entry or wrong-corpus replay still returns submission_valid=true.
+  # --unsafe-override does not help either: aiperf only flips the flag when the
+  # override actually suppressed a violation, so at 3600s there is nothing to
+  # suppress. GEAK's inner search loop runs the 900s scenario floor by design,
+  # which means WITHOUT this stamp every search-leg measurement would come back
+  # looking leaderboard-valid. So the client states the deviations itself and
+  # map_aiperf.py forces submission_valid=false with them attached.
+  local canon_entries=393
+  local canon_duration="${AGENTX_CANONICAL_DURATION:-3600}"
+  local canon_ds="${AGENTX_CANONICAL_DATASET:-$corpus}"
+  local -a noncanon=()
+  [ "$corpus" != "$canon_ds" ] && noncanon+=("corpus=${corpus}(canonical ${canon_ds})")
+  [ "$nent" != "$canon_entries" ] && noncanon+=("entries=${nent}(canonical ${canon_entries})")
+  [ "$duration" != "$canon_duration" ] && noncanon+=("duration=${duration}s(canonical ${canon_duration}s)")
+  [ -n "${AGENTX_MAX_CTX:-}" ] && noncanon+=("client_context_cap=${AGENTX_MAX_CTX}")
+  [ "${AGENTX_UNSAFE_OVERRIDE:-false}" = "true" ] && noncanon+=("unsafe_override_forced")
+
+  local smoke_args=()
+  if [ "$duration" -lt "$canon_duration" ] || [ "${AGENTX_UNSAFE_OVERRIDE:-false}" = "true" ]; then
+    # Below the scenario's 900s floor aiperf aborts outright; at or above it the
+    # flag is harmless and keeps the canonical and smoke paths uniform.
+    smoke_args+=(--unsafe-override)
+  fi
+
+  # Always exported, empty included: a value inherited from the orchestrator's
+  # environment or a previous leg must never survive into a canonical run.
+  local noncanon_reasons=""
+  if [ ${#noncanon[@]} -gt 0 ]; then
+    noncanon_reasons="$(IFS=,; echo "${noncanon[*]}")"
+    echo ">>> agentx client: NON-CANONICAL workload [${noncanon_reasons}] -- result will be stamped submission_valid=false and cannot KEEP" >&2
+  fi
+
+  local warm_lane="${AGENTX_WARMUP_REQUESTS_PER_LANE:-10}"
+  local warm_grace="${AGENTX_WARMUP_GRACE_PERIOD:-1800}"
+  local fail_thresh="${AGENTX_FAILED_REQUEST_THRESHOLD:-0.10}"
+  local idle_gap="${AGENTX_TRACE_IDLE_GAP_CAP_SECONDS:-300}"
+  local aiperf="${AIPERF_BIN:-aiperf}"
+
+  # Resolve the served model id (a reused server may expose a different name).
+  local serve_model="$MODEL"
+  local served=""
+  served="$(curl -sf "${BASE_URL:-http://127.0.0.1:${port}}/v1/models" 2>/dev/null \
+    | "$py" -c 'import sys,json; d=json.load(sys.stdin); print(d["data"][0]["id"])' 2>/dev/null || true)"
+  [ -n "$served" ] && serve_model="$served"
+
+  # Scrub stray AIPERF_* env (aiperf_client.sh does the same).
+  local _k _v
+  while IFS='=' read -r _k _v; do
+    case "$_k" in
+      AIPERF_BIN) : ;;
+      AIPERF_*) unset "$_k" 2>/dev/null || true ;;
+    esac
+  done < <(env)
+
+  export AIPERF_DATASET_CONFIGURATION_TIMEOUT="${AGENTX_DATASET_CONFIG_TIMEOUT:-1800}"
+  export AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT="${AGENTX_DATASET_CONFIG_TIMEOUT:-1800}"
+  export AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES="${AGENTX_LIVE_ASSISTANT:-0}"
+  export AIPERF_UI_REALTIME_METRICS_ENABLED="${AGENTX_REALTIME_METRICS:-true}"
+  local _mmap_default="${HF_HUB_CACHE:-${HOME:-/tmp}/.cache/huggingface/hub}/aiperf_dataset_mmap"
+  export AIPERF_DATASET_MMAP_CACHE_DIR="${AGENTX_MMAP_CACHE_DIR:-$_mmap_default}"
+
+  echo ">>> agentx client: scenario=${scenario} corpus=${corpus} conc=${conc} duration=${duration}s purpose=${purpose}"
+
+  local -a ctx_args=()
+  if [ -n "${AGENTX_MAX_CTX:-}" ]; then
+    ctx_args+=(--max-context-length "$AGENTX_MAX_CTX")
+  fi
+
+  if ! command -v "$aiperf" >/dev/null 2>&1; then
+    echo "!!! agentx client: aiperf not found (set AIPERF_BIN)." >&2
+    return 5
+  fi
+
+  "$aiperf" profile \
+    --scenario "$scenario" \
+    --url "${BASE_URL:-http://127.0.0.1:${port}}" \
+    --endpoint /v1/chat/completions \
+    --endpoint-type chat --streaming --use-server-token-count \
+    --model "$serve_model" \
+    --tokenizer "$MODEL" --tokenizer-trust-remote-code \
+    --public-dataset "$corpus" \
+    --num-dataset-entries "$nent" \
+    --concurrency "$conc" \
+    --benchmark-duration "$duration" \
+    --random-seed 42 \
+    --trajectory-start-min-ratio 0.25 \
+    --trajectory-start-max-ratio 0.75 \
+    --warmup-requests-per-lane "$warm_lane" \
+    --warmup-grace-period "$warm_grace" \
+    --trace-idle-gap-cap-seconds "$idle_gap" \
+    --failed-request-threshold "$fail_thresh" \
+    --stats-interval 30 \
+    --slice-duration 1.0 \
+    --no-gpu-telemetry \
+    ${ctx_args[@]+"${ctx_args[@]}"} \
+    ${smoke_args[@]+"${smoke_args[@]}"} \
+    --artifact-dir "$art_dir" --ui simple || return $?
+
+  local pj=""
+  pj="$(find "$art_dir" -name 'profile_export_aiperf.json' -print -quit)"
+  if [ -z "$pj" ]; then
+    echo "!!! agentx client: no profile_export_aiperf.json produced in $art_dir" >&2
+    return 6
+  fi
+
+  local mapped="${art_dir}/inferencex_result.json"
+  AGENTX_NONCANONICAL_REASONS="$noncanon_reasons" \
+    "$py" "$mapper" "$pj" "$mapped" || return $?
+
+  if [ ! -f "$mapped" ]; then
+    echo "!!! agentx client: mapper produced no $mapped" >&2
+    return 6
+  fi
+
+  "$py" -c "import json,sys; print(json.dumps(json.load(open(sys.argv[1]))))" "$mapped" \
+    >> "$RESULT_JSONL" 2>/dev/null || cat "$mapped" >> "$RESULT_JSONL"
+  mv "$mapped" "${mapped}.consumed" 2>/dev/null || true
+}

--- a/e2e_workflow/scripts/adapters/clients/inferencex.sh
+++ b/e2e_workflow/scripts/adapters/clients/inferencex.sh
@@ -63,6 +63,19 @@ adapter_bench() {
     bench_seed=0
   fi
 
+  # This client loads the model's tokenizer itself, so it has to trust the same
+  # remote code as the server it measures. bench_e2e.sh already resolves that
+  # across the recipe env and EXTRA_SERVER_ARGS and exports
+  # BENCH_TRUST_REMOTE_CODE; only the flag was missing here, so a
+  # custom-tokenizer model (Kimi-K3, DeepSeek) died in the client at
+  # transformers' resolve_trust_remote_code while the server ran fine. Pass the
+  # bare BooleanOptionalAction spelling: the client rejects
+  # --trust-remote-code=true/false.
+  local -a trust_args=()
+  if [ "${BENCH_TRUST_REMOTE_CODE:-0}" = "1" ]; then
+    trust_args=(--trust-remote-code)
+  fi
+
   # --backend vllm: OpenAI-compatible client regardless of the actual serving
   # stack (matches Hyperloom). --request-rate inf + --max-concurrency: the same
   # saturation driver. --ignore-eos + fixed seed + random-range-ratio: identical
@@ -82,6 +95,7 @@ adapter_bench() {
     --num-warmups "$num_warmups" \
     --percentile-metrics "ttft,tpot,itl,e2el" \
     --seed "$bench_seed" \
+    ${trust_args[@]+"${trust_args[@]}"} \
     --save-result \
     --result-dir "$res_dir" \
     --result-filename "${res_name}.json" || return $?

--- a/e2e_workflow/scripts/bench_e2e.sh
+++ b/e2e_workflow/scripts/bench_e2e.sh
@@ -400,7 +400,10 @@ CONC=${CONC:-64}
 # An explicit NUM_PROMPTS (e.g. Hyperloom's apply_bench_protocol forwarding its own
 # measured count) ALWAYS wins over both defaults.
 if [ -z "${NUM_PROMPTS:-}" ]; then
-  if [ "$BENCH_CLIENT" = "inferencex" ]; then
+  if [ "$BENCH_CLIENT" = "agentx" ]; then
+    # AgentX is duration-based; prompt count is owned by the trace corpus.
+    NUM_PROMPTS=1
+  elif [ "$BENCH_CLIENT" = "inferencex" ]; then
     if [ "${NUM_PROMPTS_ADAPTIVE:-0}" = "1" ]; then
       _seq_cost=$((ISL + OSL))
       if   [ "$_seq_cost" -le 1024 ];  then _factor=10

--- a/e2e_workflow/scripts/bench_replica.sh
+++ b/e2e_workflow/scripts/bench_replica.sh
@@ -45,6 +45,10 @@ if [ "${BENCH_CLIENT:-native}" = "inferencex" ]; then
   esac
   export NUM_WARMUPS=$((2 * _conc))
   export SEED=0
+elif [ "${BENCH_CLIENT:-native}" = "agentx" ]; then
+  # Trace replay owns warmup/duration; one measured window per replica.
+  export REPEATS=1
+  export GEAK_ISL_OSL_INACTIVE=1
 fi
 
 exec bash "$BENCH_E2E"

--- a/e2e_workflow/scripts/tests/test_agentx_client_canonicality.py
+++ b/e2e_workflow/scripts/tests/test_agentx_client_canonicality.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""The AgentX client must state its own workload deviations.
+
+The aiperf SCENARIO cannot police canonicality for us: it has no concept of
+corpus size, its allowlist admits every dated weka variant, and
+``--unsafe-override`` only flips ``submission_valid`` when the override actually
+suppressed a violation. GEAK's inner search loop deliberately runs the 900s
+scenario floor rather than the canonical 3600s window, so without a stamp from
+the client every search-leg number would come back looking leaderboard-valid.
+
+These tests pin that the client computes ``AGENTX_NONCANONICAL_REASONS`` itself
+and hands it to map_aiperf.py, and that a canonical run stays unstamped.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+BASH = shutil.which("bash")
+ADAPTER = (
+    Path(__file__).resolve().parents[1] / "adapters" / "clients" / "agentx.sh"
+)
+
+
+@unittest.skipIf(BASH is None, "bash is required to exercise the client adapter")
+class AgentXClientCanonicalityTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="agentx_client_test_")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        root = Path(self.tmp)
+
+        # Stub aiperf: only needs to honour --artifact-dir and record its argv.
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        self.aiperf = bin_dir / "aiperf"
+        self.aiperf.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                art=""
+                prev=""
+                for a in "$@"; do
+                  [ "$prev" = "--artifact-dir" ] && art="$a"
+                  prev="$a"
+                done
+                printf '%s\\n' "$@" > "${TEST_ARGV_LOG}"
+                mkdir -p "$art"
+                echo '{"records": {}}' > "$art/profile_export_aiperf.json"
+                """
+            )
+        )
+        self.aiperf.chmod(0o755)
+
+        # Stub mapper: records the canonicality verdict it was handed.
+        bench = root / "ix" / "benchmarks"
+        bench.mkdir(parents=True)
+        (bench / "map_aiperf.py").write_text(
+            textwrap.dedent(
+                """\
+                import json, os, sys
+                json.dump(
+                    {
+                        "output_throughput": 169.0,
+                        "noncanonical_reasons_seen": os.environ.get(
+                            "AGENTX_NONCANONICAL_REASONS", "<absent>"
+                        ),
+                    },
+                    open(sys.argv[2], "w"),
+                )
+                """
+            )
+        )
+        self.result_jsonl = root / "results.jsonl"
+        self.argv_log = root / "argv.txt"
+
+    def _run(self, **env_overrides) -> dict:
+        env = dict(os.environ)
+        env.update(
+            {
+                "PATH": f"{Path(self.tmp) / 'bin'}:{env.get('PATH', '')}",
+                "TEST_ARGV_LOG": str(self.argv_log),
+                "INFERENCEX_PATH": str(Path(self.tmp) / "ix"),
+                "RESULT_JSONL": str(self.result_jsonl),
+                "OUT_DIR": self.tmp,
+                "MODEL": "/models/Kimi-K3",
+                "BASE_URL": "http://127.0.0.1:8000",
+                "AGENTX_DATASET": "semianalysis_cc_traces_weka_062126",
+                "AGENTX_CANONICAL_DATASET": "semianalysis_cc_traces_weka_062126",
+                "AGENTX_NUM_ENTRIES": "393",
+                "GEAK_AGENTX_DURATION_S": "3600",
+                "GEAK_AGENTX_LOOP_DURATION_S": "900",
+                "CONC": "8",
+            }
+        )
+        # A stale value from the orchestrator's environment must never survive.
+        env.pop("AGENTX_NONCANONICAL_REASONS", None)
+        env.update({k: str(v) for k, v in env_overrides.items()})
+        proc = subprocess.run(
+            [BASH, "-c", f'source "{ADAPTER}"; adapter_bench 1 8 0'],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            proc.returncode, 0, msg=f"stdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+        line = self.result_jsonl.read_text().strip().splitlines()[-1]
+        record = json.loads(line)
+        record["_argv"] = self.argv_log.read_text().splitlines()
+        record["_stderr"] = proc.stderr
+        return record
+
+    def test_search_leg_at_the_scenario_floor_is_stamped_non_canonical(self):
+        """The 900s search window is NOT a leaderboard measurement."""
+        rec = self._run(MEASUREMENT_PURPOSE="search")
+        reasons = rec["noncanonical_reasons_seen"]
+        self.assertIn("duration=900s", reasons)
+        self.assertIn("canonical 3600s", reasons)
+        # And it must have told the operator, not just the mapper.
+        self.assertIn("NON-CANONICAL", rec["_stderr"])
+
+    def test_search_leg_opts_into_the_override_the_floor_requires(self):
+        rec = self._run(MEASUREMENT_PURPOSE="search")
+        self.assertIn("--unsafe-override", rec["_argv"])
+        self.assertIn("900", rec["_argv"])
+
+    def test_parity_runs_the_canonical_window_and_is_not_stamped(self):
+        rec = self._run(MEASUREMENT_PURPOSE="parity")
+        self.assertEqual(rec["noncanonical_reasons_seen"], "")
+        self.assertIn("3600", rec["_argv"])
+
+    def test_validation_also_runs_the_canonical_window(self):
+        rec = self._run(MEASUREMENT_PURPOSE="validation")
+        self.assertEqual(rec["noncanonical_reasons_seen"], "")
+        self.assertIn("3600", rec["_argv"])
+
+    def test_a_pinned_non_canonical_corpus_is_stamped(self):
+        rec = self._run(
+            MEASUREMENT_PURPOSE="parity",
+            AGENTX_DATASET="semianalysis_cc_traces_weka_061526",
+        )
+        self.assertIn("corpus=semianalysis_cc_traces_weka_061526", rec["noncanonical_reasons_seen"])
+
+    def test_a_shrunken_corpus_is_stamped_even_at_canonical_duration(self):
+        rec = self._run(MEASUREMENT_PURPOSE="parity", AGENTX_NUM_ENTRIES="50")
+        self.assertIn("entries=50", rec["noncanonical_reasons_seen"])
+        self.assertIn("canonical 393", rec["noncanonical_reasons_seen"])
+
+    def test_a_stale_inherited_verdict_never_survives_into_a_canonical_run(self):
+        """Pass-through would let a previous leg's stamp mark a clean run dirty."""
+        rec = self._run(
+            MEASUREMENT_PURPOSE="parity",
+            AGENTX_NONCANONICAL_REASONS="duration=900s(canonical 3600s)",
+        )
+        self.assertEqual(rec["noncanonical_reasons_seen"], "")
+
+    def test_client_context_cap_is_stamped_and_forwarded(self):
+        rec = self._run(MEASUREMENT_PURPOSE="parity", AGENTX_MAX_CTX="262144")
+        self.assertIn("client_context_cap=262144", rec["noncanonical_reasons_seen"])
+        self.assertIn("--max-context-length", rec["_argv"])
+
+    def test_the_replay_uses_the_scenario_corpus_and_concurrency_it_was_given(self):
+        rec = self._run(MEASUREMENT_PURPOSE="parity")
+        argv = rec["_argv"]
+        self.assertIn("inferencex-agentx-mvp", argv)
+        self.assertIn("semianalysis_cc_traces_weka_062126", argv)
+        self.assertIn("--concurrency", argv)
+        self.assertIn("8", argv)
+        # Trace replay: the synthetic sweep knobs must not appear at all.
+        for synthetic in ("--random-input-len", "--random-output-len", "--num-prompts"):
+            self.assertNotIn(synthetic, argv)
+
+    def test_inherited_aiperf_env_is_scrubbed_before_the_replay(self):
+        """An AIPERF_* value from the caller must not reconfigure the replay.
+
+        The orchestrator forwards its whole environment, so a knob left over
+        from a previous run would otherwise silently change this measurement.
+        """
+        rec = self._run(
+            MEASUREMENT_PURPOSE="parity",
+            AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES="1",
+            AIPERF_TOKENIZER_TRUST_REMOTE_CODE="bogus",
+        )
+        # The adapter re-exports the knobs it owns at their intended values.
+        self.assertEqual(rec["noncanonical_reasons_seen"], "")
+        self.assertIn("--use-server-token-count", rec["_argv"])
+
+    def test_missing_aiperf_fails_before_it_can_report_a_number(self):
+        rec_env = dict(os.environ)
+        rec_env.update(
+            {
+                "PATH": "/nonexistent",
+                "INFERENCEX_PATH": str(Path(self.tmp) / "ix"),
+                "RESULT_JSONL": str(self.result_jsonl),
+                "OUT_DIR": self.tmp,
+                "MODEL": "/models/Kimi-K3",
+                "MEASUREMENT_PURPOSE": "parity",
+            }
+        )
+        proc = subprocess.run(
+            [BASH, "-c", f'source "{ADAPTER}"; adapter_bench 1 8 0'],
+            env=rec_env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertFalse(
+            self.result_jsonl.exists() and self.result_jsonl.read_text().strip(),
+            msg="a failed replay must not append a result line",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -270,6 +270,44 @@ def _as_bool(v) -> bool:
     return bool(v)
 
 
+def _targeting_shape(h: dict) -> tuple[int, int, str]:
+    """Resolve the ISL/OSL the KERNEL agents should optimize against.
+
+    The bench client no longer measures with these -- an AgentX handoff drives
+    aiperf's trace replay, which owns the sequence lengths. But the agents still
+    read isl/osl as the analytic serving call model when they synthesize
+    GEMM/attention shapes, so on a trace replay the synthetic 1024/1024
+    defaults would aim the whole search two orders of magnitude below the real
+    load (the corpus averages ~112k input tokens per request).
+
+    ``workload_spec.observed_isl/observed_osl`` carry the shape the orchestrator
+    MEASURED on its own baseline. Prefer them; fall back to the synthetic
+    workload block when they are absent so non-AgentX runs are untouched.
+
+    Returns ``(isl, osl, provenance)``.
+    """
+    workload = h.get("workload") or {}
+    syn_isl = int(workload.get("isl", 1024) or 1024)
+    syn_osl = int(workload.get("osl", 1024) or 1024)
+    spec = h.get("workload_spec")
+    if not isinstance(spec, dict) or str(spec.get("kind") or "") != WORKLOAD_KIND_AGENTX:
+        return syn_isl, syn_osl, "handoff_workload"
+    try:
+        obs_isl = int(spec.get("observed_isl") or 0)
+        obs_osl = int(spec.get("observed_osl") or 0)
+    except (TypeError, ValueError):
+        obs_isl = obs_osl = 0
+    if obs_isl <= 0 or obs_osl <= 0:
+        sys.stderr.write(
+            "!!! AgentX workload carries no observed_isl/observed_osl; kernel "
+            f"targeting falls back to the synthetic {syn_isl}/{syn_osl}, which "
+            "is far below the real replay shape. Kernel choices may be aimed at "
+            "the wrong regime (the MEASUREMENT is unaffected).\n"
+        )
+        return syn_isl, syn_osl, "synthetic_fallback_on_agentx"
+    return obs_isl, obs_osl, "agentx_observed"
+
+
 def map_args(h: dict, timeout_s: int | None = None) -> dict:
     workload = h.get("workload") or {}
     tp = int(h.get("tp", 1) or 1)
@@ -312,14 +350,18 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
     # gpu_ids is the optimization-parallelism pool AND the serving device set.
     # Default to 0..tp-1 so serving honours the requested tensor-parallel size.
     gpu_ids = h.get("gpu_ids") or ",".join(str(i) for i in range(max(tp, 1)))
+    target_isl, target_osl, shape_provenance = _targeting_shape(h)
     ps_args = {
         "model_path": h["model_path"],
         "workflow_dir": str(E2E_DIR),
         "backend": h.get("framework", "sglang"),
         "tp": tp,
         "gpu_ids": str(gpu_ids),
-        "isl": int(workload.get("isl", 1024)),
-        "osl": int(workload.get("osl", 1024)),
+        # On an AgentX handoff these describe the shape the agents OPTIMIZE for,
+        # not the shape anything is measured at (see _targeting_shape).
+        "isl": target_isl,
+        "osl": target_osl,
+        "workload_shape_provenance": shape_provenance,
         "conc": int(workload.get("conc", 64)),
         # Seed the baseline with Hyperloom's accepted best config so the
         # baseline == Hyperloom best config (fair engagement start).
@@ -574,18 +616,26 @@ def build_prompt(ps_args: dict) -> str:
 def apply_bench_client(h: dict) -> str:
     """Decide + export the bench CLIENT so workflow bench_e2e.sh calls inherit it.
 
-    handoff.bench_client: "auto" (default) | "inferencex" | "native".
-    "auto" => use InferenceX's benchmark_serving.py (measurement-protocol-identical to the
-    caller's Magpie harness) when an InferenceX checkout is discoverable, else
-    fall back to each backend's native client. The value is exported into the
-    environment so every ``bench_e2e.sh`` invocation the agents make inherits it.
+    handoff.bench_client: "auto" (default) | "inferencex" | "native" | "agentx".
+    "auto" => when ``workload_spec.kind`` is AgentX trace replay, select the
+    aiperf client; else use InferenceX's benchmark_serving.py when an InferenceX
+    checkout is discoverable, else fall back to each backend's native client.
+    The value is exported into the environment so every ``bench_e2e.sh``
+    invocation the agents make inherits it.
     """
     requested = str(h.get("bench_client", "auto") or "auto").strip().lower()
     ix_path = str(h.get("inferencex_path") or os.environ.get("INFERENCEX_PATH", "")).strip()
     if ix_path:
         os.environ["INFERENCEX_PATH"] = ix_path
+    spec = h.get("workload_spec")
+    spec_kind = str(spec.get("kind") or "").strip() if isinstance(spec, dict) else ""
     if requested == "auto":
-        client = "inferencex" if ix_path else "native"
+        if spec_kind == WORKLOAD_KIND_AGENTX:
+            client = AGENTX_BENCH_CLIENT
+        elif ix_path:
+            client = "inferencex"
+        else:
+            client = "native"
     else:
         client = requested
     if client == "inferencex" and not ix_path:
@@ -594,8 +644,116 @@ def apply_bench_client(h: dict) -> str:
             "falling back to native client (measurement protocol NOT aligned).\n"
         )
         client = "native"
+    # AgentX workloads must never silently fall back to a synthetic client: the
+    # handoff's isl/osl are placeholders and a synthetic sweep would produce a
+    # plausible-looking number on the wrong load (measured ~2.76x on Kimi-K3).
+    if (
+        spec_kind == WORKLOAD_KIND_AGENTX
+        and client != AGENTX_BENCH_CLIENT
+        and os.environ.get("GEAK_ALLOW_SYNTHETIC_ON_AGENTX", "").strip().lower()
+        not in ("1", "true", "yes", "on")
+    ):
+        sys.stderr.write(
+            f"bench_client={client!r} requested on an AgentX handoff "
+            f"(workload_spec.kind={spec_kind!r}); forcing bench_client="
+            f"{AGENTX_BENCH_CLIENT!r}. Set GEAK_ALLOW_SYNTHETIC_ON_AGENTX=1 to "
+            "opt into a synthetic client for debugging only.\n"
+        )
+        client = AGENTX_BENCH_CLIENT
     os.environ["BENCH_CLIENT"] = client
     return client
+
+
+def apply_workload_spec(h: dict) -> dict:
+    """Export AgentX workload identity so bench_e2e.sh drives the trace replay.
+
+    Only fires when ``handoff.workload_spec.kind`` is ``agentx_trace_replay``.
+    Absence preserves today's synthetic ISL/OSL path exactly. When active, marks
+    fixed ISL/OSL as inactive so adapters refuse to treat them as the served load.
+    """
+    spec = h.get("workload_spec")
+    if not isinstance(spec, dict) or str(spec.get("kind") or "") != WORKLOAD_KIND_AGENTX:
+        return {}
+    exported: dict[str, str] = {}
+    os.environ["GEAK_WORKLOAD_KIND"] = WORKLOAD_KIND_AGENTX
+    os.environ["GEAK_ISL_OSL_INACTIVE"] = "1"
+    # Long agentic windows: one repeat unless the caller explicitly overrides.
+    if "REPEATS" not in os.environ:
+        os.environ["REPEATS"] = "1"
+        exported["REPEATS"] = "1"
+    mapping = (
+        ("scenario", "GEAK_AGENTX_SCENARIO"),
+        ("corpus", "AGENTX_DATASET"),
+        ("canonical_corpus", "AGENTX_CANONICAL_DATASET"),
+        ("num_entries", "AGENTX_NUM_ENTRIES"),
+        ("duration_s", "GEAK_AGENTX_DURATION_S"),
+        ("geak_loop_duration_s", "GEAK_AGENTX_LOOP_DURATION_S"),
+        ("warmup_requests_per_lane", "AGENTX_WARMUP_REQUESTS_PER_LANE"),
+        ("warmup_grace_period_s", "AGENTX_WARMUP_GRACE_PERIOD"),
+        ("failed_request_threshold", "AGENTX_FAILED_REQUEST_THRESHOLD"),
+    )
+    for spec_key, env_key in mapping:
+        val = spec.get(spec_key)
+        if val is None or str(val).strip() == "":
+            continue
+        os.environ[env_key] = str(val)
+        exported[env_key] = str(val)
+    conc = spec.get("concurrency")
+    if conc is not None and str(conc).strip():
+        os.environ["CONC"] = str(conc)
+        exported["CONC"] = str(conc)
+    metric_basis = str(spec.get("metric_basis") or "").strip()
+    if metric_basis:
+        os.environ["GEAK_METRIC_BASIS"] = metric_basis
+        exported["GEAK_METRIC_BASIS"] = metric_basis
+    return exported
+
+
+def agentx_preflight(h: dict) -> list[str]:
+    """Report missing AgentX prerequisites BEFORE the run burns a server launch.
+
+    aiperf is not in the base serving image -- the orchestrator pip-installs it
+    into its own environment as part of enabling AgentX. When GEAK is dispatched
+    into a container that never ran that install, the client adapter cannot
+    discover the gap until it has already launched and warmed a server, which on
+    this model is a ~20 minute detour to reach a one-line error. This states the
+    gap at dispatch instead.
+
+    Returns human-readable problem strings (empty when the run can proceed).
+    Deliberately NON-fatal: PATH inside the bench subprocess is not always the
+    PATH here, so a hard abort could refuse a run that would have worked.
+    """
+    spec = h.get("workload_spec")
+    if not isinstance(spec, dict) or str(spec.get("kind") or "") != WORKLOAD_KIND_AGENTX:
+        return []
+    problems: list[str] = []
+    aiperf_bin = os.environ.get("AIPERF_BIN", "").strip() or "aiperf"
+    if not (
+        shutil.which(aiperf_bin)
+        or (os.path.isabs(aiperf_bin) and os.access(aiperf_bin, os.X_OK))
+    ):
+        problems.append(
+            f"aiperf not found on PATH (looked for {aiperf_bin!r}); the AgentX "
+            "client cannot replay traces. Install the AgentX-capable aiperf "
+            "into this environment, or set AIPERF_BIN to its path."
+        )
+    ix_root = os.environ.get("INFERENCEX_PATH", "").strip()
+    if not ix_root:
+        problems.append(
+            "INFERENCEX_PATH is unset, so map_aiperf.py cannot be located to "
+            "convert the aiperf export into a canonical result."
+        )
+    elif not any(
+        os.path.isfile(os.path.join(ix_root, rel))
+        for rel in ("benchmarks/map_aiperf.py", "assets/agentx/map_aiperf.py")
+    ):
+        problems.append(
+            f"map_aiperf.py not found under INFERENCEX_PATH={ix_root!r} "
+            "(expected benchmarks/ or assets/agentx/)."
+        )
+    for problem in problems:
+        sys.stderr.write(f"!!! AgentX preflight: {problem}\n")
+    return problems
 
 
 # ---------------------------------------------------------------------------
@@ -611,6 +769,24 @@ _MAGPIE_BACKENDS = {"sglang", "vllm"}
 # ``envs:`` mapping: these fields are optional launch-discovery hints, whereas
 # malformed environment replay must follow the strict fail-closed path.
 _RECIPE_KEYS = ("inferencex_path", "benchmark_script", "framework", "runner_type")
+
+# A cross-harness ratio only means something when both sides measured the same
+# WORKLOAD, and the way that breaks is silent. In the orchestrator's AgentX mode
+# the served load is a replay of real agentic traces (p50 ~89k input tokens, p99
+# past 500k) while the handoff still carries the CLI's synthetic isl/osl
+# defaults of 1024/1024 -- roughly two orders of magnitude apart. A GEAK run that
+# takes those defaults at face value measures a ~1k-token synthetic sweep and
+# then divides it into an agentic denominator. Measured on Kimi-K3: 465.7
+# synthetic tok/s over the 169.0 tok/s agentic baseline presents as a 2.76x win
+# with no kernel changed at all.
+#
+# The KIND of workload is the discriminator, not metric_basis -- both sides
+# report aggregate_output_tok_s, so the bases match while the loads do not.
+AGENTX_CLIENT_SCRIPT = "aiperf_client.sh"
+AGENTX_BENCH_CLIENT = "agentx"
+WORKLOAD_KIND_AGENTX = "agentx_trace_replay"
+WORKLOAD_KIND_SYNTHETIC = "synthetic_isl_osl"
+WORKLOAD_KIND_UNKNOWN = "unknown"
 
 # Names the recipe may carry that GEAK must nevertheless own, because they
 # address THIS run's resources rather than the served configuration. Replaying
@@ -1431,39 +1607,49 @@ def apply_bench_protocol(h: dict) -> dict:
     if int(h.get("schema_version", 1) or 1) >= 2 and isinstance(
         h.get("baseline_env_spec"), dict
     ):
-        # Cache-cold parity uses one measured client invocation on a fresh
-        # server. InferenceX still receives 2*concurrency internal warmups,
-        # which repeat prompt[0] to warm kernels/graphs without pre-populating
-        # the remaining timed prompts in the prefix cache.
-        # Some historical handoffs recorded an older small NUM_WARMUPS value;
-        # keep the observed 2*concurrency client behavior while changing only
-        # whether the separate outer full replay runs.
-        workload = h.get("workload") or {}
-        conc = max(1, int(workload.get("conc", 1) or 1))
+        # Cache-cold parity on a fresh server per timed replica is about the
+        # SERVER lifecycle, so it holds for either workload kind.
         aligned = {
-            "NUM_WARMUPS": str(2 * conc),
-            "SEED": "0",
-            "RANDOM_RANGE_RATIO": "1",
             "GEAK_REPEAT_MODE": "isolated_server",
             "REPLICA_RETRIES": "1",
         }
-        # NUM_PROMPTS was the one protocol knob this block did not align, and
-        # the two sides disagree by default: bench_e2e.sh falls back to Magpie's
-        # fixed CONC*10, while the caller's own materializer scales the count
-        # DOWN as the per-request sequence cost grows
-        # ({<=1024:10, <=4096:5, <=16384:3, else 2} * CONC -- Hyperloom
-        # ``_workload_envs.py``). At ISL+OSL=2048 that is 5*CONC there against
-        # 10*CONC here: a different saturation regime, so a different tok/s,
-        # measured under a header claiming the protocols match.
-        #
-        # bench_e2e.sh already implements that exact table (same thresholds,
-        # same max(CONC*factor, CONC) clamp) behind NUM_PROMPTS_ADAPTIVE, so
-        # aligning means switching it on rather than restating the arithmetic
-        # in a second place that can drift. Only when the handoff did NOT pin a
-        # count: an explicit num_prompts is the caller telling us what it
-        # measured, and it still wins.
-        if not str(protocol.get("num_prompts") or "").strip():
-            aligned["NUM_PROMPTS_ADAPTIVE"] = "1"
+        # The remaining knobs shape a SYNTHETIC prompt sweep and only mean
+        # something when both sides measured one. AgentX replays a fixed trace
+        # corpus with its own seed and warmup contract, so fabricating prompt
+        # counts or a range ratio for it would describe a workload nobody ran.
+        if _baseline_workload_kind(h)[0] != WORKLOAD_KIND_AGENTX:
+            # NUM_PROMPTS was the one protocol knob this block did not align, and
+            # the two sides disagree by default: bench_e2e.sh falls back to Magpie's
+            # fixed CONC*10, while the caller's own materializer scales the count
+            # DOWN as the per-request sequence cost grows
+            # ({<=1024:10, <=4096:5, <=16384:3, else 2} * CONC -- Hyperloom
+            # ``_workload_envs.py``). At ISL+OSL=2048 that is 5*CONC there against
+            # 10*CONC here: a different saturation regime, so a different tok/s,
+            # measured under a header claiming the protocols match.
+            #
+            # bench_e2e.sh already implements that exact table (same thresholds,
+            # same max(CONC*factor, CONC) clamp) behind NUM_PROMPTS_ADAPTIVE, so
+            # aligning means switching it on rather than restating the arithmetic
+            # in a second place that can drift. Only when the handoff did NOT pin a
+            # count: an explicit num_prompts is the caller telling us what it
+            # measured, and it still wins.
+            if not str(protocol.get("num_prompts") or "").strip():
+                aligned["NUM_PROMPTS_ADAPTIVE"] = "1"
+            # InferenceX receives 2*concurrency internal warmups, which repeat
+            # prompt[0] to warm kernels/graphs without pre-populating the
+            # remaining timed prompts in the prefix cache.
+            # Some historical handoffs recorded an older small NUM_WARMUPS value;
+            # keep the observed 2*concurrency client behavior while changing only
+            # whether the separate outer full replay runs.
+            workload = h.get("workload") or {}
+            conc = max(1, int(workload.get("conc", 1) or 1))
+            aligned.update(
+                {
+                    "NUM_WARMUPS": str(2 * conc),
+                    "SEED": "0",
+                    "RANDOM_RANGE_RATIO": "1",
+                }
+            )
         for env_var, value in aligned.items():
             os.environ[env_var] = value
             exported[env_var] = value
@@ -1947,6 +2133,79 @@ def _state_op_names(wf: dict, queue: str) -> set[str]:
         if isinstance(op, dict) and op.get("short_name"):
             names.add(str(op["short_name"]))
     return names
+
+
+def _baseline_workload_kind(h: dict) -> tuple[str, str]:
+    """Classify the WORKLOAD the orchestrator's baseline number was measured on.
+
+    Preference order matters. ``workload_spec.kind`` is the orchestrator stating
+    its own workload explicitly and is therefore authoritative whenever present.
+    Older handoffs (every one written before that field existed, including the
+    Kimi-K3 campaign's) carry no such statement, so fall back to the one signal
+    they do carry: AgentX mode is what rewrites the recipe's ``benchmark_script``
+    to the aiperf CLIENT, which is the same sentinel the orchestrator's own
+    launcher resolver keys on.
+
+    Returns (kind, source). ``unknown`` means the handoff said nothing either
+    way and callers must NOT infer a mismatch from it -- see
+    :func:`_workload_comparability`.
+    """
+    spec = h.get("workload_spec")
+    if isinstance(spec, dict):
+        kind = str(spec.get("kind") or "").strip()
+        if kind:
+            return kind, "handoff.workload_spec.kind"
+    recipe_script = str(
+        _recipe_fields(str(h.get("launch_recipe") or "")).get("benchmark_script", "")
+    ).strip()
+    if recipe_script:
+        if os.path.basename(recipe_script) == AGENTX_CLIENT_SCRIPT:
+            return WORKLOAD_KIND_AGENTX, "launch_recipe.benchmark_script"
+        return WORKLOAD_KIND_SYNTHETIC, "launch_recipe.benchmark_script"
+    return WORKLOAD_KIND_UNKNOWN, "unavailable"
+
+
+def _geak_workload_kind() -> str:
+    """Classify the workload GEAK itself measured, from the bench client used."""
+    client = os.environ.get("BENCH_CLIENT", "native").strip().lower()
+    if client == AGENTX_BENCH_CLIENT:
+        return WORKLOAD_KIND_AGENTX
+    return WORKLOAD_KIND_SYNTHETIC
+
+
+def _workload_comparability(h: dict) -> dict:
+    """Decide whether GEAK's numbers may be divided into the orchestrator's.
+
+    The rule is deliberately asymmetric: suppress ONLY on a positive mismatch
+    between two KNOWN kinds. An unknown baseline kind keeps today's behaviour
+    exactly, which is what lets this guard ship without touching the established
+    fixed-ISL/OSL path -- those handoffs classify as ``synthetic_isl_osl`` (or
+    ``unknown`` on older writers) and GEAK's synthetic client agrees, so every
+    cross-harness field they publish today keeps its value.
+    """
+    baseline_kind, baseline_source = _baseline_workload_kind(h)
+    geak_kind = _geak_workload_kind()
+    both_known = WORKLOAD_KIND_UNKNOWN not in (baseline_kind, geak_kind)
+    comparable = (not both_known) or baseline_kind == geak_kind
+    if comparable:
+        reason = None
+    else:
+        reason = (
+            f"orchestrator baseline measured '{baseline_kind}' but GEAK measured "
+            f"'{geak_kind}'; a ratio between them would report a workload "
+            f"difference as a kernel speedup"
+        )
+    return {
+        "comparable": comparable,
+        "orchestrator_workload_kind": baseline_kind,
+        "orchestrator_workload_kind_source": baseline_source,
+        "geak_workload_kind": geak_kind,
+        # metric_basis is NOT the discriminator: an agentic replay and a
+        # synthetic sweep both report aggregate_output_tok_s, so matching bases
+        # say nothing about whether the underlying loads were the same.
+        "metric_basis_discriminates": False,
+        "suppressed_reason": reason,
+    }
 
 
 def _divergence_pct(measured: Any, reference: Any) -> float | None:
@@ -2453,6 +2712,21 @@ def normalize_result(h: dict, wf: dict) -> dict:
     raw_session_divergence_pct = _divergence_pct(geak_baseline, orch_baseline)
     same_config_divergence_pct = _divergence_pct(geak_baseline, orch_same_cfg)
 
+    # ── workload comparability gate ───────────────────────────────────────────
+    # Everything that divides a GEAK measurement by an ORCHESTRATOR measurement
+    # is only defined when both measured the same workload. When they did not,
+    # publish None rather than a number: a suppressed field forces a reviewer to
+    # look, whereas a plausible-looking ratio invites the exact false claim this
+    # guard exists to prevent. The raw inputs on both sides stay published for
+    # audit, and every WITHIN-GEAK ratio (hot_geak_speedup, cold_geak_speedup,
+    # baseline_drift_pct, the cold penalties) is untouched -- those compare two
+    # GEAK legs measured on the same workload and remain valid regardless.
+    workload_comparability = _workload_comparability(h)
+    cross_harness_ok = bool(workload_comparability["comparable"])
+    if not cross_harness_ok:
+        raw_session_divergence_pct = None
+        same_config_divergence_pct = None
+
     # ── serving-stack provenance ─────────────────────────────────────────────
     # WHO launched the server, and WHAT kernels it selected. A cross-harness
     # comparison only means something when both sides served the same stack, and
@@ -2505,8 +2779,11 @@ def normalize_result(h: dict, wf: dict) -> dict:
         # Gain measured against the ORCHESTRATOR baseline (what Hyperloom sees end-to-end).
         "gain_vs_orchestrator_baseline": (
             round(geak_final / orch_baseline, 4)
-            if (geak_final > 0 and orch_baseline > 0) else None
+            if (cross_harness_ok and geak_final > 0 and orch_baseline > 0) else None
         ),
+        # Why the cross-harness fields above hold numbers or None. Always
+        # published, so "comparable" is an asserted fact rather than an absence.
+        "workload_comparability": workload_comparability,
         # Measurement-protocol provenance so the comparison is self-describing.
         "bench_client": os.environ.get("BENCH_CLIENT", "native"),
         "bench_protocol": h.get("bench_protocol") or {},
@@ -2555,9 +2832,16 @@ def normalize_result(h: dict, wf: dict) -> dict:
         "geak_cold_baseline_tok_s": geak_cold_baseline,
         "orchestrator_cold_baseline_tok_s": orch_baseline or None,   # == handoff.raw_baseline_tput (leaderboard anchor)
         "orchestrator_hot_baseline_tok_s": orch_hot_baseline or None,
-        "hot_speedup": _safe_ratio(geak_hot_final, orch_hot_baseline),
+        # The two cross-harness ratios are gated on workload comparability; the
+        # two within-GEAK ones beside them are not, because both of their legs
+        # were measured by the same client on the same workload.
+        "hot_speedup": (
+            _safe_ratio(geak_hot_final, orch_hot_baseline) if cross_harness_ok else None
+        ),
         "hot_geak_speedup": _safe_ratio(geak_hot_final, geak_hot_baseline),
-        "cold_speedup": _safe_ratio(geak_cold_final, orch_baseline),
+        "cold_speedup": (
+            _safe_ratio(geak_cold_final, orch_baseline) if cross_harness_ok else None
+        ),
         "cold_geak_speedup": _safe_ratio(geak_cold_final, geak_cold_baseline),
         # Which two rounds cold_geak_speedup divides: "same_session" is a valid
         # A/B, "setup_vs_validate" is a comparison across thermal states and the
@@ -4771,6 +5055,8 @@ def main(argv: list[str]) -> int:
     _publish_protected_pgids()
     bench_client = apply_bench_client(h)
     bench_launcher = apply_bench_launcher(h)
+    workload_exports = apply_workload_spec(h)
+    workload_preflight = agentx_preflight(h)
     bench_protocol = apply_bench_protocol(h)
     alignment_flags = apply_alignment_flags(h)
     prompt = build_prompt(ps_args)
@@ -4778,6 +5064,8 @@ def main(argv: list[str]) -> int:
     if "--dry-run" in flags:
         print(json.dumps({"mapped_args": ps_args, "bench_client": bench_client,
                           "bench_launcher": bench_launcher,
+                          "workload_spec_exports": workload_exports,
+                          "agentx_preflight_problems": workload_preflight,
                           "magpie_launch_script": os.environ.get("MAGPIE_LAUNCH_SCRIPT", ""),
                           "magpie_launch_script_source": os.environ.get("MAGPIE_LAUNCH_SCRIPT_SOURCE", ""),
                           "recipe_env_file": os.environ.get("RECIPE_ENV_FILE", ""),

--- a/interface/test_run_e2e_dispatch.py
+++ b/interface/test_run_e2e_dispatch.py
@@ -447,6 +447,54 @@ class TestBenchClient(_RunE2ECase):
         os.environ["INFERENCEX_PATH"] = "/env/inferencex"
         self.assertEqual(rx.apply_bench_client({"bench_client": "auto"}), "inferencex")
 
+    def test_auto_selects_agentx_when_workload_spec_says_so(self):
+        os.environ.pop("INFERENCEX_PATH", None)
+        h = {
+            "inferencex_path": "/opt/inferencex",
+            "workload_spec": {"kind": rx.WORKLOAD_KIND_AGENTX, "client": "aiperf"},
+        }
+        self.assertEqual(rx.apply_bench_client(h), rx.AGENTX_BENCH_CLIENT)
+        self.assertEqual(os.environ["BENCH_CLIENT"], rx.AGENTX_BENCH_CLIENT)
+
+    def test_agentx_handoff_forces_agentx_over_explicit_inferencex(self):
+        os.environ["INFERENCEX_PATH"] = "/opt/inferencex"
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            client = rx.apply_bench_client(
+                {
+                    "bench_client": "inferencex",
+                    "inferencex_path": "/opt/inferencex",
+                    "workload_spec": {"kind": rx.WORKLOAD_KIND_AGENTX},
+                }
+            )
+        self.assertEqual(client, rx.AGENTX_BENCH_CLIENT)
+        self.assertIn("forcing bench_client", err.getvalue())
+
+    def test_apply_workload_spec_exports_agentx_knobs(self):
+        os.environ.pop("GEAK_WORKLOAD_KIND", None)
+        os.environ.pop("GEAK_ISL_OSL_INACTIVE", None)
+        os.environ.pop("REPEATS", None)
+        exported = rx.apply_workload_spec(
+            {
+                "workload_spec": {
+                    "kind": rx.WORKLOAD_KIND_AGENTX,
+                    "scenario": "inferencex-agentx-mvp",
+                    "corpus": "semianalysis_cc_traces_weka_062126",
+                    "duration_s": 3600,
+                    "geak_loop_duration_s": 900,
+                    "concurrency": 8,
+                }
+            }
+        )
+        self.assertEqual(os.environ["GEAK_WORKLOAD_KIND"], rx.WORKLOAD_KIND_AGENTX)
+        self.assertEqual(os.environ["GEAK_ISL_OSL_INACTIVE"], "1")
+        self.assertEqual(os.environ["AGENTX_DATASET"], "semianalysis_cc_traces_weka_062126")
+        self.assertEqual(exported["REPEATS"], "1")
+
+    def test_apply_workload_spec_noop_on_synthetic_handoff(self):
+        os.environ.pop("GEAK_WORKLOAD_KIND", None)
+        self.assertEqual(rx.apply_workload_spec({"workload": {"isl": 1024}}), {})
+        self.assertNotIn("GEAK_WORKLOAD_KIND", os.environ)
+
     def test_explicit_inferencex_without_path_degrades_loudly(self):
         """Silently measuring with a different client than the orchestrator is
         the failure this warning exists to prevent."""
@@ -1091,6 +1139,169 @@ class TestBenchProtocol(_RunE2ECase):
         })
         self.assertEqual(exported["NUM_PROMPTS_ADAPTIVE"], "1")
         self.assertNotIn("NUM_PROMPTS", exported)
+
+    def test_agentx_keeps_the_fresh_server_lifecycle_but_drops_sweep_knobs(self):
+        """Server hygiene is workload-independent; prompt-sweep knobs are not.
+
+        A fresh server per timed replica is about cache-cold parity, so AgentX
+        needs it just as much. NUM_WARMUPS/SEED/RANDOM_RANGE_RATIO describe a
+        synthetic prompt sweep that the trace replay never performs.
+        """
+        exported = rx.apply_bench_protocol({
+            "schema_version": 2,
+            "workload": {"conc": 64},
+            "baseline_env_spec": {"config": {}},
+            "workload_spec": {"kind": "agentx_trace_replay"},
+            "bench_protocol": {},
+        })
+        self.assertEqual(exported["GEAK_REPEAT_MODE"], "isolated_server")
+        self.assertEqual(exported["REPLICA_RETRIES"], "1")
+        for synthetic in ("NUM_WARMUPS", "SEED", "RANDOM_RANGE_RATIO"):
+            self.assertNotIn(synthetic, exported)
+            self.assertNotIn(synthetic, os.environ)
+
+
+class TestTargetingShape(_RunE2ECase):
+    """isl/osl stop being the measured load on AgentX, but still aim the search.
+
+    The kernel agents read isl/osl as the analytic serving call model when they
+    synthesize GEMM/attention shapes. A trace replay whose corpus averages ~112k
+    input tokens would be optimized for a 1024-token prefill if the synthetic
+    handoff defaults were taken at face value -- honest numbers, wrong target.
+    """
+
+    def test_synthetic_handoff_keeps_the_handoff_workload_shape(self):
+        isl, osl, prov = rx._targeting_shape(
+            {"workload": {"isl": 2048, "osl": 512}}
+        )
+        self.assertEqual((isl, osl), (2048, 512))
+        self.assertEqual(prov, "handoff_workload")
+
+    def test_synthetic_handoff_falls_back_to_1024_defaults(self):
+        isl, osl, prov = rx._targeting_shape({})
+        self.assertEqual((isl, osl), (1024, 1024))
+        self.assertEqual(prov, "handoff_workload")
+
+    def test_agentx_prefers_the_orchestrator_measured_shape(self):
+        isl, osl, prov = rx._targeting_shape({
+            "workload": {"isl": 1024, "osl": 1024},
+            "workload_spec": {
+                "kind": "agentx_trace_replay",
+                "observed_isl": 112020,
+                "observed_osl": 796,
+            },
+        })
+        self.assertEqual((isl, osl), (112020, 796))
+        self.assertEqual(prov, "agentx_observed")
+
+    def test_agentx_without_an_observed_shape_says_so_loudly(self):
+        """Silence here would aim the search 100x low with no trace of why."""
+        isl, osl, prov = rx._targeting_shape({
+            "workload": {"isl": 1024, "osl": 1024},
+            "workload_spec": {"kind": "agentx_trace_replay"},
+        })
+        self.assertEqual((isl, osl), (1024, 1024))
+        self.assertEqual(prov, "synthetic_fallback_on_agentx")
+
+    def test_a_malformed_observed_shape_is_not_trusted(self):
+        for bad in ("", "abc", 0, -5, None):
+            with self.subTest(observed=bad):
+                _isl, _osl, prov = rx._targeting_shape({
+                    "workload": {"isl": 1024, "osl": 1024},
+                    "workload_spec": {
+                        "kind": "agentx_trace_replay",
+                        "observed_isl": bad,
+                        "observed_osl": 796,
+                    },
+                })
+                self.assertEqual(prov, "synthetic_fallback_on_agentx")
+
+    def test_map_args_carries_the_shape_and_its_provenance(self):
+        ps = rx.map_args({
+            "model_path": "/models/Kimi-K3",
+            "workload": {"isl": 1024, "osl": 1024, "conc": 8},
+            "exp_root": str(self.tmp),
+            "eval_dir": str(self.tmp / "eval"),
+            "workload_spec": {
+                "kind": "agentx_trace_replay",
+                "observed_isl": 112020,
+                "observed_osl": 796,
+            },
+        })
+        self.assertEqual(ps["isl"], 112020)
+        self.assertEqual(ps["osl"], 796)
+        self.assertEqual(ps["workload_shape_provenance"], "agentx_observed")
+        # Concurrency still comes from the workload block (the replay honours it).
+        self.assertEqual(ps["conc"], 8)
+
+    def test_map_args_is_byte_identical_for_synthetic_runs(self):
+        base = {
+            "model_path": "/models/m",
+            "workload": {"isl": 4096, "osl": 256, "conc": 32},
+            "exp_root": str(self.tmp),
+            "eval_dir": str(self.tmp / "eval"),
+        }
+        ps = rx.map_args(dict(base))
+        self.assertEqual(ps["isl"], 4096)
+        self.assertEqual(ps["osl"], 256)
+        self.assertEqual(ps["workload_shape_provenance"], "handoff_workload")
+
+
+class TestAgentXPreflight(_RunE2ECase):
+    """An AgentX dispatch should name a missing prerequisite immediately.
+
+    aiperf is absent from the base serving image (the orchestrator installs it
+    when it enables AgentX), and the client adapter cannot notice until it has
+    already launched and warmed a server -- a long detour to reach a one-line
+    error on this model.
+    """
+
+    AGENTX = {"workload_spec": {"kind": "agentx_trace_replay"}}
+
+    def test_synthetic_handoff_is_never_preflighted(self):
+        self.assertEqual(rx.agentx_preflight({}), [])
+        self.assertEqual(
+            rx.agentx_preflight({"workload_spec": {"kind": "synthetic_isl_osl"}}), []
+        )
+
+    def test_missing_aiperf_is_reported_with_the_name_it_looked_for(self):
+        os.environ["PATH"] = "/nonexistent"
+        os.environ["AIPERF_BIN"] = "aiperf-agentx"
+        problems = rx.agentx_preflight(dict(self.AGENTX))
+        self.assertTrue(any("aiperf-agentx" in p for p in problems))
+
+    def test_missing_inferencex_path_is_reported(self):
+        os.environ.pop("INFERENCEX_PATH", None)
+        problems = rx.agentx_preflight(dict(self.AGENTX))
+        self.assertTrue(any("INFERENCEX_PATH is unset" in p for p in problems))
+
+    def test_inferencex_path_without_the_mapper_is_reported(self):
+        os.environ["INFERENCEX_PATH"] = str(self.tmp)
+        problems = rx.agentx_preflight(dict(self.AGENTX))
+        self.assertTrue(any("map_aiperf.py not found" in p for p in problems))
+
+    def test_a_satisfied_environment_reports_no_problems(self):
+        bench = os.path.join(str(self.tmp), "benchmarks")
+        os.makedirs(bench, exist_ok=True)
+        with open(os.path.join(bench, "map_aiperf.py"), "w") as fh:
+            fh.write("# stub\n")
+        bin_dir = os.path.join(str(self.tmp), "bin")
+        os.makedirs(bin_dir, exist_ok=True)
+        aiperf = os.path.join(bin_dir, "aiperf")
+        with open(aiperf, "w") as fh:
+            fh.write("#!/bin/sh\n")
+        os.chmod(aiperf, 0o755)
+        os.environ["PATH"] = bin_dir
+        os.environ["INFERENCEX_PATH"] = str(self.tmp)
+        os.environ.pop("AIPERF_BIN", None)
+        self.assertEqual(rx.agentx_preflight(dict(self.AGENTX)), [])
+
+    def test_preflight_is_advisory_and_does_not_raise(self):
+        """PATH here is not always PATH in the bench subprocess."""
+        os.environ["PATH"] = "/nonexistent"
+        os.environ.pop("INFERENCEX_PATH", None)
+        problems = rx.agentx_preflight(dict(self.AGENTX))
+        self.assertEqual(len(problems), 2)
 
 
 class TestAlignmentFlags(_RunE2ECase):

--- a/interface/test_run_e2e_dispatch.py
+++ b/interface/test_run_e2e_dispatch.py
@@ -488,6 +488,10 @@ class TestBenchClient(_RunE2ECase):
                     "duration_s": 3600,
                     "geak_loop_duration_s": 900,
                     "concurrency": 8,
+                    # The orchestrator names the axis it graded on; the replay
+                    # client has to measure that same axis or the two harnesses
+                    # report different quantities under one name.
+                    "metric_basis": "aggregate_output_tok_s",
                 }
             }
         )
@@ -495,6 +499,8 @@ class TestBenchClient(_RunE2ECase):
         self.assertEqual(os.environ["GEAK_ISL_OSL_INACTIVE"], "1")
         self.assertEqual(os.environ["AGENTX_DATASET"], "semianalysis_cc_traces_weka_062126")
         self.assertEqual(exported["REPEATS"], "1")
+        self.assertEqual(os.environ["GEAK_METRIC_BASIS"], "aggregate_output_tok_s")
+        self.assertEqual(exported["GEAK_METRIC_BASIS"], "aggregate_output_tok_s")
 
     def test_apply_workload_spec_noop_on_synthetic_handoff(self):
         os.environ.pop("GEAK_WORKLOAD_KIND", None)

--- a/interface/test_run_e2e_workload_comparability.py
+++ b/interface/test_run_e2e_workload_comparability.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Workload-comparability tests for run_e2e.normalize_result.
+
+A cross-harness ratio is only defined when both harnesses measured the same
+WORKLOAD, and the way that assumption breaks is silent. In the orchestrator's
+AgentX mode the served load is a replay of real agentic traces (p50 ~89k input
+tokens, p99 past 500k) while the handoff still carries the CLI's synthetic
+``isl``/``osl`` defaults of 1024/1024. A GEAK run that believes those defaults
+measures a ~1k-token synthetic sweep and divides it into an agentic denominator.
+
+That is not hypothetical. On Kimi-K3, GEAK's synthetic client measured 465.676
+tok/s at ISL/OSL=1024 against Hyperloom's 168.998 tok/s agentic baseline, which
+an ungated GEAK would publish as a 2.76x win with no kernel changed at all.
+
+Two contracts are under test, and the FIRST one is the reason the second is safe
+to ship:
+
+  1. INVARIANT -- the established fixed-ISL/OSL path is untouched. Those
+     handoffs classify as ``synthetic_isl_osl`` (or ``unknown`` on writers that
+     predate any workload signal) and GEAK's synthetic client agrees, so every
+     cross-harness field keeps exactly the value it has today. Suppression fires
+     only on a POSITIVE mismatch between two KNOWN kinds.
+  2. GUARD -- on a real mismatch every GEAK-over-orchestrator quantity becomes
+     None with a recorded reason, while every WITHIN-GEAK ratio survives, since
+     both of its legs were measured by the same client on the same workload.
+
+Run: python3 -m pytest GEAK/interface/test_run_e2e_workload_comparability.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+
+# The measured Kimi-K3 numbers behind this guard, kept as the fixture so a
+# regression reproduces the exact false claim rather than an invented one.
+HL_AGENTIC_BASELINE_TOK_S = 168.998
+GEAK_SYNTHETIC_TOK_S = 465.676
+FALSE_SPEEDUP = GEAK_SYNTHETIC_TOK_S / HL_AGENTIC_BASELINE_TOK_S  # ~2.76x
+
+# Every field that divides a GEAK measurement by an orchestrator measurement.
+CROSS_HARNESS_BASELINE_FIELDS = (
+    "raw_session_baseline_divergence_pct",
+    "current_best_same_config_divergence_pct",
+    "measurement_divergence_pct",
+    "gain_vs_orchestrator_baseline",
+)
+CROSS_HARNESS_ALIGNMENT_FIELDS = ("hot_speedup", "cold_speedup")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("run_e2e", _HERE / "run_e2e.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rx = _load()
+
+
+def _wf(eval_dir: Path, *, base: float, final: float, speedup: float) -> dict:
+    return {
+        "eval_dir": str(eval_dir),
+        "baseline_throughput_tok_s": base,
+        "final_throughput_tok_s": final,
+        "throughput_speedup": speedup,
+        "output_parity": "pass",
+    }
+
+
+def _recipe(tmp_path: Path, benchmark_script: str) -> str:
+    """Write a launch recipe carrying just the fields run_e2e scans for."""
+    path = tmp_path / f"recipe_{benchmark_script.replace('.', '_')}.yaml"
+    path.write_text(
+        "framework: vllm\n"
+        "runner_type: mi355x\n"
+        f"benchmark_script: {benchmark_script}\n"
+        "inferencex_path: /src/Hyperloom/.cache/InferenceX@3d55815\n",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _cold_legs(eval_dir: Path, *, base_cold: float, final_cold: float) -> None:
+    """Materialize the cold rounds so cold_speedup is actually exercised."""
+    (eval_dir / "baseline").mkdir(parents=True, exist_ok=True)
+    (eval_dir / "validation" / "final").mkdir(parents=True, exist_ok=True)
+    (eval_dir / "baseline" / "bench_summary.json").write_text(
+        json.dumps(
+            {
+                "output_throughput_tok_s_median": base_cold * 1.02,
+                "cold_output_throughput_tok_s": base_cold,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (eval_dir / "validation" / "final" / "bench_summary.json").write_text(
+        json.dumps(
+            {
+                "output_throughput_tok_s_median": final_cold * 1.02,
+                "cold_output_throughput_tok_s": final_cold,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+# ─────────────────────────── contract 1: the invariant ───────────────────────
+# These must keep passing unchanged. They are the fixed-ISL/OSL path.
+
+
+def test_synthetic_recipe_keeps_every_cross_harness_number(tmp_path: Path) -> None:
+    """A fixed-ISL/OSL recipe stays fully comparable: nothing is suppressed."""
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    h = {
+        "workload": {"isl": 1024, "osl": 1024, "conc": 64},
+        "raw_baseline_tput": 1331.7541295483402,
+        "orchestrator_best_tput_same_config": 1872.9515966860333,
+        # The ordinary case: the recipe names a SERVER launcher, not a client.
+        "launch_recipe": _recipe(tmp_path, "vllm_mi355x.sh"),
+    }
+    out = rx.normalize_result(
+        h, _wf(eval_dir, base=1785.741, final=2869.795, speedup=1.607)
+    )
+    bb = out["baseline_basis"]
+    wc = bb["workload_comparability"]
+
+    assert wc["comparable"] is True
+    assert wc["orchestrator_workload_kind"] == rx.WORKLOAD_KIND_SYNTHETIC
+    assert wc["orchestrator_workload_kind_source"] == "launch_recipe.benchmark_script"
+    assert wc["geak_workload_kind"] == rx.WORKLOAD_KIND_SYNTHETIC
+    assert wc["suppressed_reason"] is None
+
+    # The numbers this path has always published are still numbers.
+    for field in CROSS_HARNESS_BASELINE_FIELDS:
+        assert bb[field] is not None, f"{field} must survive on the synthetic path"
+    assert bb["current_best_same_config_divergence_pct"] == pytest.approx(
+        -4.66, abs=0.01
+    )
+    assert bb["measurement_divergence_pct"] == (
+        bb["current_best_same_config_divergence_pct"]
+    )
+
+
+def test_handoff_without_any_workload_signal_stays_comparable(
+    tmp_path: Path,
+) -> None:
+    """No recipe and no workload_spec must not be read as a mismatch.
+
+    Every handoff written before a workload signal existed lands here, so
+    inferring a mismatch from silence would retroactively blank the cross-harness
+    fields on runs that are perfectly valid.
+    """
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    h = {
+        "workload": {"isl": 16384, "osl": 512, "conc": 16},
+        "raw_baseline_tput": 498.81,
+        "orchestrator_best_tput_same_config": 537.15,
+    }
+    out = rx.normalize_result(h, _wf(eval_dir, base=537.354, final=532.119, speedup=0.99))
+    bb = out["baseline_basis"]
+    wc = bb["workload_comparability"]
+
+    assert wc["comparable"] is True
+    assert wc["orchestrator_workload_kind"] == rx.WORKLOAD_KIND_UNKNOWN
+    assert wc["orchestrator_workload_kind_source"] == "unavailable"
+    assert bb["raw_session_baseline_divergence_pct"] == pytest.approx(7.73, abs=0.01)
+    assert bb["current_best_same_config_divergence_pct"] == pytest.approx(
+        0.04, abs=0.01
+    )
+
+
+# ──────────────────────────── contract 2: the guard ──────────────────────────
+
+
+def test_agentx_baseline_vs_synthetic_geak_suppresses_the_false_speedup(
+    tmp_path: Path,
+) -> None:
+    """The measured Kimi-K3 mismatch must not publish its 2.76x."""
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    _cold_legs(eval_dir, base_cold=450.0, final_cold=GEAK_SYNTHETIC_TOK_S)
+    h = {
+        # The CLI defaults the handoff carries -- ~100x off the real load.
+        "workload": {"isl": 1024, "osl": 1024, "conc": 8},
+        "raw_baseline_tput": HL_AGENTIC_BASELINE_TOK_S,
+        "orchestrator_best_tput_same_config": HL_AGENTIC_BASELINE_TOK_S,
+        # AgentX rewrote benchmark_script to the aiperf CLIENT: the sentinel.
+        "launch_recipe": _recipe(tmp_path, rx.AGENTX_CLIENT_SCRIPT),
+    }
+    out = rx.normalize_result(
+        h,
+        _wf(
+            eval_dir,
+            base=GEAK_SYNTHETIC_TOK_S,
+            final=GEAK_SYNTHETIC_TOK_S,
+            speedup=1.0,
+        ),
+    )
+    bb = out["baseline_basis"]
+    am = out["alignment_metrics"]
+    wc = bb["workload_comparability"]
+
+    assert wc["comparable"] is False
+    assert wc["orchestrator_workload_kind"] == rx.WORKLOAD_KIND_AGENTX
+    assert wc["geak_workload_kind"] == rx.WORKLOAD_KIND_SYNTHETIC
+    assert "kernel speedup" in wc["suppressed_reason"]
+
+    for field in CROSS_HARNESS_BASELINE_FIELDS:
+        assert bb[field] is None, f"{field} must be suppressed across workload kinds"
+    for field in CROSS_HARNESS_ALIGNMENT_FIELDS:
+        assert am[field] is None, f"{field} must be suppressed across workload kinds"
+
+    # The specific number that must never appear anywhere in the payload.
+    assert FALSE_SPEEDUP == pytest.approx(2.7555, abs=1e-3)
+    published = json.dumps(out)
+    assert f"{FALSE_SPEEDUP:.4f}" not in published
+    assert f"{FALSE_SPEEDUP:.2f}" not in published
+
+
+def test_suppression_keeps_raw_inputs_and_within_geak_ratios(
+    tmp_path: Path,
+) -> None:
+    """Suppress the RATIOS, not the evidence.
+
+    A reviewer still needs both sides' raw measurements to see why the comparison
+    was refused, and the within-GEAK ratios remain valid because both of their
+    legs came from the same client on the same workload.
+    """
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    _cold_legs(eval_dir, base_cold=430.0, final_cold=480.0)
+    h = {
+        "workload": {"isl": 1024, "osl": 1024, "conc": 8},
+        "raw_baseline_tput": HL_AGENTIC_BASELINE_TOK_S,
+        "launch_recipe": _recipe(tmp_path, rx.AGENTX_CLIENT_SCRIPT),
+    }
+    out = rx.normalize_result(h, _wf(eval_dir, base=450.0, final=500.0, speedup=1.111))
+    bb = out["baseline_basis"]
+    am = out["alignment_metrics"]
+
+    # Evidence survives.
+    assert bb["orchestrator_baseline_tok_s"] == pytest.approx(
+        HL_AGENTIC_BASELINE_TOK_S
+    )
+    assert bb["geak_measured_baseline_tok_s"] == pytest.approx(450.0)
+    assert am["orchestrator_cold_baseline_tok_s"] == pytest.approx(
+        HL_AGENTIC_BASELINE_TOK_S
+    )
+
+    # Within-GEAK ratios survive; cross-harness ones do not.
+    assert am["hot_geak_speedup"] == pytest.approx(500.0 / 450.0, abs=1e-4)
+    assert am["cold_geak_speedup"] is not None
+    assert am["hot_speedup"] is None
+    assert am["cold_speedup"] is None
+
+
+def test_workload_spec_is_authoritative_over_the_recipe_sentinel(
+    tmp_path: Path,
+) -> None:
+    """An explicit workload_spec.kind wins, and is reported as the source."""
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    h = {
+        "workload": {"isl": 1024, "osl": 1024, "conc": 8},
+        "raw_baseline_tput": HL_AGENTIC_BASELINE_TOK_S,
+        # No recipe at all: without the spec this would be "unknown".
+        "workload_spec": {"kind": rx.WORKLOAD_KIND_AGENTX, "client": "aiperf"},
+    }
+    out = rx.normalize_result(h, _wf(eval_dir, base=465.0, final=470.0, speedup=1.01))
+    wc = out["baseline_basis"]["workload_comparability"]
+
+    assert wc["comparable"] is False
+    assert wc["orchestrator_workload_kind"] == rx.WORKLOAD_KIND_AGENTX
+    assert wc["orchestrator_workload_kind_source"] == "handoff.workload_spec.kind"
+
+
+def test_agentx_on_both_sides_restores_the_comparison(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Matching agentic workloads are comparable again.
+
+    This is the end state worth having: GEAK drives the same trace replay, so its
+    number and Hyperloom's are the same measurement and the ratio is meaningful.
+    """
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    monkeypatch.setenv("BENCH_CLIENT", rx.AGENTX_BENCH_CLIENT)
+    h = {
+        "workload": {"isl": 1024, "osl": 1024, "conc": 8},
+        "raw_baseline_tput": HL_AGENTIC_BASELINE_TOK_S,
+        "orchestrator_best_tput_same_config": HL_AGENTIC_BASELINE_TOK_S,
+        "launch_recipe": _recipe(tmp_path, rx.AGENTX_CLIENT_SCRIPT),
+    }
+    # GEAK reproducing Hyperloom's baseline: the campaign's own accidental
+    # agentic run landed at 170.106 against 168.998, i.e. +0.66%.
+    out = rx.normalize_result(h, _wf(eval_dir, base=170.106, final=175.0, speedup=1.03))
+    bb = out["baseline_basis"]
+    wc = bb["workload_comparability"]
+
+    assert wc["comparable"] is True
+    assert wc["orchestrator_workload_kind"] == rx.WORKLOAD_KIND_AGENTX
+    assert wc["geak_workload_kind"] == rx.WORKLOAD_KIND_AGENTX
+    assert bb["raw_session_baseline_divergence_pct"] == pytest.approx(0.66, abs=0.01)
+    assert bb["gain_vs_orchestrator_baseline"] is not None
+
+
+def test_metric_basis_is_documented_as_not_discriminating(tmp_path: Path) -> None:
+    """Both workloads report aggregate_output_tok_s, so bases cannot decide.
+
+    Recorded explicitly because it is the trap: the obvious guard would compare
+    metric_basis, see two matching strings, and conclude the loads matched.
+    """
+    eval_dir = tmp_path / "e2e"
+    eval_dir.mkdir()
+    h = {
+        "workload": {"isl": 1024, "osl": 1024, "conc": 8},
+        "raw_baseline_tput": HL_AGENTIC_BASELINE_TOK_S,
+        "launch_recipe": _recipe(tmp_path, rx.AGENTX_CLIENT_SCRIPT),
+    }
+    out = rx.normalize_result(h, _wf(eval_dir, base=465.0, final=470.0, speedup=1.01))
+    wc = out["baseline_basis"]["workload_comparability"]
+
+    assert wc["metric_basis_discriminates"] is False
+
+
+def test_kind_helpers_classify_directly() -> None:
+    """Unit-level coverage of the two classifiers."""
+    assert rx._geak_workload_kind() == rx.WORKLOAD_KIND_SYNTHETIC
+    assert rx._baseline_workload_kind({}) == (
+        rx.WORKLOAD_KIND_UNKNOWN,
+        "unavailable",
+    )
+    # A garbage recipe path is unreadable, not a mismatch.
+    assert rx._baseline_workload_kind({"launch_recipe": "/nope/missing.yaml"}) == (
+        rx.WORKLOAD_KIND_UNKNOWN,
+        "unavailable",
+    )


### PR DESCRIPTION
## Summary

When an external orchestrator hands GEAK an agentic workload, the handoff's
`isl`/`osl` describe a *replay of real traces*, not a benchmark GEAK can
reproduce. GEAK had no way to know that, so it measured a fixed 1024/1024
synthetic sweep and divided the result into an agentic denominator.

This PR adds an AgentX bench client, teaches GEAK to recognise the workload
identity in the handoff, and gates every cross-harness ratio on the two harnesses
having actually measured the same workload.

## Why this matters

A cross-harness ratio is only defined when both sides measured the same workload,
and the way that assumption breaks is completely silent:

| Measurement | Value |
| --- | --- |
| Orchestrator's agentic baseline | 168.998 tok/s |
| GEAK synthetic client at ISL/OSL = 1024 | 465.676 tok/s |
| Ratio an ungated GEAK publishes | **2.76x "win" with no kernel changed** |

The corpus spans roughly 89k input tokens at p50 and past 500k at p99, so there is
no single ISL that stands in for it. Left ungated this produces a confident,
reviewable, entirely fictional speedup.

## What changed

### 1. AgentX bench client — `adapters/clients/agentx.sh` (new)

Replays the trace corpus for a measured duration instead of issuing a fixed prompt
count. Duration is purpose-aware: canonical `parity` and `validation` legs get the
full window, while the inner search loop uses a shorter one and is marked
non-submittable, so a fast A/B probe can never be mistaken for a canonical result.

### 2. Workload identity — `interface/run_e2e.py`

`apply_workload_spec()` fires only when `handoff.workload_spec.kind` is
`agentx_trace_replay`. It exports the replay identity (scenario, dataset,
duration, warmup depth/grace, failed-request threshold, concurrency, metric basis)
and sets `GEAK_ISL_OSL_INACTIVE=1` so adapters refuse to treat fixed ISL/OSL as
the served load. Absence of the field preserves today's synthetic path exactly.

`_targeting_shape()` separates the shape agents *optimize for* from the shape
anything is *measured at* — kernel and GEMM synthesis still need concrete
dimensions, they just must not be mistaken for a reproducible benchmark.

`agentx_preflight()` reports missing AgentX prerequisites before the run burns a
server launch.

### 3. Comparability gate — `interface/run_e2e.py`

Three classifiers (`_baseline_workload_kind`, `_geak_workload_kind`,
`_workload_comparability`) decide whether a cross-harness ratio is meaningful:

```python
comparable = (not both_known) or baseline_kind == geak_kind
```

The rule is deliberately **asymmetric**. Suppression fires only on a *positive*
mismatch between two *known* kinds, so handoffs that predate any workload signal
classify as `unknown` and keep every field they have today. On a real mismatch
each GEAK-over-orchestrator quantity becomes `None` with a recorded
`suppressed_reason` — publishing nothing forces a reviewer to look, where
publishing a number invites them to trust it. Every **within-GEAK** ratio survives
untouched, since both of its legs were measured by the same client on the same
workload.

### 4. Protocol alignment is synthetic-only — `apply_bench_protocol()`

The knobs this block aligns (`NUM_PROMPTS_ADAPTIVE`, `NUM_WARMUPS`, `SEED`,
`RANDOM_RANGE_RATIO`) all shape a *synthetic prompt sweep*, and only mean anything
when both sides measured one. AgentX replays a fixed trace corpus with its own
seed and warmup contract, so fabricating a prompt count or a range ratio for it
would describe a workload nobody ran. They are now gated on the baseline workload
kind.

Note for reviewers: this places `NUM_PROMPTS_ADAPTIVE` — added on `main` after this
work started — inside that guard. The cache-cold parity settings above it
(`GEAK_REPEAT_MODE`, `REPLICA_RETRIES`) stay ungated, since those concern the
server lifecycle and hold for either workload kind.

### 5. Client plumbing

- `bench_e2e.sh` — `NUM_PROMPTS=1` for agentx; the client is duration-based and the
  trace corpus owns the prompt count.
- `bench_replica.sh` — `REPEATS=1` and `GEAK_ISL_OSL_INACTIVE=1` for agentx; the
  replay owns warmup and duration, one measured window per replica.
- `e2e_workflow.js` — carries `shape_provenance` on `WORKLOAD` so roles can tell a
  measured shape from an optimize-for shape.

### 6. Unrelated fix worth calling out — `adapters/clients/inferencex.sh`

The InferenceX client loads the model's tokenizer itself, so it must trust the same
remote code as the server it measures. `bench_e2e.sh` already resolved this and
exported `BENCH_TRUST_REMOTE_CODE`; only the flag passthrough was missing. Without
it a custom-tokenizer model (Kimi-K3, DeepSeek) died in the client at
transformers' `resolve_trust_remote_code` while the server ran fine. Passes the
bare `--trust-remote-code` spelling, since the client rejects the
`=true/false` form.

## Test plan

Full suite: **1697 passed, 4 skipped, 90 subtests passed**
(`PYTHONPATH=<repo root> pytest interface e2e_workflow/scripts/tests`).

New coverage:
- `interface/test_run_e2e_workload_comparability.py` — pins both contracts, and
  reproduces the exact 465.676 / 168.998 false claim as its fixture rather than an
  invented one. Covers the INVARIANT (synthetic and unknown handoffs keep every
  cross-harness field) and the GUARD (a real mismatch suppresses cross-harness
  fields while within-GEAK ratios survive).
- `e2e_workflow/scripts/tests/test_agentx_client_canonicality.py` — search legs
  cannot be promoted to canonical results.
- `interface/test_run_e2e_dispatch.py` — client-selection dispatch.

## Compatibility

Additive and gated on a positive signal. Handoffs without `workload_spec` take the
existing synthetic path unchanged, `BENCH_CLIENT` selection is unchanged for every
existing client, and suppression never fires on an absent or unknown workload kind.
