### PR TITLE
Prioritize queued heads over implicit tuning in budgeted runs

### DIFF
--- a/e2e_workflow/README.md
+++ b/e2e_workflow/README.md
@@ -148,12 +148,24 @@ achievable number (it is broader = more backends, deeper = more/faster rounds, p
 spare GPUs while the e2e gate runs on the serving slot, with matched in-window A/B so parallelism never
 corrupts a measurement).
 
-## Tuning skillset (`tuning_skillset`, default ON)
+## Tuning skillset (`tuning_skillset`)
 
 A dedicated phase — **after ConfigSweep, before HeadKernel** — that runs the tuning skillset vendored at
 `<repo>/perf_knowledge/expert_skills/tuning/`: an independently-validated method for tuning GPU ops on AMD Instinct (per-op
 tuners, deploy paths into a live server, and the engagement checks that prove a tuned artifact is
 actually what the machine runs).
+
+With a finite external `time_budget_s`, an invocation that has pending HeadKernel work skips
+implicitly enabled tuning before starting a tuning worker. This prevents the optional phase from
+consuming the head-dispatch window. Set `tuning_skillset:true` explicitly to request the existing
+tune-then-head path, or drive the tuning and head phases separately with their carried state.
+Tune-only, unbudgeted, and no-pending-head invocations keep the existing default. Previously accepted
+tuning state and its deploy bundle remain available when a new tuning attempt is skipped.
+
+The skip is recorded as `implicit_tuning_skipped_for_head_generation` in the ledger and tuning result.
+This is phase admission, not worker cancellation or a guarantee that profiling, capture, authoring,
+or final validation will finish within the budget. No duration estimate is used to admit an unbounded
+tuning worker, and the existing dispatch and final-reserve deadlines remain unchanged.
 
 **It is vendored whole and run whole.** The tree is byte-identical to the standalone repo it is validated
 in (37 executable claims in `validate/claims.py`), hash-pinned by

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -3014,7 +3014,19 @@ function gemmSynthFor(h) { return (h && h.op_kind === 'moe') ? 'false' : GEMM_SY
 // the profile is re-taken exactly as it is after a config win, because tuning changes the landscape too.
 // ===========================================================================
 let tuning = ST.tuning || null;
-if (want('tune') && TUNING_SKILLSET_ENABLED) {
+// A finite runner budget cannot reserve generation time by merely racing an unbounded tuning
+// worker against a timer: the worker may still be running. When tuning was only the implicit
+// default, give already-queued head work priority by never starting that optional worker.
+// An explicit tuning_skillset=true requests the existing tune-then-head path; tune-only and
+// unbudgeted invocations keep it too. A carried accepted tuning result is never discarded.
+const tuningAdmissionSkip = A.tuning_skillset == null && TUNING_SKILLSET_ENABLED &&
+  want('tune') && want('head') && headQueue.length > 0 && HEAD_BUDGET > 0 &&
+  Number.isFinite(TIME_BUDGET_MS) && TIME_BUDGET_MS > 0
+  ? { reason: 'implicit_tuning_skipped_for_head_generation',
+      queued_heads: headQueue.length, elapsed_ms: ELAPSED_MS,
+      head_dispatch_deadline_ms: TIME_HEAD_DEADLINE_MS }
+  : null;
+if (want('tune') && TUNING_SKILLSET_ENABLED && !tuningAdmissionSkip) {
   phase('TuningSkillset');
   log(`Tuning skillset: ${TUNING_SKILLSET_DIR} (whole, standalone, pre-HeadKernel); ` +
     `no op cap, tuning-kb ${TUNING_KB_ENABLED ? 'ENABLED' : 'DISABLED (blind eval)'}.`);
@@ -3264,12 +3276,20 @@ if (want('tune') && TUNING_SKILLSET_ENABLED) {
     history.ledger.push({ direction: 'tuning_skillset', verdict: tuning && tuning.gate === 'skipped' ? 'skipped' : 'dead_end',
       lesson: (tuning && (tuning.reason || tuning.summary)) || 'tuning phase produced no result' });
   }
+} else if (tuningAdmissionSkip) {
+  log(`[budget] skipping implicit TuningSkillset before ${headQueue.length} queued head(s); ` +
+    'no tuning worker started. Set tuning_skillset=true to request tune-then-head explicitly.');
+  history.ledger.push({ direction: 'tuning_skillset', verdict: 'skipped',
+    lesson: tuningAdmissionSkip.reason, ...tuningAdmissionSkip });
 } else if (want('tune') && !TUNING_SKILLSET_ENABLED) {
   log('Tuning skillset DISABLED (tuning_skillset=false) — skipping the phase entirely.');
 }
 // Report inputs for the tuning phase. Empty object when the phase is off/absent, so the Report prompt is
 // byte-identical to a build without this feature.
-const TUNING_REPORT_INPUTS = (TUNING_SKILLSET_ENABLED && tuning) ? { TUNING_RESULT: tuning } : {};
+const TUNING_REPORT_INPUTS = {
+  ...((TUNING_SKILLSET_ENABLED && tuning) ? { TUNING_RESULT: tuning } : {}),
+  ...(tuningAdmissionSkip ? { TUNING_ADMISSION_SKIP: tuningAdmissionSkip } : {}),
+};
 // Finalize inputs. A tuned DATA artifact cannot ride the PYTHONPATH overlay, so the ONLY way it reaches
 // production is for Finalize to fold this bundle into EVAL_DIR/final/ (concatenate its diff into
 // final_patch.diff, copy its files, and invoke its deploy.sh from final_launch.sh before the server
@@ -4678,7 +4698,10 @@ function tuningReturn() {
   if (!TUNING_SKILLSET_ENABLED) return { enabled: false };
   const base = {
     enabled: true, skillset_dir: TUNING_SKILLSET_DIR, kb_enabled: TUNING_KB_ENABLED, ran: !!tuning,
+    ...(tuningAdmissionSkip ? { admission_skip: tuningAdmissionSkip } : {}),
   };
+  if (!tuning && tuningAdmissionSkip)
+    return { ...base, gate: 'skipped', reason: tuningAdmissionSkip.reason };
   if (!tuning) return { ...base, gate: want('tune') ? 'not_run' : 'phase_not_selected' };
   const finalT = validatedOk ? validation.director_verified_throughput_tok_s : finalTput;
   const totalGain = (finalT || 0) - (BASELINE_TPUT || 0);

--- a/e2e_workflow/scripts/test_tuning_head_admission.js
+++ b/e2e_workflow/scripts/test_tuning_head_admission.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Execute the shipped tuning and head scheduling blocks with deterministic workers.
+// These are CPU orchestration tests, not GPU measurements or cancellation tests.
+'use strict';
+const assert = require('assert/strict');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'e2e_workflow.js'), 'utf8');
+const between = (start, end) => {
+  const a = src.indexOf(start), b = src.indexOf(end, a);
+  assert(a >= 0 && b > a, `source block exists: ${start}`);
+  return src.slice(a, b);
+};
+const budgetSrc = between('const TIME_BUDGET_MS =', '// ---- FAST MODE');
+const tuneSrc = between('// PHASE: TuningSkillset', '// PHASE: HeadKernel');
+const headSrc = between("if (want('head') && headQueue.length && HEAD_BUDGET > 0)", '// PHASE: Milestone loop');
+const returnSrc = between('function tuningReturn()', 'const wfReturn =');
+
+async function runCase(options = {}) {
+  const A = { ...(options.args || {}) };
+  if (options.budgetS !== null) A.time_budget_s = options.budgetS === undefined ? 15942 : options.budgetS;
+  const budget = new Function('A', 'setTimeout', budgetSrc + `
+    return { TIME_BUDGET_MS, TIME_HEAD_DEADLINE_MS, FINAL_RESERVE_MS };
+  `)(A, () => ({ unref() {} }));
+  const heads = options.noHeads ? [] : [{ short_name: 'attention', op_kind: 'attention', pct_gpu_time: 9 }];
+  const phases = new Set(options.phases || ['tune', 'head']);
+  const calls = [], acquired = [], released = [], logs = [];
+  let active = 0;
+  const carried = options.carriedTuning || null;
+  const ctx = {
+    A, ST: carried ? { tuning: carried } : {}, tuning: carried, ...budget,
+    ELAPSED_MS: options.expired ? 10071000 : 3600000,
+    TIME_DEADLINE_HIT: !!options.expired, FAST_DEADLINE_HIT: false,
+    want: (phase) => phases.has(phase), phase: (name) => calls.push('phase:' + name),
+    log: (line) => logs.push(line),
+    TUNING_SKILLSET_ENABLED: String(A.tuning_skillset == null ? true : A.tuning_skillset) === 'true',
+    TUNING_SKILLSET_DIR: '/skills', TUNING_KB_ENABLED: false,
+    HEAD_BUDGET: options.headBudget == null ? 1 : options.headBudget,
+    HEAD_AUTHOR_MAX: 1, HEAD_PROTECT_PCT: 30, HEAD_THRESHOLD_PCT: 5,
+    FAST_MODE: false, DEEP: false, headQueue: heads, kernelQueue: [], headDispatched: 0,
+    history: { ledger: [] }, acceptedHeads: [], acceptedKernels: [], flaggedHeads: [],
+    EVAL_DIR: '/eval', MODEL_PATH: '/model', WORKFLOW_DIR: '/workflow',
+    GPU_LIST: ['0'], WORKLOAD: { isl: 8192, osl: 1024, conc: 64 }, CONC: 64,
+    BASELINE_TPUT: 1000, curTput: carried ? 1100 : 1000,
+    curEnv: carried ? carried.apply_env : '', curFlags: '',
+    curOverlay: carried ? carried.apply_overlay : '/overlay/base',
+    profile: {}, strategy: {}, SEARCH_REPLICAS: 1, NOISE_BAND: 0.5, E2E_REPEATS: 1,
+    ACCURACY_GATE: 'none', ANALYSIS_SKILL_INPUTS: {}, TUNING_SCHEMA: {}, PROFILE_SCHEMA: {},
+    STRATEGY_SCHEMA: {}, EXTRACT_OP_SCHEMA: {}, OPBENCH_SCHEMA: {}, KB_DIMS: null,
+    ENABLE_FP8: true, KERNEL_WF_DIR: '/kernel', KERNEL_WF_SCRIPT: '/kernel/workflow.js',
+    KERNEL_KNOWLEDGE_DIR: '/knowledge', KERNEL_BUDGET: 1, BUDGET: 1,
+    CONFIG_TUNE_ENABLED: false, USE_EXPERT_SKILLS: false,
+    EXPERT_SKILLS_DIR: '/experts', KB_ARGS: {}, GRAPH_REQ: '', TASK: '',
+    validatedOk: false, validation: null, finalize: null, finalTput: 0,
+    roleAgent: (role, phase, intro, inputs) => ({ role, phase, inputs }),
+    gemmSynthFor: () => false,
+    applyOpIdentityGuard: (queue) => queue,
+    ensureFlydslGate: async () => {},
+    bankAccepted: (entries, record) => entries.push(record),
+    e2eFrom: (result) => ({ e2e_delta_pct: result.e2e_delta_pct }),
+    krOf: (inputs) => inputs.KERNEL_RESULT,
+    integAccepted: (result) => result.gate === 'accepted',
+  };
+  const advance = (ms) => {
+    ctx.ELAPSED_MS += ms;
+    ctx.TIME_DEADLINE_HIT = budget.TIME_HEAD_DEADLINE_MS != null &&
+      ctx.ELAPSED_MS >= budget.TIME_HEAD_DEADLINE_MS;
+  };
+  const worker = async (name, duration, result) => {
+    calls.push(name); acquired.push(name); active++;
+    try { advance(duration); return result; }
+    finally { active--; released.push(name); }
+  };
+  ctx.safeAgent = async (prompt) => {
+    if (prompt.role === 'tuning_specialist') {
+      // The historical receipt bounds combined pre-head work at 10,070.79 seconds.
+      // Phase-entry time here is a simulation input, not a recovered timestamp.
+      const duration = options.slowTuning ? 10070793 - ctx.ELAPSED_MS : 1000;
+      return worker('tuning', duration, options.acceptTuning ? {
+        gate: 'accepted', engagement_verified: true, ab_complete: true,
+        correctness_gate: 'pass', pre_tune_throughput_tok_s: 1000,
+        post_tune_throughput_tok_s: 1100, tuning_delta_pct: 10,
+        apply_env: 'TUNED_TABLE=/eval/tuned.csv', apply_overlay: '/overlay/tuned',
+        deploy_bundle: '/eval/tuning/deploy', deploy_verified: true,
+        ops_tuned: [{ op: 'gemm', backend: 'aiter', isolated_speedup: 1.1, engaged: true }],
+      } : { gate: 'no_win', reason: 'no measured tuning win' });
+    }
+    if (prompt.role === 'op_benchmarker') return worker('bakeoff', 1000, {
+      gate: 'author_recommended', author_plan: [{ language: 'triton' }],
+    });
+    if (prompt.role === 'system_architect') return worker('strategize', 1000, { head_candidates: heads });
+    return worker('profile', 1000, { profile_topN_json: '/profile.json' });
+  };
+  ctx.extractWithBaseline = async (_role, _phase, _intro, inputs) => {
+    ctx.extractionInputs = inputs;
+    return worker('capture', 1000, { smoke: 'pass', task_dir: '/task', op_kind: 'attention' });
+  };
+  let authorAttempts = 0;
+  ctx.fastBoundedWorkflow = async (_ref, args) => {
+    assert.equal(args.mode, 'author');
+    authorAttempts++;
+    if (options.retryAuthor && authorAttempts === 1)
+      return worker('author-transient', 1000, { authored: false, validation_status: 'error' });
+    return worker('author', 1000, { authored: true, final_geomean: 1.2,
+      final_patch: '/head.patch', eval_dir: '/head' });
+  };
+  ctx.runIntegrateBothLegs = async (_intro, inputs) => {
+    ctx.integrationInputs = inputs;
+    return worker('integrate', 1000, { gate: 'accepted', ab_complete: true,
+      ref_med: ctx.curTput, e2e_throughput_tok_s: ctx.curTput + 20,
+      e2e_delta_pct: 2, accepted_overlay: '/overlay/combined' });
+  };
+  // Negative control removes ONLY the admission decision from the executed source.
+  // The rest of the shipped tuning and head dispatch paths are identical.
+  const tuningCode = options.withoutAdmission
+    ? tuneSrc.replace(' && !tuningAdmissionSkip)', ')') : tuneSrc;
+  const script = new vm.Script(`(async () => {
+    ${tuningCode}
+    ${headSrc}
+    finalTput = curTput;
+    ${returnSrc}
+    return { tuning, result: tuningReturn(), finalizeInputs: TUNING_FINALIZE_INPUTS,
+      reportInputs: TUNING_REPORT_INPUTS };
+  })()`);
+  const result = await script.runInNewContext(ctx, { timeout: 1000 });
+  assert.equal(active, 0, 'all simulated workers returned; the skip path starts none');
+  assert.deepEqual(acquired, released, 'no simulated worker is abandoned by a timer race');
+  return { ...result, ctx, calls, authorAttempts, logs };
+}
+
+(async () => {
+  const before = await runCase({ slowTuning: true, withoutAdmission: true });
+  assert(before.calls.includes('tuning'));
+  assert.equal(before.authorAttempts, 0, 'the old scheduling path loses all author dispatch');
+  const after = await runCase({ slowTuning: true, retryAuthor: true });
+  assert(!after.calls.includes('tuning'), 'implicit tuning starts no worker or cleanup obligation');
+  assert.equal(after.authorAttempts, 2, 'capture, bakeoff and a transient retry reach authoring');
+  assert.equal(after.ctx.acceptedHeads.length, 1);
+  assert.equal(after.result.ran, false);
+  assert.equal(after.result.gate, 'skipped');
+  assert.equal(after.result.reason, 'implicit_tuning_skipped_for_head_generation');
+  assert.equal(after.ctx.history.ledger[0].reason, after.result.reason);
+  assert.equal(after.reportInputs.TUNING_ADMISSION_SKIP.reason, after.result.reason);
+  assert.equal(after.result.admission_skip.queued_heads, 1);
+  assert.equal(after.ctx.FINAL_RESERVE_MS, before.ctx.FINAL_RESERVE_MS);
+  assert.equal(after.ctx.TIME_HEAD_DEADLINE_MS, before.ctx.TIME_HEAD_DEADLINE_MS);
+
+  const combined = await runCase({ args: { tuning_skillset: true }, acceptTuning: true });
+  assert(combined.calls.indexOf('tuning') < combined.calls.indexOf('capture'));
+  assert.equal(combined.ctx.acceptedKernels.length, 1, 'tuned table remains banked');
+  assert.equal(combined.ctx.acceptedHeads.length, 1, 'new authored overlay remains banked');
+  assert.equal(combined.ctx.extractionInputs.CURRENT_ENV, 'TUNED_TABLE=/eval/tuned.csv');
+  assert.equal(combined.ctx.integrationInputs.CURRENT_OVERLAY, '/overlay/tuned');
+  assert.equal(combined.finalizeInputs.TUNING_DEPLOY_BUNDLE, '/eval/tuning/deploy');
+  assert.equal(combined.result.gate, 'accepted');
+
+  const carried = { ...combined.tuning };
+  const resumed = await runCase({ carriedTuning: carried });
+  assert(!resumed.calls.includes('tuning'));
+  assert.deepEqual(resumed.tuning, carried, 'skipping a new attempt preserves the prior accept');
+  assert.equal(resumed.ctx.extractionInputs.CURRENT_ENV, carried.apply_env);
+  assert.equal(resumed.finalizeInputs.TUNING_DEPLOY_BUNDLE, carried.deploy_bundle);
+  assert.equal(resumed.result.gate, 'accepted');
+  assert.deepEqual(resumed.reportInputs.TUNING_RESULT, carried);
+  assert.equal(resumed.result.admission_skip.reason, after.result.reason);
+
+  for (const options of [{ noHeads: true }, { headBudget: 0 },
+    { phases: ['tune'] }, { budgetS: null }, { budgetS: 0 },
+    { budgetS: -1 }, { budgetS: 'Infinity' }, { budgetS: 'invalid' }]) {
+    const result = await runCase(options);
+    assert(result.calls.includes('tuning'), JSON.stringify(options));
+    assert(!result.result.admission_skip);
+  }
+  const disabled = await runCase({ args: { tuning_skillset: false } });
+  assert(!disabled.calls.includes('tuning'));
+  assert.equal(disabled.result.enabled, false);
+  const expired = await runCase({ expired: true });
+  assert(!expired.calls.includes('tuning'));
+  assert.equal(expired.authorAttempts, 0, 'admission cannot recover an already-expired deadline');
+  const explicitSlow = await runCase({ args: { tuning_skillset: 'true' }, slowTuning: true });
+  assert(explicitSlow.calls.includes('tuning'));
+  assert.equal(explicitSlow.authorAttempts, 0, 'explicit tune-first retains its documented tradeoff');
+  console.log('PASS: source-derived admission, starvation control, author dispatch/retry, combined win, carried state, phase/budget boundaries, and no spawned tuning worker on skips.');
+})().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/e2e_workflow/scripts/test_tuning_skillset_phase.js
+++ b/e2e_workflow/scripts/test_tuning_skillset_phase.js
@@ -127,7 +127,7 @@ if (phaseList) {
 // Source order is what actually runs — assert the gated blocks are in the same sequence.
 const at = (re) => src.search(re);
 const iConfig = at(/if \(want\('config'\)/);
-const iTune = at(/if \(want\('tune'\) && TUNING_SKILLSET_ENABLED\)/);
+const iTune = at(/if \(want\('tune'\) && TUNING_SKILLSET_ENABLED && !tuningAdmissionSkip\)/);
 const iHead = at(/if \(want\('head'\)/);
 ok(iTune > 0, "a gated `want('tune')` block exists");
 ok(iConfig > 0 && iConfig < iTune, 'the tune block runs AFTER the ConfigSweep block');
@@ -214,8 +214,15 @@ if (gate) {
 // The tuning loop is uncapped by design: tuning ops are cheap and cumulative, unlike head ops.
 ok(!/TUNING_BUDGET/.test(src), 'no op budget caps the tuning loop');
 // The report inputs must be an EMPTY spread when off, so the Report prompt is unchanged.
-ok(/const TUNING_REPORT_INPUTS = \(TUNING_SKILLSET_ENABLED && tuning\) \? \{ TUNING_RESULT: tuning \} : \{\};/.test(src),
+{
+  const start = src.indexOf('const TUNING_REPORT_INPUTS =');
+  const end = src.indexOf('// Finalize inputs.', start);
+  const reportInputsFor = new Function('TUNING_SKILLSET_ENABLED', 'tuning', 'tuningAdmissionSkip',
+    src.slice(start, end) + '\nreturn TUNING_REPORT_INPUTS;');
+  ok(JSON.stringify(reportInputsFor(false, null, null)) === '{}' &&
+    JSON.stringify(reportInputsFor(true, null, null)) === '{}',
   'report inputs are an empty object when the phase is off/absent (Report prompt byte-identical)');
+}
 ok((src.match(/\.\.\.TUNING_REPORT_INPUTS/g) || []).length === 1,
   'the report spread appears exactly once (Report phase only)');
 // Fast mode's contract is HeadKernel-only, so 'tune' must join its skip set.
@@ -341,6 +348,12 @@ ok(/Prior tuning knowledge/.test(role) && /KB_REFERENCE_DIR/.test(role),
   'the role file tells the specialist to check the KB before searching');
 ok(/prove engagement/i.test(role) && /A recall is not an accept/.test(role),
   'a recalled artifact still has to earn its accept on this box');
+
+// Keep the executed scheduling regression in the existing L0 entry point.
+try {
+  require('child_process').execFileSync(process.execPath,
+    [path.join(__dirname, 'test_tuning_head_admission.js')], { stdio: 'inherit' });
+} catch (_) { failures++; }
 
 console.log(failures === 0
   ? '\nPASS: tuning skillset is vendored whole and runs standalone before HeadKernel.'

--- a/interface/run_e2e.py
+++ b/interface/run_e2e.py
@@ -406,8 +406,9 @@ def map_args(h: dict, timeout_s: int | None = None) -> dict:
     # config_tune sweep disabled above: Hyperloom's EXPLORE searched server
     # flags/env, whereas this phase runs the vendored tuning skillset's own loop
     # (per-op tuners -> tuned artifacts -> engagement proof), which upstream did
-    # not do. So it stays enabled by default and is only overridden on request.
-    # Omitted keys => the workflow's own defaults, byte-identical to a direct call.
+    # not do. Preserve whether the caller explicitly requested it: budgeted workflows
+    # give pending head generation priority over tuning enabled only by default.
+    # An explicit true retains tune-then-head; omitted keys use workflow admission.
     if h.get("tuning_skillset") is not None:
         ps_args["tuning_skillset"] = "true" if _as_bool(h["tuning_skillset"]) else "false"
     # tuning-kb is the skillset's per-model ANSWER KEY: right for production, but it
@@ -2775,6 +2776,8 @@ def _tuning_skillset_section(wf: dict, eval_dir: Path) -> dict | None:
     t = wf.get("tuning_skillset")
     if not isinstance(t, dict) or not t.get("enabled"):
         return None
+    admission = t.get("admission_skip")
+    admission_fields = {"admission_skip": dict(admission)} if isinstance(admission, dict) else {}
     if not t.get("ran"):
         # Enabled but never executed (e.g. a phase-scoped invocation that skipped it). Record that
         # plainly rather than implying a measured no-win.
@@ -2782,7 +2785,12 @@ def _tuning_skillset_section(wf: dict, eval_dir: Path) -> dict | None:
             "phase": "TuningSkillset",
             "ran": False,
             "gate": t.get("gate") or "not_run",
-            "explanation": "The standalone tuning-skillset phase was enabled but did not run in this invocation.",
+            "explanation": (
+                "Implicit tuning was skipped to prioritize queued head generation; no tuning worker was started."
+                if admission_fields else
+                "The standalone tuning-skillset phase was enabled but did not run in this invocation."
+            ),
+            **admission_fields,
         }
 
     gate = t.get("gate") or "unknown"
@@ -2811,6 +2819,7 @@ def _tuning_skillset_section(wf: dict, eval_dir: Path) -> dict | None:
     section: dict[str, Any] = {
         "phase": "TuningSkillset",
         "ran": True,
+        **admission_fields,
         "gate": gate,
         "explanation": explanation,
         "mode": t.get("mode") or "",

--- a/interface/test_run_e2e_dispatch.py
+++ b/interface/test_run_e2e_dispatch.py
@@ -270,6 +270,19 @@ class TestMapArgs(_RunE2ECase):
         )
         self.assertNotIn("time_budget_s", ps_zero)
 
+    def test_tuning_request_presence_survives_handoff_mapping(self):
+        # Omission permits budget-aware head priority; explicit true requests tuning first.
+        for supplied, expected in (({}, None), ({"tuning_skillset": True}, "true"),
+                                   ({"tuning_skillset": "true"}, "true"),
+                                   ({"tuning_skillset": False}, "false")):
+            with self.subTest(supplied=supplied):
+                ps = rx.map_args(self._handoff(**supplied), timeout_s=15942)
+                self.assertEqual(ps["time_budget_s"], 15942)
+                if expected is None:
+                    self.assertNotIn("tuning_skillset", ps)
+                else:
+                    self.assertEqual(ps["tuning_skillset"], expected)
+
     def test_unparseable_fidelity_knobs_are_dropped_not_raised(self):
         """A junk max_model_len/mem_fraction must degrade to the adapter default,
         never abort the run before it starts."""

--- a/interface/test_run_e2e_tuning_result.py
+++ b/interface/test_run_e2e_tuning_result.py
@@ -94,6 +94,27 @@ def test_absent_when_phase_disabled(tmp_path):
     assert "tuning_skillset" not in out
 
 
+def test_generation_admission_skip_survives_result_normalization(tmp_path):
+    admission = {"reason": "implicit_tuning_skipped_for_head_generation", "queued_heads": 2}
+    t = _norm(tmp_path, _wf(tuning_skillset={
+        "enabled": True, "ran": False, "gate": "skipped", "admission_skip": admission,
+    }))["tuning_skillset"]
+    assert t["ran"] is False
+    assert t["gate"] == "skipped"
+    assert t["admission_skip"] == admission
+    assert "no tuning worker was started" in t["explanation"]
+    assert "reaches_production_via" not in t
+
+
+def test_carried_tuning_accept_survives_skipping_a_new_attempt(tmp_path):
+    admission = {"reason": "implicit_tuning_skipped_for_head_generation", "queued_heads": 1}
+    t = _norm(tmp_path, _wf(tuning_skillset=_tuning(admission_skip=admission)))["tuning_skillset"]
+    assert t["gate"] == "accepted"
+    assert t["admission_skip"] == admission
+    assert t["deploy_bundle"] == "/eval/tuning/deploy"
+    assert t["apply_overlay"] == "/eval/tuning/overlay"
+
+
 # --------------------------------------------------------------------------- additivity
 
 


### PR DESCRIPTION
Fixes #453

Budgeted runs with queued heads can spend their head-dispatch window in TuningSkillset even when the caller never requested tuning explicitly. This change skips starting that optional phase when `tuning_skillset` is omitted, the external `time_budget_s` is finite and positive, tune and head are selected, and both the head queue and head budget are nonempty.

An explicit `tuning_skillset=true` retains the existing tune-then-head path. Tune-only, no-head, zero-head-budget, disabled-tuning, and unbudgeted behavior stay the same. Carried accepted tuning state, deployment data, and overlays remain available. The ledger, report inputs, workflow result, and normalized `result.json` record `implicit_tuning_skipped_for_head_generation`.

The regression executes the shipped tuning and head blocks with deterministic mocked workers. Its negative control removes only the new admission guard and reproduces zero author dispatch after slow tuning. With admission enabled, capture, bakeoff, authoring including a transient retry, and accepted integration run. Additional cases cover explicit tuning plus head acceptance, carried accepted state, phase/budget boundaries, and skip metadata.

Validation on main `bf7dbe3`:

- Python compatibility and normalization suite: **372 passed, 4 skipped** because Torch is unavailable.
- Existing tuning-contract L0 entry point, including the new scheduling regression: passed.
- Time-reserve and expert-skills compatibility checks: passed.
- Ruff on the three changed Python files and `git diff --check`: passed.
- Whole-workflow syntax check: passed after replacing the exact leading `export const meta =` with `const meta =` and compiling in an async function; this is syntax validation only.

Integration checks at the inspected PR heads:

- PR #437 (`35465a47`) plus the complete-argv correction (#452): applied cleanly; **376 Python tests passed, 4 skipped**; tuning/scheduling Node checks passed.
- PR #444 (`990a84e6`): tuning/scheduling Node checks passed after one declaration-location conflict was resolved by retaining PR444's earlier `let tuning` declaration. The candidate itself remains based on main.

This policy addresses implicit-tuning starvation. It does not reserve a complete generation window, change the dispatch/finalization deadlines, cancel running workers, or guarantee completion of earlier profiling, capture, authoring, or final validation. Explicit tuning can still exhaust the head-dispatch window. No GPU performance result or production adoption is claimed.

