### PR TITLE
Preserve JSON text in environment assignments

### DIFF
--- a/interface/effective_config.py
+++ b/interface/effective_config.py
@@ -51,7 +51,9 @@ class _Flag:
     value: Optional[str]
 
 
-def _protect_bare_json(text: str) -> tuple[str, dict[str, str]]:
+def _protect_bare_json(
+    text: str, *, canonicalize_json: bool = True
+) -> tuple[str, dict[str, str]]:
     """Replace balanced bare JSON values before POSIX ``shlex`` removes quotes."""
 
     protected: dict[str, str] = {}
@@ -102,21 +104,24 @@ def _protect_bare_json(text: str) -> tuple[str, dict[str, str]]:
             i += 1
             continue
         token = f"__GEAK_JSON_{len(protected)}__"
-        protected[token] = json.dumps(
-            parsed, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        protected[token] = (
+            json.dumps(parsed, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+            if canonicalize_json else candidate
         )
         out.append(token)
         i = end
     return "".join(out), protected
 
 
-def _shell_tokens(text: Any) -> list[str]:
-    """Split shell text while retaining and canonicalising bare JSON values."""
+def _shell_tokens(text: Any, *, canonicalize_json: bool = True) -> list[str]:
+    """Split shell text while protecting bare JSON values."""
 
     rendered = str(text or "").strip()
     if not rendered:
         return []
-    protected_text, protected = _protect_bare_json(rendered)
+    protected_text, protected = _protect_bare_json(
+        rendered, canonicalize_json=canonicalize_json
+    )
     tokens = shlex.split(protected_text, posix=True)
     for index, token in enumerate(tokens):
         for marker, value in protected.items():
@@ -197,7 +202,8 @@ def _parse_env(value: Any) -> "OrderedDict[str, str]":
     if isinstance(value, Mapping):
         return OrderedDict((str(key), str(item)) for key, item in value.items())
     result: "OrderedDict[str, str]" = OrderedDict()
-    for token in _shell_tokens(value):
+    # Environment values are opaque strings, including any embedded JSON text.
+    for token in _shell_tokens(value, canonicalize_json=False):
         key, separator, item = token.partition("=")
         if not separator or not key:
             raise ValueError(f"environment entry must be KEY=VALUE: {token!r}")

--- a/interface/test_effective_config.py
+++ b/interface/test_effective_config.py
@@ -217,6 +217,40 @@ def test_conflicting_extra_and_accepted_env_raises(tmp_path: Path) -> None:
         )
 
 
+@pytest.mark.parametrize("quoting", ["bare", "assignment", "value"])
+@pytest.mark.parametrize("value", [
+    '{"b": 2, "a": 1}',
+    '["second", "first"]',
+    '{"scale": 1.00}',
+    '{ "label": "caf\u00e9" }',
+])
+def test_json_environment_values_roundtrip_without_normalization(
+    tmp_path: Path, value: str, quoting: str
+) -> None:
+    token = f"CONFIG={value}"
+    if quoting == "assignment":
+        token = shlex.quote(token)
+    elif quoting == "value":
+        token = f"CONFIG={shlex.quote(value)}"
+    result = resolve_effective_config(_handoff(
+        _recipe(tmp_path, "vllm", ""),
+        extra_envs={"CONFIG": value},
+        accepted_env=token,
+    ))
+
+    assert result.final_env["CONFIG"] == value
+    assert result.conflicts == []
+
+
+def test_distinct_json_environment_strings_still_conflict(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="conflicting environment variable.*CONFIG"):
+        resolve_effective_config(_handoff(
+            _recipe(tmp_path, "vllm", ""),
+            extra_envs={"CONFIG": '{"scale":1.0}'},
+            accepted_env=shlex.quote('CONFIG={"scale":1.00}'),
+        ))
+
+
 def test_manifest_digest_and_dict_are_deterministic(tmp_path: Path) -> None:
     recipe = _recipe(tmp_path, "vllm", "--dtype auto", A="1")
     first = resolve_effective_config(_handoff(recipe))


### PR DESCRIPTION
Environment values emitted in both `extra_envs` and `accepted_env` could falsely conflict because GEAK canonicalized JSON only in the shell-string form. Keep the original JSON text when tokenizing environment assignments. Server-flag tokenization retains its existing semantic normalization.

Regression coverage exercises bare assignments, whole-assignment quoting, and value-only quoting with object key order, array whitespace, numeric spelling, and Unicode. A separate case confirms that distinct literal JSON environment strings still conflict. On main the new cases produce **9 failures and 4 passes**; the corrected focused resolver/dispatch/alignment/Magpie suite passes **249 tests**, plus 8 subtests.

The candidate applies cleanly over #452 and #437+#452. With Hyperloom's separate producer-quoting correction, both compositions pass all **12 actual producer-to-consumer boundary cases**: six argv/state cases and six environment cases. The harness calls production functions and stops before the external runner.

The complete L0 Python job passed **1,949 tests, with 5 skips**, plus 85 passing subtests. The coverage gate passed at **97.47%** over its configured trees; `effective_config.py` reached 100%. An initial local wrapper set `PYTHONPATH` to the repository root, which made a script-local `kb.py` shadow the `kb` package in subprocess tests. Removing that wrapper override made the unchanged tests pass.

Ruff 0.16.6 reports the same 17 advisory findings on the two files before and after the patch, with no new findings. Whitespace checks pass.

This change preserves supported bare-JSON assignments and does not alter launch-argument authority, measurement mode, or worker scheduling. No GPU performance or historical funnel recovery is claimed.

Fixes #455.
