### PR TITLE
feat(e2e): enable GEAK e2e workflow optimization on ATOM

### DIFF
--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -582,13 +582,14 @@ const PARITY_REPLICAS = parseInt(A.parity_replicas != null ? A.parity_replicas :
 const SEARCH_REPLICAS = parseInt(A.search_replicas != null ? A.search_replicas : 1, 10);
 const VALIDATION_REPLICAS = parseInt(A.validation_replicas != null ? A.validation_replicas : 3, 10);
 // CUDA/HIP-graph deployment requirement (general; derived from the serving config, NOT hardcoded).
-// vllm/sglang capture the steady-state decode path into a FULL CUDA graph UNLESS --enforce-eager is set.
+// vllm/sglang/atom capture the steady-state decode path into a FULL CUDA/HIP graph UNLESS --enforce-eager
+// is set (ATOM exposes both --enforce-eager and --cudagraph-capture-sizes, so it belongs in this set).
 // A kernel that wins only via its OWN per-call graph-capture+replay wrapper falls back to eager inside the
 // server's graph, so the isolated win evaporates e2e (observed on M3: MoE 1.22x isolated -> 0% e2e). When
 // graphs are on we inject an EXPLICIT requirement into every kernel-optimize task: the win must be intrinsic
 // and graph-capture-safe. Detection is config-driven (enforce-eager absent + graph-capable backend), so it
 // auto-disables for an enforce-eager run and applies to any future graph-capturing backend.
-const CUDA_GRAPH_DEPLOY = (BACKEND === 'vllm' || BACKEND === 'sglang') && !/enforce[-_]eager/i.test(INIT_FLAGS);
+const CUDA_GRAPH_DEPLOY = (BACKEND === 'vllm' || BACKEND === 'sglang' || BACKEND === 'atom') && !/enforce[-_]eager/i.test(INIT_FLAGS);
 const GRAPH_REQ = CUDA_GRAPH_DEPLOY ? (
   ' DEPLOYMENT REQUIREMENT — the server captures the steady-state decode path into a FULL CUDA/HIP graph, ' +
   'so this kernel runs INSIDE that captured graph. Your speedup MUST be INTRINSIC: better tiles/algorithm, ' +

--- a/e2e_workflow/roles/kernel_extractor.md
+++ b/e2e_workflow/roles/kernel_extractor.md
@@ -812,6 +812,14 @@ force real compact-operand compute:
      (the OUTER leaf described above — engages on ALL gfx and subsumes aiter tuned_gemm; confirm the symbol
      imports in the serving venv before trusting it).
    - **vLLM · unquantized bf16/fp16 · CUDA** → `torch.nn.functional:linear`.
+   - **ATOM · fp8 a8w8 blockscale dense GEMM · ROCm (gfx950)** → seed the live-seam search with
+     `atom.model_ops.linear:gemm_a8w8_blockscale_preshuffle_impl`.
+   - **ATOM · DeepSeek-V2/R1 fused QKV-A projection** → seed the live-seam search with
+     `atom.models.deepseek_v2:_fuse_qkv_a_proj_reduce_rmsnorm_quant_fp8`.
+     These ATOM entries are **version/model-specific candidates, not an authority**: confirm that the
+     symbol imports in the serving environment, prove `engagement_hits>0`, and require the normal
+     `deepest_verified:true` device-kernel correlation. If either check fails, discover and certify the
+     live seam from the installed ATOM version instead of forcing the recorded name.
    - **fp8/quantized · non-vLLM backend (sglang/atom) · attention · MoE** → do NOT guess a seam (a wrong
      fp8/attn seam is just another dead rebind). GREP the live server for the actual quant-apply / backend
      forward and use that verbatim; for attention the seam is the backend forward you captured.

--- a/e2e_workflow/scripts/adapters/atom.sh
+++ b/e2e_workflow/scripts/adapters/atom.sh
@@ -1,0 +1,231 @@
+# ATOM serving adapter for bench_e2e.sh.  Sourced (not executed). Defines the contract functions.
+# Reads the same env the dispatcher exports; sets SERVER_PID in adapter_launch; appends canonical
+# result lines to $RESULT_JSONL.
+#
+# ATOM is AMD's MI3xx serving stack (`python3 -m atom.entrypoints.openai_server`). It speaks the
+# OpenAI-compatible surface (/v1/completions, /v1/chat/completions, /v1/models) plus /health and
+# /start_profile,/stop_profile, so OpenAI-compatible bench clients drive it with `--backend vllm`.
+#
+# FLAG SURFACE — probed on-box, NOT guessed. Source of truth for this file is
+#   python3 -m atom.entrypoints.openai_server --help
+# on rocm/atom:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom20260511. Notable facts that
+# differ from the sglang/vllm adapters and that you MUST keep in mind when editing:
+#
+#   * TWO PORTS. `--server-port` is the HTTP/OpenAI port that $BASE_URL must point at. `--port` is the
+#     ENGINE-INTERNAL port (default 8006) used for engine IPC. Passing the HTTP port as `--port` gives
+#     a server that never answers on $BASE_URL. We derive the internal port from PORT so two concurrent
+#     ATOM servers on one box do not collide; override with ATOM_ENGINE_PORT.
+#   * MEM_FRACTION maps to `--gpu-memory-utilization` (0.0-1.0) — the dimension IS supported, so unlike
+#     a stack without the knob we pass it through rather than dropping it.
+#   * `--kv_cache_dtype {bf16,fp8}` uses UNDERSCORES (not --kv-cache-dtype). ATOM's own default is bf16;
+#     this adapter defaults to fp8 to match the InferenceX MI355X recipes it was written for. Override
+#     with KV_CACHE_DTYPE=bf16.
+#   * Profiling is a CLI flag, `--torch-profiler-dir`, NOT the VLLM_TORCH_PROFILER_DIR env var. ATOM
+#     validates the directory exists at config time and ABORTS if it does not, so we mkdir -p first.
+#     Each rank writes its own subdir: $PROFILE_DIR/rank_<N>/ (or dp<D>_tp<N>/ under DP), so anything
+#     hunting for traces must recurse. Traces are named *.pt.trace.json.gz.
+#   * ATOM_PROFILER_MORE=1 turns on record_shapes/with_stack/profile_memory inside the rank profiler.
+#     record_shapes is what makes a trace usable for shape-driven kernel work, so adapter_profile_window
+#     asks for it by default (ATOM_PROFILER_MORE=0 to opt out of the extra trace weight).
+#
+# TUNING SURFACE the Config Tuner can drive through EXTRA_SERVER_ARGS / EXTRA_ENV (all probed above):
+#   args: --cudagraph-capture-sizes --level(0-3 compile) --max-num-batched-tokens --max-num-seqs
+#         --enable-tbo[prefill|all] --all2all-backend[high-throughput|low-latency] --enforce-eager
+#         --enable_prefix_caching --scheduler-delay-factor --block-size --method{mtp,eagle3}
+#         --num-speculative-tokens
+#   env:  ATOM_USE_TRITON_MLA ATOM_USE_TRITON_MOE ATOM_USE_TRITON_GEMM (Triton kernel paths — these are
+#         the hooks an OVERLAY_PYTHONPATH kernel actually lands on), ATOM_ENABLE_*_FUSION,
+#         ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD, ATOM_MOE_GU_ITLV, ATOM_USE_UNIFIED_ATTN,
+#         ATOM_FP8_BLOCKSCALE_WEIGHT_PRESHUFFLE, ATOM_V4_BACKEND.
+
+adapter_default_port() { echo 8888; }
+
+# ---- ATOM worker-reaping supervisor -------------------------------------------------------------
+# WHY: ATOM starts its per-rank ModelRunners with multiprocessing.spawn. Those workers do NOT die on
+# the SIGTERM that server_teardown.sh sends to the process group -- the leader exits promptly, the
+# workers reparent to pid 1 and keep running, each still holding its share of weights + KV cache
+# (~277 GiB/GPU for DSR1 fp8 on MI355X). server_teardown.sh's escalation is gated on the LEADER still
+# being alive after the grace window ("kill -0 $SERVER_PID || break"), so a leader that exits cleanly
+# means SIGKILL is never sent to the group and the whole box stays pinned. The next launch then dies
+# with "HIP out of memory ... 64.00 MiB is free" -- observed on this box before this supervisor existed.
+#
+# FIX: interpose a tiny supervisor as the group leader. It forwards SIGTERM to the server, waits for
+# it to actually exit, and then SIGKILLs the remaining process group -- i.e. the leaked workers. It
+# stays alive until that is done, which ALSO keeps server_teardown.sh's own escalation path valid.
+#
+# SAFETY: `kill -KILL 0` signals the caller's process group, so it is only correct when we lead that
+# group. Under $SERVER_LAUNCH_PREFIX (setsid) we do. The pgid==pid guard makes the self-reap a no-op
+# if the prefix is ever empty, where our group would be the benchmark's own -- never nuke that.
+_ATOM_SUPERVISOR='
+"$@" &
+_c=$!
+trap "kill -TERM $_c 2>/dev/null || true" TERM INT
+wait "$_c"
+while kill -0 "$_c" 2>/dev/null; do sleep 1; wait "$_c" 2>/dev/null || true; done
+if [ "$(ps -o pgid= -p $$ 2>/dev/null | tr -d " ")" = "$$" ]; then
+  kill -KILL 0 2>/dev/null || true
+fi
+true
+'
+
+adapter_launch() {
+  # Pin GPU_ARCHS so aiter's JIT skips rocm_agent_enumerator/_detect_native (see sglang.sh / vllm.sh).
+  local _ga="${GPU_ARCHS:-$(rocminfo 2>/dev/null | grep -m1 -oE 'gfx[0-9a-f]+' || true)}"
+
+  # Engine-internal port MUST differ from the HTTP port (see header). Derived, not fixed at ATOM's
+  # 8006 default, so parallel servers on one box don't fight over the engine socket.
+  local _eport="${ATOM_ENGINE_PORT:-$(( PORT + 1000 ))}"
+
+  # --max-model-len: mirror the InferenceX fixed_seq_len recipes, which pin 10240 for every shape
+  # EXCEPT 1k/1k (where they leave the model default). Explicit MAX_MODEL_LEN always wins. This keeps
+  # GEAK numbers comparable to the InferenceX baseline instead of silently sizing KV differently.
+  local _mml="${MAX_MODEL_LEN:-}"
+  if [ -z "$_mml" ] && ! { [ "${ISL:-}" = "1024" ] && [ "${OSL:-}" = "1024" ]; }; then
+    _mml=10240
+  fi
+
+  local -a _opt=()
+  [ -n "$_mml" ] && _opt+=(--max-model-len "$_mml")
+  [ -n "${KV_CACHE_DTYPE:-fp8}" ] && _opt+=(--kv_cache_dtype "${KV_CACHE_DTYPE:-fp8}")
+  [ -n "${BLOCK_SIZE:-16}" ] && _opt+=(--block-size "${BLOCK_SIZE:-16}")
+  [ -n "${MEM_FRACTION:-}" ] && _opt+=(--gpu-memory-utilization "$MEM_FRACTION")
+  # EP / DP-attention follow the recipe's own gating (EP_SIZE>1, DP_ATTENTION=true).
+  [ "${EP_SIZE:-1}" -gt 1 ] 2>/dev/null && _opt+=(--enable-expert-parallel)
+  [ "${DP_ATTENTION:-false}" = "true" ] && _opt+=(--enable-dp-attention)
+  [ "${BENCH_TRUST_REMOTE_CODE:-0}" = "1" ] && _opt+=(--trust-remote-code)
+
+  # Server-side torch profiler. Flag-based, and ATOM asserts the dir already exists.
+  # ATOM_PROFILER_MORE is read inside the WORKER process when the profiler is constructed, so it has
+  # to be on the launch line — setting it later (e.g. around /start_profile) is too late.
+  local -a _prof=() _prof_env=()
+  if [ -n "${PROFILE_DIR:-}" ]; then
+    mkdir -p "$PROFILE_DIR"
+    _prof=(--torch-profiler-dir "$PROFILE_DIR")
+    _prof_env=(ATOM_PROFILER_MORE="${ATOM_PROFILER_MORE:-1}")
+  fi
+
+  # Launch through $SERVER_LAUNCH_PREFIX (adapter contract): it puts the server in its
+  # own session so teardown can prove the process group is ours. Empty when unset.
+  # shellcheck disable=SC2086
+  ${SERVER_LAUNCH_PREFIX:-} env $EXTRA_ENV \
+    ${_ga:+GPU_ARCHS=$_ga} \
+    HIP_VISIBLE_DEVICES=$GPU CUDA_VISIBLE_DEVICES=$GPU \
+    OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}" \
+    "${_prof_env[@]}" \
+    PYTHONPATH="${OVERLAY_PYTHONPATH:+$OVERLAY_PYTHONPATH:}${PYTHONPATH:-}" \
+    bash -c "$_ATOM_SUPERVISOR" atom-supervisor \
+      python3 -m atom.entrypoints.openai_server \
+        --model "$MODEL" \
+        --host "$HOST" --server-port "$PORT" --port "$_eport" \
+        -tp "$TP" \
+        "${_opt[@]}" \
+        "${_prof[@]}" \
+        $EXTRA_SERVER_ARGS \
+      > "$LOG" 2>&1 &
+  SERVER_PID=$!
+}
+
+adapter_health() { curl -sf "${BASE_URL}/health" >/dev/null 2>&1; }
+
+# adapter_bench NUM_PROMPTS MAX_CONC PROFILE_FLAG
+# ATOM ships a vllm-derived client at atom.benchmarks.benchmark_serving with the same flag surface
+# (verified via --help), including --num-warmups and --random-range-ratio. This is the NATIVE bench;
+# BENCH_CLIENT=inferencex replaces it with InferenceX's client and keeps this as adapter_bench_native.
+adapter_bench() {
+  local NUMP="$1" MAXC="$2" PROF="${3:-0}"
+  local res_dir="${OUT_DIR:-$PROFILE_DIR}/atom_client"
+  mkdir -p "$res_dir"
+  local res_name="atom_bench_$$_${RANDOM}.json"
+  local extra=()
+  [ "$PROF" = "1" ] && extra=(--profile)
+  [ "${BENCH_TRUST_REMOTE_CODE:-0}" = "1" ] && extra+=(--trust-remote-code)
+  [ -n "${REQUEST_RATE:-}" ] && extra+=(--request-rate "$REQUEST_RATE") || extra+=(--request-rate inf)
+
+  python3 -m atom.benchmarks.benchmark_serving \
+    --backend vllm --base-url "$BASE_URL" --model "$MODEL" \
+    --dataset-name random --random-input-len "$ISL" --random-output-len "$OSL" \
+    --random-range-ratio "${RANDOM_RANGE_RATIO:-0}" \
+    --num-prompts "$NUMP" --max-concurrency "$MAXC" \
+    --num-warmups "${NUM_WARMUPS:-$(( MAXC < 8 ? MAXC : 8 ))}" \
+    --seed "$SEED" --ignore-eos \
+    --percentile-metrics "ttft,tpot,itl,e2el" \
+    --save-result --result-dir "$res_dir" --result-filename "$res_name" \
+    "${extra[@]}" || return $?
+
+  local res_json="$res_dir/$res_name"
+  [ -f "$res_json" ] || res_json="$(ls -t "$res_dir"/*.json 2>/dev/null | head -n1)"
+  if [ -n "$res_json" ] && [ -f "$res_json" ]; then
+    python3 -c "import json,sys; print(json.dumps(json.load(open(sys.argv[1]))))" "$res_json" \
+      >> "$RESULT_JSONL" 2>/dev/null || cat "$res_json" >> "$RESULT_JSONL"
+    mv "$res_json" "$res_json.consumed" 2>/dev/null || true
+  else
+    echo "!!! atom client: no result file in $res_dir" >&2
+    return 6
+  fi
+}
+
+# adapter_profile_window — capture a window on the warm, mid-load server via ATOM's HTTP profiler
+# (needs --torch-profiler-dir at launch). Like vllm and unlike sglang, /start_profile takes no step
+# count: it runs until /stop_profile, so the window is time-controlled (start, sleep, stop).
+# Traces land per-rank under $PROFILE_DIR/<rank_*|dp*_tp*>/, hence the recursive find.
+#
+# TWO ATOM-SPECIFIC HAZARDS, both observed on this box:
+#
+#  1. FINISHED vs IN-PROGRESS. ATOM's _on_trace_ready writes `<name>.pt.trace.json.tmp` and only
+#     renames it to `.pt.trace.json.gz` once the gzip completes. A glob like '*.trace.json*' matches
+#     the .tmp too, so counting it declares victory while the trace is still being written — teardown
+#     then kills the server mid-gzip and the trace is LOST. Only finalized .gz files count here.
+#  2. SIZE. ATOM_PROFILER_MORE=1 turns on with_stack + profile_memory as well as record_shapes, so the
+#     per-second trace cost is far higher than vllm/sglang: a 23s window produced a 5.5 GiB trace for
+#     rank_0 ALONE (~44 GiB across TP=8), and gzipping that outlives any sane timeout. The dispatcher
+#     sizes PROFILE_WINDOW_SEC for a cheap profiler, so clamp it here; a few seconds of steady-state
+#     decode is already thousands of steps at conc=4. Raise ATOM_PROFILE_WINDOW_MAX_SEC to override.
+adapter_profile_window() {
+  local before after wsec
+  # Only FINALIZED traces count (see hazard 1).
+  _atom_count_traces() { find "$PROFILE_DIR" -name '*.trace.json.gz' 2>/dev/null | wc -l; }
+  _atom_count_partial() { find "$PROFILE_DIR" -name '*.trace.json.tmp' 2>/dev/null | wc -l; }
+  before=$(_atom_count_traces)
+
+  wsec="${PROFILE_WINDOW_SEC:-20}"
+  local wmax="${ATOM_PROFILE_WINDOW_MAX_SEC:-6}"
+  if [ "$wsec" -gt "$wmax" ] 2>/dev/null; then
+    echo ">>> atom: clamping PROFILE_WINDOW_SEC ${wsec}->${wmax}s (ATOM_PROFILER_MORE traces are ~240 MiB/s/rank)"
+    wsec="$wmax"
+  fi
+
+  if ! curl -sf -X POST "${BASE_URL}/start_profile" >/dev/null 2>&1; then
+    echo "!!! /start_profile request failed (ATOM torch profiler not enabled at launch? needs --torch-profiler-dir)" >&2
+    return 1
+  fi
+  sleep "$wsec"
+  # /stop_profile asks every rank to flush; the gzip itself continues asynchronously afterwards.
+  curl -s --max-time "${PROFILE_WINDOW_TIMEOUT:-180}" -X POST "${BASE_URL}/stop_profile" \
+    >/dev/null 2>&1 || echo "!!! /stop_profile request errored (checking for a trace anyway)" >&2
+
+  # Wait for a NEW finalized .gz. While a .tmp is still growing the gzip is alive, so keep extending
+  # patience rather than timing out on a trace that IS being written -- returning early here is what
+  # lets teardown destroy it.
+  local hard=$(( $(date +%s) + ${ATOM_PROFILE_FINALIZE_TIMEOUT:-900} ))
+  local quiet=$(( $(date +%s) + ${PROFILE_WINDOW_TIMEOUT:-180} ))
+  local last_sz=-1 sz
+  while [ "$(date +%s)" -lt "$hard" ]; do
+    after=$(_atom_count_traces)
+    [ "$after" -gt "$before" ] && return 0
+    if [ "$(_atom_count_partial)" -gt 0 ]; then
+      # a .tmp exists: extend the quiet deadline as long as it keeps growing
+      sz=$(find "$PROFILE_DIR" -name '*.trace.json.tmp' -printf '%s\n' 2>/dev/null | sort -rn | head -1)
+      if [ "${sz:-0}" != "$last_sz" ]; then
+        last_sz="${sz:-0}"; quiet=$(( $(date +%s) + ${PROFILE_WINDOW_TIMEOUT:-180} ))
+      fi
+    fi
+    [ "$(date +%s)" -ge "$quiet" ] && break
+    sleep 5
+  done
+  after=$(_atom_count_traces)
+  if [ "$after" -le "$before" ] && [ "$(_atom_count_partial)" -gt 0 ]; then
+    echo "!!! atom: profiler left only an unfinished .tmp trace (gzip did not complete in time)." >&2
+    echo "    Lower PROFILE_WINDOW_SEC / ATOM_PROFILE_WINDOW_MAX_SEC, or set ATOM_PROFILER_MORE=0 to drop with_stack." >&2
+  fi
+  [ "$after" -gt "$before" ]
+}

--- a/e2e_workflow/scripts/parse_profile.py
+++ b/e2e_workflow/scripts/parse_profile.py
@@ -47,18 +47,31 @@ from collections import defaultdict
 # Each entry: (regex, classification, backend_guess, editable, hint)
 # --------------------------------------------------------------------------- #
 RULES = [
-    (r"triton|_kernel_0d1d|tt\.|fused_.*kernel", "triton", "triton", True,
-     "Triton kernel — extractable; try Triton tuning, or a CK/HIP rewrite if memory/compute bound."),
-    (r"Cijk|Tensile|hipblaslt|_gemm|GemmEx|gemm_|hgemm|sgemm|f16_gemm|igemm",
-     "library_gemm", "hipblaslt", False,
-     "Library GEMM (hipBLASLt/Tensile). Tune via heuristics/env or swap to aiter/CK GEMM; rarely source-editable."),
+    # Strong implementation/library fingerprints precede generic operation names.
+    # CK and Triton symbols commonly contain "gemm"; that alone is not hipBLASLt evidence.
     (r"aiter|ater::", "fused_custom", "aiter", True,
      "AITER kernel. Has source; compare aiter vs triton vs CK for this shape."),
-    (r"flash|fmha|attention|attn|_mha_|paged|kv_cache|decode_attention|prefill",
+    (r"\bck_|composable_kernel|CK::|ck::", "fused_custom", "ck", True,
+     "Composable Kernel. Compare CK instance/config; source-tunable via instance selection."),
+    (r"nccl|rccl|ncclDevKernel|allreduce|all2all|alltoall|all_gather",
+     "communication", "rccl", False,
+     "Collective kernel. Tune topology or the collective backend, not a compute-kernel seam."),
+    (r"BLOCK_SIZE_|BLOCK_M|BLOCK_N|num_warps|num_stages|_kernel_0d1d",
+     "triton", "triton", True,
+     "Triton JIT kernel (launch/autotune constants in the symbol). Extractable."),
+    # Some ATOM/AITER HIP symbols omit the aiter namespace in profiler output.
+    # Keep this list narrow and require live-seam verification downstream.
+    (r"\b(?:fmoe_|opus_|kn_(?:mla|get_mla)|wv_splitk|dynamic_per_group_scaled_quant)",
+     "fused_custom", "aiter", True,
+     "ATOM/AITER kernel family. Verify the live Python seam before attempting a rebind."),
+    (r"triton|_kernel_0d1d|tt\.|fused_.*kernel", "triton", "triton", True,
+     "Triton kernel — extractable; try Triton tuning, or a CK/HIP rewrite if memory/compute bound."),
+    (r"Cijk|Tensile|hipblaslt|GemmEx|hgemm|sgemm|f16_gemm|igemm",
+     "library_gemm", "hipblaslt", False,
+     "Library GEMM (hipBLASLt/Tensile). Tune via heuristics/env or swap to aiter/CK GEMM; rarely source-editable."),
+    (r"flash|fmha|attention|attn|_mha_|mla|paged|kv_cache|decode_attention|prefill",
      "library_attn", "ck", False,
      "Attention kernel (CK/AITER/FA). Try --attention-backend swap + per-shape backend; source-edit only if Triton attn."),
-    (r"ck_|composable_kernel|CK::|ck::", "fused_custom", "ck", True,
-     "Composable Kernel. Compare CK instance/config; source-tunable via instance selection."),
     (r"mamba|ssm|causal_conv|selective_scan|chunk_scan|chunk_fwd|chunk_gated|"
      r"gated_delta|delta_rule|state_passing|recompute_w|kkt_solve|l2norm|cumsum",
      "fused_custom", "triton", True,
@@ -80,7 +93,7 @@ def classify(name):
         if re.search(rx, name, re.IGNORECASE):
             return cls, backend, editable, hint
     # Fallback: a snake_case symbol ending in 'kernel' (and not a mangled C++ symbol) is almost
-    # always a Triton/custom JIT kernel in sglang -> editable.
+    # always a Triton/custom JIT kernel -> editable.
     if re.search(r"^[a-z0-9_]+kernel[a-z0-9_]*$", name) or re.search(r"_fwd_kernel|_bwd_kernel", name):
         return ("triton", "triton", True,
                 "Snake_case JIT kernel (likely Triton). Extractable; tune or compare backends.")

--- a/e2e_workflow/scripts/tests/test_parse_profile.py
+++ b/e2e_workflow/scripts/tests/test_parse_profile.py
@@ -89,7 +89,7 @@ def _shared_impl(func):
 # window [300,350), cpu_ops carrying the shapes, and kernel launches placed
 # both inside and outside those windows.
 # --------------------------------------------------------------------------- #
-GEMM = "void gemm_kernel<float>(int)"
+GEMM = "void hipblaslt::gemm_kernel<float>(int)"
 
 
 def _trace_events():
@@ -207,6 +207,7 @@ class TestClassify(unittest.TestCase):
             "rms_norm_forward": ("reduction_norm", "triton", True),
             "vectorized_elementwise_add": ("elementwise_overhead", "torch_native", True),
             "Memcpy DtoH": ("memory", "torch_native", False),
+            "ncclDevKernel_Generic_1": ("communication", "rccl", False),
         }
         for name, want in expected.items():
             with self.subTest(name=name):
@@ -230,6 +231,27 @@ class TestClassify(unittest.TestCase):
 
     def test_classification_is_case_insensitive(self):
         self.assertEqual(pp.classify("TRITON_FOO")[0], "triton")
+
+    def test_atom_and_jit_gemms_are_not_mislabeled_as_hipblaslt(self):
+        cases = {
+            "void ck::kernel_gemm_xdl_cshuffle_v3_multi_d_blockscale_b_preshuffle<int>()":
+                ("fused_custom", "ck", True),
+            "_batched_gemm_a8w8_kernel_BLOCK_SIZE_M_4_BLOCK_SIZE_N_16":
+                ("triton", "triton", True),
+            "void kn_mla_reduce_v1_ps<MlaTraits>()":
+                ("fused_custom", "aiter", True),
+            "void kn_get_mla_metadata_v1_2<MlaTraits>()":
+                ("fused_custom", "aiter", True),
+            "_ZN5aiter35fused_qk_rmsnorm_group_quant_kernel":
+                ("fused_custom", "aiter", True),
+        }
+        for name, want in cases.items():
+            with self.subTest(name=name):
+                self.assertEqual(pp.classify(name)[:3], want)
+
+    def test_generic_gemm_name_is_not_assumed_to_be_hipblaslt(self):
+        cls, backend, editable, _ = pp.classify("custom_gemm_dispatch")
+        self.assertEqual((cls, backend, editable), ("other", "unknown", True))
 
 
 class TestShortNameAndNormKey(unittest.TestCase):

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -153,6 +153,7 @@ DONE_POLL_S = float(os.environ.get("GEAK_DONE_POLL_S", "15"))
 _SERVING_FIDELITY_FLAGS: dict[str, dict[str, str]] = {
     "vllm": {"max_model_len": "--max-model-len", "mem_fraction": "--gpu-memory-utilization"},
     "sglang": {"max_model_len": "--context-length", "mem_fraction": "--mem-fraction-static"},
+    "atom": {"max_model_len": "--max-model-len", "mem_fraction": "--gpu-memory-utilization"},
 }
 
 

--- a/interface/test_run_e2e_alignment.py
+++ b/interface/test_run_e2e_alignment.py
@@ -372,6 +372,18 @@ def test_fold_uses_sglang_flag_names(tmp_path: Path) -> None:
     assert "--gpu-memory-utilization" not in flags
 
 
+def test_fold_uses_atom_flag_names(tmp_path: Path) -> None:
+    """ATOM receives fidelity knobs using the flags supported by its adapter."""
+    h = _fidelity_handoff(
+        tmp_path, framework="atom", accepted_flags="--block-size 16",
+        max_model_len=10240, mem_fraction=0.9,
+    )
+    flags = rx.map_args(h)["initial_extra_server_args"]
+    assert "--block-size 16" in flags
+    assert "--max-model-len 10240" in flags
+    assert "--gpu-memory-utilization 0.9" in flags
+
+
 def test_fold_respects_explicit_caller_flag(tmp_path: Path) -> None:
     """A knob the caller already set in accepted_flags is never overridden."""
     h = _fidelity_handoff(


### PR DESCRIPTION
feat(e2e): enable GEAK e2e workflow optimization on ATOM

## Summary
Give GEAK a real ATOM serving path so kernel optimization can run against ATOM, not just vllm/sglang.

Add `adapters/atom.sh` so `BACKEND=atom` is a real serving adapter, plus a one-line `CUDA_GRAPH_DEPLOY` update (and its comment) so ATOM graph-capture runs get the same intrinsic-speedup warning as vllm/sglang.

Three ATOM-specific traps, each of which fails silently rather than erroring:
- `--port` is IPC; HTTP is `--server-port`. Get it wrong and the server starts, logs nothing unusual, and never answers on `$BASE_URL`.
- `multiprocessing.spawn` workers survive SIGTERM and reparent; teardown's SIGKILL is gated on the leader still being alive, so the leak is silent and the next launch HIP-OOMs. `adapter_launch` inserts a group-leader supervisor.
- Profiler writes `.tmp` then renames to `.gz`. Globbing `*.trace.json*` declares success mid-write, and teardown kills the server before the gzip lands. Wait only on finalized `.gz`.

## Test plan
Full e2e on MI355X / DeepSeek-R1-0528 (TP=8) ran through the adapter end to end — launch, health, bench, profile window, teardown. Relaunch after teardown no longer HIP-OOMs. `vllm`/`sglang` are untouched by this diff.