### PR TITLE
Gate optimization on roofline of 85%; lower the %GPU bar 5% -> 2%

### DIFF
--- a/.github/workflows/ci-l0-checks.yml
+++ b/.github/workflows/ci-l0-checks.yml
@@ -279,6 +279,13 @@ jobs:
       # exercise the JS half, and the clock is pure time arithmetic — no GPU, no model.
       - name: wall-clock budget / final reserve regression
         run: node e2e_workflow/scripts/test_time_budget_reserve.js
+      # The roofline gate can drop the single biggest kernel in a profile, so its confidence
+      # carve-outs (suspect / unknown / low-confidence never skip) are what keeps one bad byte
+      # model from silently deleting the run's whole workload. Predicate is extracted from the
+      # shipped source; the target table is held in sync with the Python side by
+      # scripts/tests/test_roofline_skill.py. Pure node — no GPU, no model.
+      - name: roofline skip-gate regression
+        run: node e2e_workflow/scripts/test_roofline_gate.js
 
   tuning-skillset-integrity:
     name: Vendored tuning skillset matches its manifest

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -62,9 +62,9 @@ extraction, and reversible reintegration; recursively calls `kernel_workflow.js`
 | `budget` | `6` | Max kernel-optimization tasks (config sweep is free). |
 | `kernel_budget` | `6` (`3` in fast) | Budget passed down to each recursive single-kernel run. |
 | `min_kernel_tasks` | `4` (capped by `budget`) | Milestone floor. |
-| `milestone_min_pct` | `5` | Skip editable kernels below this %GPU time (Amdahl). |
+| `milestone_min_pct` | `2` | Skip editable kernels below this %GPU time (Amdahl). Kernels at/above their roofline `target_eff` are skipped too. |
 | `config_tune` | `true` | Tier-0 flag/env/backend sweep on/off (runs FIRST). |
-| `head_threshold_pct` | `5` | Head-kernel selection threshold. |
+| `head_threshold_pct` | `2` | Head-kernel selection threshold. |
 | `head_budget` | `3` (≥ GPU count in fast) | Max head bake-offs. |
 | `head_author_max` | `2` | Author languages per head (FlyDSL + Triton). |
 | `head_protect_pct` | `30` | A dominant head is never silently dropped. |

--- a/e2e_workflow/README.md
+++ b/e2e_workflow/README.md
@@ -95,8 +95,9 @@ Workflow({
     kernel_workflow_dir: "<...>/workflows",          // optional; default = sibling kernel_workflow/
     budget: 4,            // max kernel-optimization tasks (kernel-layer tasks; config sweep is free)
     kernel_budget: 6,     // budget passed DOWN to each recursive single-kernel run
-    milestone_min_pct: 5, // Milestone only optimizes editable kernels with pct_gpu_time >= this (default 5);
-                          //   overrides min_kernel_tasks — sub-threshold kernels are skipped (Amdahl)
+    milestone_min_pct: 2, // Milestone only optimizes editable kernels with pct_gpu_time >= this (default 2);
+                          //   overrides min_kernel_tasks — sub-threshold kernels are skipped (Amdahl).
+                          //   A kernel already at/above its roofline target_eff is skipped as well.
     config_tune: "true",  // Tier-0 sweep on/off (default ON)
     tuning_skillset: "true", // standalone TuningSkillset phase on/off (default ON). Runs the VENDORED
                           //   tuning skillset (<repo>/perf_knowledge/expert_skills/tuning) WHOLE, as its own phase, AFTER

--- a/e2e_workflow/e2e_workflow.js
+++ b/e2e_workflow/e2e_workflow.js
@@ -9,7 +9,7 @@ export const meta = {
     { title: 'ConfigSweep', detail: 'Config Tuner sweeps flags/env/backends FIRST (default ON)' },
     { title: 'TuningSkillset', detail: 'Tuning Specialist runs the VENDORED tuning skillset whole + standalone (its own pre/post A/B) BEFORE HeadKernel, so its share of the gain is attributable' },
     { title: 'HeadKernel', detail: 'highest-%GPU ops (GEMM/attn): extract_op -> backend bake-off (incl. FlyDSL) + aiter-DB/author tune -> e2e gate' },
-    { title: 'Milestone', detail: 'loop over editable kernels ABOVE milestone_min_pct% GPU (default 5): plan -> extract -> recursive kernel optimize -> overlay -> e2e gate -> reprofile' },
+    { title: 'Milestone', detail: 'loop over editable kernels ABOVE milestone_min_pct% GPU (default 2) with roofline headroom left: plan -> extract -> recursive kernel optimize -> overlay -> e2e gate -> reprofile' },
     { title: 'Finalize-gate', detail: 'finish any e2e A/B left incomplete before the final phase (still OPTIMIZATION work: budget-capped, never runs inside the final reserve)' },
     { title: 'Finalize', detail: 'e2e Integrator assembles the overlay + patch + launch bundle' },
     { title: 'Report', detail: 'System Architect writes the throughput report + grows the playbook' },
@@ -57,8 +57,11 @@ const EXP_ROOT = String(A.exp_root || (WORKFLOW_DIR.replace(/\/[^/]*$/, '') + '/
 // After parse_profile.py emits the standardized Top-N, the Profiler may run ONE analysis skill to
 // enrich it with a headroom estimate the Architect can route on. Default `roofline`: per-kernel % of
 // the hardware ceiling -> attainable speedup -> expected e2e gain, so budget goes to the kernel with
-// HEADROOM rather than merely the biggest one. STRICTLY ADVISORY: it annotates and suggests an
-// ordering, never prunes a candidate and never overrides the measured pct_gpu_time.
+// HEADROOM rather than merely the biggest one. ADVISORY except for ONE declared gate: it annotates,
+// suggests an ordering, and never overrides the measured pct_gpu_time -- but a kernel already at or
+// above its class `target_eff` is dropped from both optimization tracks (`rooflineSkip` below;
+// predicate in the skill's SKILL.md section 3 step 7). That gate fires only on a full-confidence
+// verdict, so a degraded/suspect/low-confidence estimate still only reorders.
 // `analysis_skill=none` (or a missing/unreadable skill dir) disables the step and the run behaves
 // exactly as it did before the feature existed -> ANALYSIS_SKILL_* are '' and nothing is injected.
 const ANALYSIS_SKILL = String(A.analysis_skill != null ? A.analysis_skill : 'roofline').trim();
@@ -67,7 +70,7 @@ const ANALYSIS_SKILL_INPUTS = ANALYSIS_SKILL_ON ? {
   ANALYSIS_SKILL: ANALYSIS_SKILL,
   ANALYSIS_SKILL_DIR: `${WORKFLOW_DIR}/knowledge/analysis_skills/${ANALYSIS_SKILL}`,
 } : { ANALYSIS_SKILL: '', ANALYSIS_SKILL_DIR: '' };
-if (ANALYSIS_SKILL_ON) log(`Profile-analysis skill: ${ANALYSIS_SKILL} (advisory; annotates + reorders, never prunes).`);
+if (ANALYSIS_SKILL_ON) log(`Profile-analysis skill: ${ANALYSIS_SKILL} (advisory for ordering; ONE gate: at/above target_eff -> not optimized).`);
 
 // ---- Upstream TraceLens / kernel-agent prior (OPTIONAL; forwarded by run_e2e.py as args.tracelens) ----
 // run_e2e.py resolves these paths beside the geak handoff and forwards ONLY the non-null ones.
@@ -195,9 +198,9 @@ const BUDGET = parseInt(A.budget != null ? A.budget : 6, 10);       // max kerne
 const MIN_KERNEL_TASKS = Math.min(parseInt(A.min_kernel_tasks != null ? A.min_kernel_tasks : 4, 10), BUDGET);
 // Milestone only optimizes editable kernels whose profiled share is worth it: skip any candidate with
 // pct_gpu_time below this threshold (Amdahl — a kernel a few % of GPU can't move e2e past the noise band).
-// Configurable via args.milestone_min_pct (default 5). This OVERRIDES the MIN_KERNEL_TASKS floor: if no
+// Configurable via args.milestone_min_pct (default 2). This OVERRIDES the MIN_KERNEL_TASKS floor: if no
 // candidate clears the bar, the milestone stops rather than grinding low-value kernels.
-const MILESTONE_MIN_PCT = parseFloat(A.milestone_min_pct != null ? A.milestone_min_pct : 5);
+const MILESTONE_MIN_PCT = parseFloat(A.milestone_min_pct != null ? A.milestone_min_pct : 2);
 const KERNEL_BUDGET = parseInt(A.kernel_budget != null ? A.kernel_budget : (FAST_MODE ? 3 : 6), 10); // budget passed DOWN per kernel (fewer rounds in fast mode)
 const CONFIG_TUNE_ENABLED = String(A.config_tune != null ? A.config_tune : 'true') === 'true';
 // ---- TUNING SKILLSET phase (default ON) --------------------------------------------------------------
@@ -227,7 +230,7 @@ const TUNING_KB_ENABLED = String(A.tuning_kb != null ? A.tuning_kb : 'true') ===
 // recursive kernel-authoring run; tuning ops are cheap by comparison and their value is cumulative, so
 // a cap would just leave measurable wins on the table. The role decides where the returns stop.
 // Head-kernel track (GEMM/attention) — the highest-pct_gpu_time ops, optimized regardless of edit flag.
-const HEAD_THRESHOLD_PCT = parseFloat(A.head_threshold_pct != null ? A.head_threshold_pct : 5);
+const HEAD_THRESHOLD_PCT = parseFloat(A.head_threshold_pct != null ? A.head_threshold_pct : 2);
 // max head-op bake-offs. FAST MODE: the head track is parallelized across the GPU pool (one exclusive
 // lane per card), so scale the default up to the lane count (>=3) to keep every card busy in opt-A.
 // Default mode is UNCHANGED (3).
@@ -1409,6 +1412,41 @@ function kernelSelectionVerified(h, ext) {
   return { ok: true, why: `${target} launches profiled kernel ${required}` };
 }
 
+// ---- roofline skip gate ------------------------------------------------------------------------
+// A kernel already executing its byte/FLOP budget at its class target has no recoverable time left,
+// so an optimization budget spent on it buys nothing. It is dropped from BOTH tracks (head here,
+// milestone kernels below) regardless of pct_gpu_time. Source of truth for these numbers is
+// knowledge/analysis_skills/roofline/SKILL.md §7; roofline_tools.TARGET_EFF and this table are held
+// in sync by scripts/tests/test_roofline_skill.py.
+const ROOFLINE_TARGET_EFF = { gemm: 0.85, moe: 0.85, elementwise: 0.85, attn: 0.60 };
+
+// The gate fires ONLY on a full-confidence verdict. roofline_pct is a model, and the skill's own §6/§8
+// catalogue how it goes wrong: an infeasible byte model clamps to 1.0, and an unvalidated compute peak
+// can read a 43%-of-roofline kernel as 85%. Skipping on either would silently delete the largest kernel
+// in the profile — a far worse failure than tuning a saturated one. So anything degraded, suspect,
+// unclassified or low-confidence falls through to ordinary Amdahl ordering, as does a run with no
+// analysis skill at all (no fields -> no skip -> `analysis_skill=none` behaves exactly as before).
+function rooflineSkip(cand) {
+  if (!cand || cand.skip_optimization === false) return null;
+  const pct = Number(cand.roofline_pct);
+  if (!Number.isFinite(pct) || pct <= 0) return null;
+  if (cand.suspect === true) return null;
+  const klass = String(cand.headroom_class || '').trim().toLowerCase();
+  if (!klass || klass === 'unknown') return null;
+  const conf = String(cand.roofline_confidence || '').trim().toLowerCase();
+  if (conf !== 'medium' && conf !== 'high') return null;
+  // Prefer the target the analysis actually used; fall back to the class table only when absent, so
+  // a recalibrated target (SKILL.md §8 rule 5) reaches the gate without a code change.
+  let tgt = Number(cand.target_eff);
+  if (!Number.isFinite(tgt) || tgt <= 0) {
+    const kind = String(cand.op_kind || cand.classification || '').trim().toLowerCase();
+    tgt = ROOFLINE_TARGET_EFF[Object.keys(ROOFLINE_TARGET_EFF).find(k => kind.includes(k))];
+  }
+  if (!Number.isFinite(tgt) || tgt <= 0) return null;   // unknown op class -> no bar -> no skip
+  if (pct < tgt) return null;
+  return `roofline ${pct.toFixed(3)} >= target_eff ${tgt.toFixed(3)} (${klass}, confidence=${conf})`;
+}
+
 const PRE_FLAGGED_HEADS = [];
 function admitHeads(queue, stage) {
   const admitted = [];
@@ -1431,6 +1469,17 @@ function admitHeads(queue, stage) {
       PRE_FLAGGED_HEADS.push({ short_name: label,
         pct_gpu_time: head.pct_gpu_time, stage, gate: 'missing_kernel_identity',
         reason: 'gpu_kernel head carries no device_kernel/short_name/name' });
+      continue;
+    }
+    // Saturated heads are recorded, not silently dropped: a run that skipped the biggest kernel in
+    // its profile must say so in the report rather than look like it found nothing to do.
+    const saturated = rooflineSkip(head);
+    if (saturated) {
+      log(`  ⏭️  SKIP ${label} (${(+head.pct_gpu_time || 0).toFixed(1)}% GPU): ${saturated} — ` +
+        `no recoverable time, not worth a head-track budget (${stage}).`);
+      PRE_FLAGGED_HEADS.push({ short_name: label,
+        pct_gpu_time: head.pct_gpu_time, stage, gate: 'roofline_saturated',
+        reason: saturated });
       continue;
     }
     admitted.push(prepareHeadSelection(head));
@@ -4233,11 +4282,14 @@ while (want('kernel') && !TIME_DEADLINE_HIT && dispatched < BUDGET && (dispatche
   const planCandsRaw = (plan && plan.kernel_candidates) ? plan.kernel_candidates : [];
   // pct_gpu_time gate: only optimize kernels above MILESTONE_MIN_PCT (a candidate missing pct is kept,
   // not silently dropped — but logged). This gate OVERRIDES the min-floor: low-pct kernels are not worth it.
-  const planCands = planCandsRaw.filter(c => c.pct_gpu_time == null || c.pct_gpu_time >= MILESTONE_MIN_PCT);
-  const skipped = planCandsRaw.filter(c => c.pct_gpu_time != null && c.pct_gpu_time < MILESTONE_MIN_PCT);
-  if (skipped.length) log(`Milestone ${milestone}: skipped ${skipped.length} kernel(s) below ${MILESTONE_MIN_PCT}% GPU [${skipped.map(c => `${c.short_name || '?'}@${(+c.pct_gpu_time).toFixed(1)}%`).join(', ')}].`);
+  // Second gate, same place: a kernel already at its roofline target has no time left to recover, so
+  // clearing the pct bar is necessary but not sufficient. Both reasons are reported in one line.
+  const belowBar = c => c.pct_gpu_time != null && c.pct_gpu_time < MILESTONE_MIN_PCT;
+  const planCands = planCandsRaw.filter(c => !belowBar(c) && !rooflineSkip(c));
+  const skipped = planCandsRaw.filter(c => belowBar(c) || rooflineSkip(c));
+  if (skipped.length) log(`Milestone ${milestone}: skipped ${skipped.length} kernel(s) [${skipped.map(c => `${c.short_name || '?'}@${(+c.pct_gpu_time || 0).toFixed(1)}%${belowBar(c) ? ` <${MILESTONE_MIN_PCT}% GPU` : ` saturated: ${rooflineSkip(c)}`}`).join(', ')}].`);
   if (!planCands.length) {
-    if (planCandsRaw.length) log(`Milestone ${milestone}: stop — no remaining kernel clears the ${MILESTONE_MIN_PCT}% GPU bar (Amdahl: sub-threshold kernels can't move e2e). Floor is overridden by the pct gate.`);
+    if (planCandsRaw.length) log(`Milestone ${milestone}: stop — no remaining kernel both clears the ${MILESTONE_MIN_PCT}% GPU bar and has roofline headroom. Floor is overridden by these gates.`);
     else if (belowFloor) log(`Milestone ${milestone}: below floor (${dispatched}/${MIN_KERNEL_TASKS}) but Architect nominated nothing — cannot fabricate candidates; stopping.`);
     else log(`Milestone ${milestone}: stop (floor ${MIN_KERNEL_TASKS} met). ${plan ? plan.reasoning || '' : ''}`);
     break;

--- a/e2e_workflow/knowledge/analysis_skills/INDEX.md
+++ b/e2e_workflow/knowledge/analysis_skills/INDEX.md
@@ -14,9 +14,13 @@ feature existed — see "Degradation" in each skill.
 
 ## Contract every skill must honour
 
-1. **Advisory only.** A skill may ADD fields, ADD annotations and SUGGEST an ordering. It may never
-   prune a candidate, never overwrite the measured `pct_gpu_time`, and never be the sole reason a
-   kernel is or isn't optimized. The on-box measurement is always the judge.
+1. **Additive, with ONE declared gate.** A skill may ADD fields, ADD annotations and SUGGEST an
+   ordering, and it may never overwrite the measured `pct_gpu_time`. It may prune a candidate only
+   through a **single, named, documented gate** whose exact predicate is written in its `SKILL.md`
+   (`roofline`: `skip_optimization`, §3 step 7) — never as a side effect of ranking. That gate must
+   fire only on a full-confidence verdict: a degraded, `suspect`, `unknown` or low-confidence entry is
+   ordered the ordinary way, never dropped. A skill may still never be the reason a result is
+   ACCEPTED — the on-box e2e measurement is always that judge.
 2. **Markdown-first.** The skill's logic lives in its `SKILL.md` so an agent can execute it by reading.
    Helper scripts are OPTIONAL mechanical primitives (parsing, unit math). If a helper is missing or
    raises, the agent completes the analysis by hand from `SKILL.md` — a broken script must not disable

--- a/e2e_workflow/knowledge/analysis_skills/roofline/SKILL.md
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/SKILL.md
@@ -13,14 +13,19 @@ must not fail the run.**
 ## 0. The one doctrine that matters
 
 > `roofline_pct` measures **how well the kernel executes its current algorithm's byte/FLOP budget.**
-> It says **nothing about whether that budget is necessary.**
+> A kernel that already spends that budget at its class target has **no recoverable time left**, and
+> an optimization budget spent on it buys nothing.
 
-A kernel at 90% of the memory roofline is not "done" — it is **done with kernel micro-tuning**. The
-remaining lever is to move fewer bytes. Never read a high `roofline_pct` as "stop optimizing this
-kernel", especially when it is the largest consumer of GPU time. See §7.
+So this skill **gates**, it does not merely advise: `roofline_pct >= target_eff` (§7) removes the
+kernel from both optimization tracks, however large its `pct_gpu_time`. The measured example in §9 is
+exactly this case — a head owning 26.45% of GPU time, at 88% of its roof, whose optimization measured
+**−0.064% e2e**. Ranking by `pct_gpu_time` alone spends the run on it every time.
 
-Corollary: this skill is **advisory**. It reorders and annotates. `pct_gpu_time` remains the primary
-key and the measurement remains the judge. This skill may never prune a candidate.
+**The gate fires only on a real verdict.** `roofline_pct` is a *model*, and §6/§8 catalogue the ways
+that model is wrong. An entry that is `suspect`, `headroom_class: unknown`, or `confidence: low` is
+NOT evidence of saturation and must never be skipped — it is re-measured (stage C) or ranked the
+ordinary Amdahl way. Deleting the biggest kernel in the profile because a byte model was wrong is a
+far worse failure than tuning a saturated one.
 
 ---
 
@@ -58,13 +63,14 @@ Write `profile/round_<R>/profile_roofline.json` and a human-readable `profile_ro
     "arithmetic_intensity": 4.6, "ridge_point": 625.0,
     "bound_type": "memory|compute|latency|unknown",  // latency = neither roof near its ceiling
     "roofline_pct": 0.88,               // achieved / peak on the AI-selected roof
-    "target_eff": 0.90,
-    "attainable_speedup": 1.023,
-    "expected_e2e_gain_pct": 0.59,
+    "target_eff": 0.85,
+    "attainable_speedup": 1.0,
+    "expected_e2e_gain_pct": 0.0,
     "headroom_class": "underperforming|moderate|saturated|unknown",
     "confidence": "low|medium|high",
     "suspect": false,
-    "byte_reduction_levers": ["..."],   // populated only when headroom_class=saturated
+    "skip_optimization": true,          // roofline_pct >= target_eff -> not optimized at all (§3 step 7)
+    "skip_reason": "roofline 0.880 >= target_eff 0.850 -> no recoverable time; ...",
     "notes": "assumptions made, what would sharpen this"
   }],
   "ranking_by_pct": ["..."],            // BOTH rankings are emitted, side by side
@@ -79,7 +85,7 @@ see the disagreement rather than a single blended number that hides it.
 
 ## 3. Procedure
 
-0. **Scope to the head.** Analyse ONLY entries with `pct_gpu_time >= HEAD_THRESHOLD_PCT` (default 5),
+0. **Scope to the head.** Analyse ONLY entries with `pct_gpu_time >= HEAD_THRESHOLD_PCT` (default 2),
    biggest first, capped at ~8. Below that bar the Amdahl ceiling is under the noise band no matter
    what the roofline says, so a headroom estimate cannot change a decision — modelling those kernels
    only adds failure modes. Skipped entries are **absent** from the artifact; they are NOT `degraded[]`
@@ -117,13 +123,15 @@ see the disagreement rather than a single blended number that hides it.
    roof is real, and `target_eff` already prices in the occupancy penalty for irregular classes like
    paged attention) — so a low-utilization head still ranks by its headroom. What changes is the
    **lever**: latency-bound underperformance is fixed by occupancy / shorter dependency chains /
-   fusion, **not** by byte reduction (§7.1). Byte reduction only helps a genuinely bandwidth-bound
+   fusion, **not** by byte reduction. Byte reduction only helps a genuinely bandwidth-bound
    (high-`hbm_util`) head.
 6. Classify headroom, banded against `target_eff` (**not** against the raw roofline — what matters is
    the distance to what a good implementation of this class can realistically reach):
    `roofline_pct ≥ 0.9×target_eff` → **saturated**; `≥ 0.6×target_eff` → **moderate**; else →
    **underperforming**; unmodelled or low-confidence → **unknown**.
-   *88% against a 0.90 target is **saturated**, not "nearly there" — tuning has nothing left to give.*
+   *80% against a 0.85 target is **saturated**, not "nearly there" — tuning has nothing left to give.*
+   These three bands are a **description**, deliberately wider than the skip gate in step 7: the band
+   `0.9×target ≤ roofline_pct < target` is "saturated but still optimized".
 
    **Two outcomes must produce NO verdict** (`headroom_class: "unknown"`), because in each the ratio
    is not evidence about the kernel:
@@ -140,7 +148,20 @@ see the disagreement rather than a single blended number that hides it.
 
    `bound_type` is a CLOSED set: `memory | compute | latency | unknown`. If none fits, emit `unknown`
    — never invent a category the consumer has no routing rule for.
-7. Sanity-check (§6 L3), emit both rankings, write the artifact.
+7. **Decide the skip gate** — this is the one field the consumer acts on rather than ranks on:
+   ```
+   skip_optimization = (headroom_class != "unknown") and (not suspect) and (roofline_pct >= target_eff)
+   ```
+   A kernel at or above its class target has no recoverable time left, so it is dropped from **both**
+   optimization tracks (head and kernel) rather than reordered. Populate `skip_reason` when it fires.
+
+   **The two guards are not optional.** Both no-verdict outcomes above already set
+   `headroom_class: "unknown"`, and this gate must respect that — otherwise an infeasible model
+   clamped to 1.0, or a `confidence: low` derived peak, deletes the largest kernel in the profile on
+   the strength of a number §6 says is not evidence. A `low`-confidence entry (stage A, or peaks
+   derived from device props) may be **displayed** but must NOT set `skip_optimization`; re-measure at
+   stage C first. See §8: a "kernel at 85%" read off an unvalidated peak may really be at 43%.
+8. Sanity-check (§6 L3), emit both rankings, write the artifact.
 
 **Per-launch, not aggregate.** Compare bytes for ONE launch against ONE launch's `base_latency_ms`. If
 a logical op is split across several launches (e.g. a fused-MoE layer issuing a stage-1 and a stage-2
@@ -177,7 +198,7 @@ flops = 2 · pairs · (per-expert MAC count for this stage)
 bytes ≈ experts_hit · (per-expert weight elems) · w   + activations
 ```
 If the implementation streams **all** `E` experts regardless of routing, use `E` instead of
-`experts_hit` — and note that the difference between the two IS a byte-reduction lever (§7). When
+`experts_hit` — and note that the difference between the two IS an algorithmic lever (§7.1). When
 unsure which the kernel does, compute both, report the `experts_hit` figure, and put the all-expert
 figure in `notes`.
 
@@ -248,12 +269,15 @@ the model needs stage-C measurement, not as a hardware anomaly.
 `target_eff` = how close a **well-implemented** kernel of this class gets to its roofline bound. It is
 set by **access regularity**, not by how important the kernel is.
 
+It is **also the skip bar** (§3 step 7): at or above it, the kernel is not optimized at all. So these
+four numbers decide what a run works on, and moving one moves the whole budget.
+
 | op class | `target_eff` | why |
 |---|---|---|
-| dense GEMM | **0.90** | regular, dense compute |
-| MoE / grouped GEMM | **0.90** | decode weight streaming is essentially a memcpy |
-| elementwise / norm / quant | 0.85–0.90 | pure streaming |
-| attention decode (paged) | **0.50** | irregular paged KV access, occupancy-sensitive |
+| dense GEMM | **0.85** | regular, dense compute |
+| MoE / grouped GEMM | **0.85** | decode weight streaming is essentially a memcpy |
+| elementwise / norm / quant | **0.85** | pure streaming |
+| attention decode (paged) | **0.60** | irregular paged KV access, occupancy-sensitive |
 
 These are **priors, not constants** — §8 corrects them from observed outcomes.
 
@@ -261,12 +285,13 @@ These are **priors, not constants** — §8 corrects them from observed outcomes
 
 | `headroom_class` | `bound_type` | `pct_gpu_time` | route |
 |---|---|---|---|
+| **any, with `roofline_pct ≥ target_eff`** | any | **any** | **SKIPPED — dropped from both tracks** (§3 step 7). Applies however large `pct_gpu_time` is |
 | underperforming | memory / compute | high | **kernel track, top priority** — real micro-optimization headroom |
 | underperforming | latency | high | kernel track — but the lever is **occupancy / dependency-chain / fusion / split-K**, not byte reduction |
-| **saturated** | memory | **high** | **byte-reduction / algorithmic track — NOT dropped** (§7.1) |
-| saturated | latency | high | occupancy/access-pattern is the ceiling — fewer bytes (e.g. fp8 KV) or fusion; not more tuning |
+| saturated (still below target) | memory | high | kernel track, low priority — little left, but not yet at the bar |
+| saturated (still below target) | latency | high | occupancy / access pattern is the ceiling; fusion before more tuning |
 | any | any | low | low priority (ordinary Amdahl) |
-| unknown, or `confidence: low` | any | any | **fall back entirely to `pct_gpu_time` ordering** |
+| unknown, `suspect`, or `confidence: low` | any | any | **never skipped** — fall back entirely to `pct_gpu_time` ordering |
 
 **Shippability gate (applies before any of the above).** A head kernel with no editable call site —
 a monolithic hand-written assembly `.co` or a precompiled CK `.so` — cannot take an in-kernel rewrite
@@ -275,22 +300,19 @@ tuning DB (`tuned_fmoe`, `AITER_CONFIG_*`), or a backend swap. When the profiler
 non-editable, route it to the host-side track and say so; do not dispatch a rewrite that cannot be
 integrated. (The `editable` flag comes from the profiler's Top-N, not from this skill.)
 
-### 7.1 Saturated + high `pct_gpu_time` → byte-reduction levers
+### 7.1 What a skipped kernel is NOT
 
-The biggest kernel stays the biggest target; only the *class of fix* changes. Enumerate levers that
-make the kernel move **fewer bytes for the same work**:
+`skip_optimization` means *this run does not spend budget here*. It does not mean the kernel is
+optimal in an absolute sense: a kernel at its roofline still moves whatever bytes its **algorithm**
+demands, and changing that algorithm (fusing an adjacent op away, not streaming experts routing never
+touches, fp8→fp4 weights) can still beat it. That work is out of scope for this skill and for the
+optimization tracks it feeds — it is an algorithmic change, not a kernel optimization, and it is
+routed by the Architect on its own merits, not by a roofline number.
 
-- **Fuse an adjacent op away.** If a prologue/epilogue kernel (activation quant, silu, a norm) appears
-  separately in the Top-N, fusing it into the saturated kernel removes an entire activation round-trip
-  — and removes that kernel's own GPU time too.
-- **Stop reading what isn't used.** If the kernel streams all `E` experts but routing only touches
-  `experts_hit`, the difference is pure waste.
-- **Layout / packing.** Remove padding waste, improve coalescing, improve L2 reuse between stages of
-  the same logical op.
-- **Lower-precision weights** (e.g. fp8 → fp4). Directly cuts bytes. **Lossy — must pass the accuracy
-  gate.**
+Record skipped heads in the artifact with their `skip_reason` rather than omitting them, so a run
+that skipped its largest kernel says so plainly instead of looking like it found nothing.
 
-**Hard constraints on every byte-reduction lever (do not violate):**
+**Hard constraints on every lever this skill routes to (do not violate):**
 > The **measurement contract and output semantics are fixed.** The workload — `isl`, `osl`,
 > **`conc` / batch size — is supplied by the user and must not be changed**. Do **not** introduce
 > speculative decoding (MTP or otherwise) as an optimization. A lever that raises throughput by
@@ -303,8 +325,10 @@ make the kernel move **fewer bytes for the same work**:
 2. **Validate the peak before believing a `roofline_pct`.** The peaks are empirical microbench
    results, not spec figures. The load-bearing cross-check: BF16 and FP16 MFMA run at the same rate on
    these parts, so their peaks must be equal — when they are not, the compute-axis number is inflated
-   (a "kernel at 85%" may really be at 43%). Trivial streaming also tops out near ~0.85 of the HBM pin
-   rate, which is why the memory `target_eff` is 0.90, not 1.0.
+   (a "kernel at 85%" may really be at 43%). **This is why the skip gate refuses `confidence: low`
+   entries** — 85% is now a hard bar, and an inflated compute axis would skip a kernel with 2× of
+   headroom left. Trivial streaming also tops out near ~0.85 of the HBM pin rate, which is why the
+   memory `target_eff` is 0.85, not 1.0.
 3. **Two noise bands, not one.** An **isolated-kernel** speedup is real only if it clears the
    isolated repeat band (**~3.4%** on identical reruns here — much wider than people assume), while an
    **e2e serving** delta uses the serving band (~0.5%). Do not judge an isolated kernel win against the
@@ -315,8 +339,8 @@ make the kernel move **fewer bytes for the same work**:
    `expected_e2e_gain_pct` vs measured isolated speedup and measured e2e delta) into
    `knowledge/backend_playbook.md`, which already grows every run. Systematic error in a class's
    `target_eff` or byte model shows up there and is corrected in the next run.
-6. **Never sole authority.** No candidate is ever pruned because of this skill; no result is ever
-   accepted because of it. The e2e gate decides.
+6. **Never sole authority for ACCEPTING.** This skill prunes (§3 step 7), but it never accepts: no
+   result is ever taken as a win because of a roofline number. The e2e gate decides that.
 
 ## 9. Worked example (real data — Qwen3.5-35B-A3B-FP8, gfx950, vLLM, TP1, isl/osl 1k, conc 64)
 
@@ -327,17 +351,27 @@ layers ⇒ 2 launches per layer ⇒ one logical layer = 98.9 µs.
 E=256, top_k=8, hidden=2048, moe_intermediate=512, fp8 weights. At M=64, `pairs`=512 ⇒
 `experts_hit` ≈ 221/256. Layer weight bytes ≈ 697 MB (all-expert: 805 MB).
 ⇒ achieved 7.04 TB/s = **88% of roofline**, AI ≈ 4.6 ≪ ridge 625 ⇒ **memory-bound**.
-⇒ `attainable_speedup` = 0.90/0.88 = **1.023×**, `expected_e2e_gain_pct` = **+0.59%** → **saturated**.
-*(All-expert bytes give 102% — an L3 `suspect` case, and evidence for the "stop reading unused
-experts" lever.)*
+⇒ 0.88 ≥ the 0.85 MoE target ⇒ `attainable_speedup` = **1.0×**, `expected_e2e_gain_pct` = **0.00%**,
+**saturated**, and **`skip_optimization: true`** — the largest kernel in the profile is not optimized.
+*(All-expert bytes give 102% — an L3 `suspect` case, which is therefore **not** skipped: the same
+number arrived at through a broken byte model carries no verdict.)*
 
 **`kernel_paged_attention_2d`** — `pct_gpu_time` 8.86%, decode `t` = 141.1 µs, 10 launches/step
 (= the 10 full-attention layers of 40, `full_attention_interval`=4).
-⇒ achieved ≈ 1.4–2.3 TB/s = **18–29% of roofline** ⇒ `attainable_speedup` ≈ **1.7–2.8×**,
-`expected_e2e_gain_pct` ≈ **+3.7%** → **underperforming**.
+⇒ achieved ≈ 1.4–2.3 TB/s = **18–29% of roofline** ⇒ against the 0.60 target,
+`attainable_speedup` ≈ **2.1–3.4×**, `expected_e2e_gain_pct` ≈ **+4.7–6.2%** → **underperforming**,
+not skipped.
 
 **Why this matters:** ranking by `pct_gpu_time` puts MoE first (26.45% vs 8.86%). Ranking by roofline
 headroom puts attention first. The run that produced these numbers spent its budget on the MoE and
-measured **−0.064% e2e** (isolated 1.047×, predicted 1.023× ✅); the attention kernel it reached later
-yielded **1.56× isolated** (predicted 1.7× ✅). Both predictions were calibrated — and the MoE was
-correctly identified as needing a byte-reduction lever, not another tuning pass.
+measured **−0.064% e2e**; the attention kernel it reached later yielded **1.56× isolated**. The gate
+encodes that outcome: the MoE is skipped and the budget goes to attention.
+
+**Two honest caveats on these priors** (§8 rule 5 — record predicted vs actual, do not launder it):
+- The MoE's isolated speedup was **1.047×**, above the 1.0× a skipped kernel is credited with. By §8
+  rule 4 that is the model being wrong, and on an isolated bench it was. It is skipped anyway because
+  the number that decides is the e2e one, and that was **−0.064%** — a real isolated win that bought
+  nothing served.
+- Attention against a 0.60 target predicts **2.1–3.4×** where the squad measured **1.56×**. The prior
+  is optimistic here, more so than the 0.50 it replaced. It is used to rank and to gate, not to
+  promise a speedup; the isolated bench remains the judge of what was actually achieved.

--- a/e2e_workflow/knowledge/analysis_skills/roofline/roofline_tools.py
+++ b/e2e_workflow/knowledge/analysis_skills/roofline/roofline_tools.py
@@ -31,17 +31,22 @@ _DTYPE_BYTES = {
 }
 
 # target_eff priors -- SKILL.md section 7 is the source of truth; keep the two in sync.
+# These are ALSO the skip bar: a kernel at or above its class target is not optimized at all
+# (see `skip_optimization` below), so moving one of these numbers moves what the run works on.
 TARGET_EFF = {
-    "gemm": 0.90,
-    "moe": 0.90,
-    "elementwise": 0.875,
-    "attn": 0.50,
+    "gemm": 0.85,
+    "moe": 0.85,
+    "elementwise": 0.85,
+    "attn": 0.60,
 }
 
 #: Only kernels big enough for a headroom estimate to change a decision are worth analysing.
 #: Below this the Amdahl ceiling is under the noise band anyway, so modelling them adds failure
 #: modes without adding information. Callers should pass the run's HEAD_THRESHOLD_PCT.
-DEFAULT_MIN_PCT_GPU = 5.0
+#: Tracks the orchestrator's pct_gpu_time bar (milestone_min_pct / head_threshold_pct, both 2):
+#: analysing a NARROWER band than the run optimizes would hand the skip gate a kernel with no
+#: roofline entry at all, which reads as "no verdict" and silently disables the gate for it.
+DEFAULT_MIN_PCT_GPU = 2.0
 DEFAULT_TOP_N = 8
 
 #: Kernel launch + scheduling overhead. A launch whose duration is within a small multiple of this
@@ -206,6 +211,11 @@ def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_
       * dispatch-bound -- the launch is timed by overhead, not by its transfer or its math;
       * infeasible (`raw_pct` outside (0,1]) -- the byte/FLOP model is wrong. A clamped 100% must
         never be read as "saturated"; that would turn a modelling failure into a routing decision.
+
+    `skip_optimization` is the run-level gate: a kernel at or above its class `target_eff` has no
+    recoverable time left and is dropped from BOTH optimization tracks. It is only ever True on a
+    real verdict -- every no-verdict path above sets it False explicitly, so a wrong byte model can
+    never silently delete the biggest kernel in the profile.
     """
     try:
         b, f, t = float(bytes_moved or 0), float(flops or 0), float(t_seconds or 0)
@@ -235,6 +245,7 @@ def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_
         "hbm_util": hbm_util, "compute_util": compute_util,
         "arithmetic_intensity": ai, "ridge_point": ridge,
         "roofline_pct_raw": raw_pct, "target_eff": tgt, "suspect": False,
+        "skip_optimization": False, "skip_reason": "",
     }
 
     # (1) Dispatch-bound by time: the launch is timed by scheduling overhead, not by its own transfer
@@ -242,7 +253,7 @@ def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_
     if t <= float(launch_overhead_s or 0) * LATENCY_BOUND_FACTOR:
         out.update(bound_type="latency", roofline_pct=min(max(raw_pct, 0.0), 1.0),
                    attainable_speedup=1.0, expected_e2e_gain_pct=0.0,
-                   headroom_class="unknown",
+                   headroom_class="unknown", skip_optimization=False,
                    note="per-launch time is within launch-overhead scale -> dispatch-bound; "
                         "roofline not applicable, lever is fusion / graph capture")
         return out
@@ -254,7 +265,7 @@ def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_
     if not (0.001 <= raw_pct <= 1.0):
         out.update(bound_type=roof_axis, roofline_pct=min(max(raw_pct, 0.0), 1.0),
                    attainable_speedup=1.0, expected_e2e_gain_pct=0.0,
-                   headroom_class="unknown", suspect=True,
+                   headroom_class="unknown", suspect=True, skip_optimization=False,
                    bytes_upper_bound=pbw * t, flops_upper_bound=(pfl * t) if pfl > 0 else None,
                    note="model infeasible (raw %.3f outside (0,1]) -> NOT a saturation verdict; "
                         "re-estimate with a tighter model or measure with counters (stage C)"
@@ -275,6 +286,10 @@ def roofline_metrics(bytes_moved, flops, t_seconds, peak_bw, peak_flops, target_
     out.update(bound_type=bound, roofline_pct=raw_pct, attainable_speedup=attainable,
                expected_e2e_gain_pct=float(pct_gpu_time or 0.0) * (1.0 - 1.0 / attainable),
                headroom_class=classify_headroom(raw_pct, tgt))
+    if raw_pct >= tgt:
+        out.update(skip_optimization=True,
+                   skip_reason="roofline %.3f >= target_eff %.3f -> no recoverable time; "
+                               "not worth an optimization budget" % (raw_pct, tgt))
     return out
 
 
@@ -283,7 +298,11 @@ def classify_headroom(roofline_pct, target_eff):
 
     Banded against `target_eff`, NOT against the raw roofline: what matters is the distance to what
     a good implementation of this class can realistically reach. Within 10% of that target means
-    tuning has nothing left to give (88% vs a 90% target is saturated, not "nearly there").
+    tuning has nothing left to give (0.80 against a 0.85 target is saturated, not "nearly there").
+
+    This is a THREE-BAND DESCRIPTION and is deliberately wider than the skip gate, which fires only
+    at `>= target_eff`. The band `0.9*target <= p < target` is therefore "saturated but still
+    optimized" -- reported as having little left, yet not dropped.
     """
     try:
         p, t = float(roofline_pct), float(target_eff)
@@ -383,11 +402,15 @@ def _selftest():
     moe = roofline_metrics(wbytes, 2 * M * tk * (2 * I * H + H * I), t_layer,
                            peaks["hbm_bw_bytes_s"], peak_flops_for(peaks, "fp8"),
                            TARGET_EFF["moe"], pct_gpu_time=26.45)
-    print("MoE   : hit %.0f/%d, %.0f MB/layer -> %.0f%% of roofline, %s, %.3fx, +%.2f%% e2e (%s)"
+    print("MoE   : hit %.0f/%d, %.0f MB/layer -> %.0f%% of roofline, %s, %.3fx, +%.2f%% e2e (%s, skip=%s)"
           % (hit, E, wbytes / 1e6, 100 * moe["roofline_pct"], moe["bound_type"],
-             moe["attainable_speedup"], moe["expected_e2e_gain_pct"], moe["headroom_class"]))
+             moe["attainable_speedup"], moe["expected_e2e_gain_pct"], moe["headroom_class"],
+             moe["skip_optimization"]))
     ok &= (moe["bound_type"] == "memory" and moe["headroom_class"] == "saturated"
            and 0.85 <= moe["roofline_pct"] <= 0.92 and moe["expected_e2e_gain_pct"] < 1.0)
+    # The gate on the case that motivated it: this head owns 26.45% of GPU time and optimizing it
+    # measured -0.064% e2e. At 0.88 against a 0.85 target it is now skipped outright.
+    ok &= moe["skip_optimization"] is True and "target_eff" in moe["skip_reason"]
 
     B, S, kvh, hd = 64, 1024 + 1024 // 2, 2, 256
     attn = roofline_metrics(B * S * kvh * hd * 2 * dtype_bytes("bf16"),
@@ -399,9 +422,10 @@ def _selftest():
              attn["bound_type"], attn["attainable_speedup"], attn["expected_e2e_gain_pct"],
              attn["headroom_class"]))
     # low util on both axes above the dispatch floor -> latency/occupancy-bound, but the verdict is
-    # KEPT (real headroom) so the ranking inversion below survives.
+    # KEPT (real headroom) so the ranking inversion below survives. Far below its 0.60 target, so
+    # the skip gate does not fire -- the head the profile ranked SECOND is the one that gets worked.
     ok &= (attn["bound_type"] == "latency" and attn["headroom_class"] == "underperforming"
-           and attn["attainable_speedup"] > 1.4
+           and attn["attainable_speedup"] > 1.4 and attn["skip_optimization"] is False
            and attn["expected_e2e_gain_pct"] > moe["expected_e2e_gain_pct"])
 
     # the whole point: the two rankings disagree, and roofline is the one that matched reality
@@ -413,7 +437,10 @@ def _selftest():
     allx = roofline_metrics(E * (2 * I * H + H * I) * 1, 1.0, t_layer, peaks["hbm_bw_bytes_s"],
                             peak_flops_for(peaks, "fp8"), TARGET_EFF["moe"], pct_gpu_time=26.45)
     assert allx["suspect"] and allx["roofline_pct"] <= 1.0, allx
-    print("L3    : all-expert bytes -> raw %.2f clamped to %.2f, suspect=True  OK"
+    # The clamp lands ABOVE target_eff. If the gate read roofline_pct alone it would now delete the
+    # biggest kernel in the profile on the strength of a broken byte model -- it must not.
+    assert allx["skip_optimization"] is False, allx
+    print("L3    : all-expert bytes -> raw %.2f clamped to %.2f, suspect=True, skip=False  OK"
           % (allx["roofline_pct_raw"], allx["roofline_pct"]))
 
     # degradation: unusable inputs return None instead of raising

--- a/e2e_workflow/roles/system_architect.md
+++ b/e2e_workflow/roles/system_architect.md
@@ -48,15 +48,20 @@ profile is where the budget goes, even though those kernels are library calls.
 **`achievable_speedup` is the half everyone guesses wrong.** A big `pct_gpu_time` is *necessary* but not
 *sufficient*: a kernel already running at the hardware's bandwidth or compute ceiling has no time left to
 recover, no matter how much of the profile it owns. When a roofline prior is available (step 1c) use it
-to ground that factor in a measured ceiling instead of a class prior — but note what it does and does not
-mean: **a saturated kernel is done with micro-tuning, NOT done being optimized.** If it is still the
-largest consumer of GPU time it remains the top target; the lever just moves from "make this kernel
-faster" to "make it move fewer bytes" (step 1d). Never let a headroom estimate drop the biggest kernel.
+to ground that factor in a measured ceiling instead of a class prior — and when it says the kernel is at
+its class `target_eff`, **do not optimize that kernel at all**, however much of the profile it owns. The
+measured case: a fused-MoE head owning 26.45% of GPU time, at 88% of its roof, whose optimization was
+worth **−0.064% e2e**. A run that spends its budget there has spent it on nothing.
+
+That gate is only trustworthy on a **full-confidence** verdict, so the confidence rules in step 1c are
+load-bearing rather than advisory: dropping the biggest kernel in the profile because a byte model was
+wrong is a far worse failure than tuning a saturated one.
 
 **`edit=N` (library) does NOT mean "skip" — it means "Tier-C code rewrite is unavailable."** A
 fixed-shape GEMM is one of the most tunable things on the chip. Route by *which optimization the op
 admits*, not by the edit flag:
-- **Head track** — any kernel with `pct_gpu_time ≥ HEAD_THRESHOLD_PCT` (default 5%), GEMM or attention,
+- **Head track** — any kernel with `pct_gpu_time ≥ HEAD_THRESHOLD_PCT` (default 2%) **and roofline
+  headroom left** (step 1c), GEMM or attention,
   **regardless of edit flag** → Kernel Extractor `extract_op` → **Op Benchmarker** ladder: Tier A
   backend select → Tier B per-backend tune (**GEMM = aiter per-shape DB**, NOT TunableOp) → **Tier C
   ALWAYS author+optimize a real kernel via kernel_workflow (triton ≥1)** → Tier D quant. **All GEMM
@@ -147,52 +152,58 @@ OPTIONAL upstream TraceLens prior (may be empty strings — treat empty/missing 
    profile is the judge; TraceLens only ADDs hints/candidates, never prunes them.** Treat any `shapes` it
    carries as a STARTING hint that the Extractor will re-verify against a live capture (they may be inaccurate).
    If the prior is absent, proceed exactly as before.
-1c. **Roofline prior (ADVISORY — only if `ANALYSIS_SKILL_DIR` is non-empty AND the Profiler returned a
+1c. **Roofline prior (only if `ANALYSIS_SKILL_DIR` is non-empty AND the Profiler returned a
    `profile_roofline_json` that EXISTS; otherwise skip this step entirely and route exactly as before).**
    Read the artifact. Per entry it gives `roofline_pct` (how much of the hardware ceiling the kernel
-   already reaches), `bound_type`, `attainable_speedup`, `expected_e2e_gain_pct`, `headroom_class` and a
-   `confidence`. Use it to answer the question `pct_gpu_time` alone cannot: **is the time this kernel
-   spends actually recoverable?**
+   already reaches), `target_eff`, `bound_type`, `attainable_speedup`, `expected_e2e_gain_pct`,
+   `headroom_class`, `skip_optimization` and a `confidence`. Use it to answer the question
+   `pct_gpu_time` alone cannot: **is the time this kernel spends actually recoverable?**
 
-   **The doctrine (do not violate).** `roofline_pct` measures how well a kernel executes its *current*
-   byte/FLOP budget; it says NOTHING about whether that budget is necessary. So:
-   - **NEVER prune a candidate on roofline.** Same rule as TraceLens: the measured `pct_gpu_time` is the
-     judge; this prior only ADDs information and REORDERS. `drop_list` decisions stay Amdahl-based.
-   - **A saturated head is NOT dropped — it is REROUTED.** A kernel that is both a large `pct_gpu_time`
-     and `headroom_class: saturated` is done with *micro-tuning*, not done being optimized. It remains a
-     top target; what changes is the class of fix (see 1d).
-   - Honour `confidence`: **`low` (stage A, or derived peaks) = display and annotate ONLY, do not rank on
-     it.** `medium`/`high` may be used as a SECONDARY ranking key. `unknown`/`suspect`/`modeled:false`
-     entries fall back to the ordinary playbook prior for that entry alone.
-   - If a kernel squad later measures an isolated speedup LARGER than `attainable_speedup`, the roofline
-     model was wrong: prefer the measurement, and say so in the report.
+   **The gate.** Unlike TraceLens, this prior DOES prune, through exactly one predicate:
+
+   > `roofline_pct ≥ target_eff` (the skill's `skip_optimization`) → **do not optimize this kernel.**
+   > Do not nominate it as a head or kernel candidate. This holds however large its `pct_gpu_time` is.
+
+   Class targets are gemm/moe/elementwise **0.85**, attention decode **0.60** (roofline `SKILL.md` §7).
+   The orchestrator enforces the same predicate on both queues, so a nomination above the bar is
+   dropped anyway — don't waste one.
+
+   **What the gate does NOT license (do not violate):**
+   - **It fires only on a full-confidence verdict.** `low` confidence (stage A, or peaks derived from
+     device props), `suspect`, `modeled:false`, or `headroom_class: unknown` → **never skipped**, and
+     not ranked on either; that entry falls back to the ordinary playbook prior. An unvalidated compute
+     peak can read a kernel with 2× of headroom as "at 85%" (`SKILL.md` §8) — skipping on it would
+     delete the largest kernel in the profile for nothing.
+   - **`roofline_pct` still says nothing about whether the byte/FLOP budget is *necessary*.** A skipped
+     kernel is not proven optimal; it is proven not worth a *tuning* budget. Changing its algorithm is
+     a different lever and is routed on its own merits, never on this number.
+   - If a kernel squad measures an isolated speedup LARGER than `attainable_speedup`, the roofline model
+     was wrong: prefer the measurement, and say so in the report.
 
    **Routing table** (applies only at `confidence` ≥ medium; otherwise use `pct_gpu_time` order):
 
    | `headroom_class` | `pct_gpu_time` | route |
    |---|---|---|
+   | **any, at `roofline_pct ≥ target_eff`** | **any** | **SKIPPED — not nominated to either track** |
    | underperforming | high | **kernel/head track, top priority** — real headroom exists |
-   | **saturated** | **high** | **byte-reduction track (1d) — NOT dropped, NOT another tuning pass** |
+   | saturated (still below target) | high | kernel/head track, low priority — little left, but not at the bar |
    | any | low | low priority (ordinary Amdahl) |
-   | unknown / low confidence | any | ignore roofline; order by `pct_gpu_time` |
+   | unknown / suspect / low confidence | any | **never skipped**; ignore roofline, order by `pct_gpu_time` |
 
    Report BOTH orderings in `strategy.md` — the one by `pct_gpu_time` and the one by
    `expected_e2e_gain_pct` — and state explicitly which you followed and why. When they disagree, that
    disagreement is the most useful thing in the analysis; do not hide it behind a single blended number.
+   **List every skipped kernel with its `skip_reason`**: a run that skipped the biggest kernel in its
+   profile must say so plainly rather than read as having found nothing.
 
-1d. **Byte-reduction levers (for a `saturated` + high-`pct_gpu_time` head).** The kernel is at the
-   bandwidth/compute wall, so the only remaining win is to make it do the same work moving fewer bytes.
-   Enumerate concretely: **fuse an adjacent op away** (a separate quant/silu/norm kernel in the Top-N →
-   fusing it removes a whole activation round-trip *and* that kernel's own GPU time); **stop reading what
-   isn't used** (e.g. streaming all `E` experts when routing only touches a fraction); **layout/packing**
-   (padding waste, coalescing, L2 reuse between stages); **lower-precision weights** (fp8→fp4, lossy →
-   must pass the accuracy gate).
-   **🔴 Hard constraints — a "win" that violates these is not a win:** the **measurement contract is
+1d. **🔴 Hard constraints — a "win" that violates these is not a win:** the **measurement contract is
    fixed**. The user-supplied workload — `isl`, `osl`, **`conc`/batch size — must NOT be changed**, and
    **speculative decoding (MTP or otherwise) must NOT be introduced** as an optimization. Raising
    throughput by changing what is being measured is out of scope for this workflow.
 
-2. Partition the Top-N into FOUR routes (by what optimization the op admits, NOT by edit flag):
+2. Partition the Top-N into FOUR routes (by what optimization the op admits, NOT by edit flag).
+   **Apply the step 1c skip gate first**: an entry at `roofline_pct ≥ target_eff` on a full-confidence
+   verdict goes to `drop_list` with its `skip_reason`, not to any of these four.
    - **config fast path** — service-level env/flag with no op isolation: `--attention-backend` swap,
      `--quantization fp8`, cuda-graph, torch-compile, kv-cache-dtype, scheduling/mem knobs → Config
      Tuner, FIRST. **GEMM tuning is NOT a config axis** (it's a head-track op now).
@@ -289,10 +300,10 @@ Return JSON:
      "source_hint": "<TraceLens source_file/source_path if any, else ''>",
      "launcher_hint": "<TraceLens kernel_path/launcher_source_file if any, else ''>",
      "bound_type": "<memory|compute|'' from TraceLens or the roofline prior>",
-     "roofline_pct": 0.0, "attainable_speedup": 0.0, "expected_e2e_gain_pct": 0.0,
+     "roofline_pct": 0.0, "target_eff": 0.0, "attainable_speedup": 0.0, "expected_e2e_gain_pct": 0.0,
      "headroom_class": "<underperforming|moderate|saturated|unknown|'' if no roofline prior>",
      "roofline_confidence": "<low|medium|high|'' if none>",
-     "byte_reduction_levers": ["only when headroom_class=saturated; see step 1d"]}
+     "suspect": false}
   ],
   "kernel_candidates": [
     {"id": "k0", "short_name": "...", "classification": "...", "pct_gpu_time": 0.0,
@@ -301,12 +312,12 @@ Return JSON:
      "source_hint": "<TraceLens source_file/source_path if any, else ''>",
      "launcher_hint": "<TraceLens kernel_path/launcher_source_file if any, else ''>",
      "bound_type": "<memory|compute|'' from TraceLens or the roofline prior>",
-     "roofline_pct": 0.0, "attainable_speedup": 0.0, "expected_e2e_gain_pct": 0.0,
+     "roofline_pct": 0.0, "target_eff": 0.0, "attainable_speedup": 0.0, "expected_e2e_gain_pct": 0.0,
      "headroom_class": "<underperforming|moderate|saturated|unknown|'' if no roofline prior>",
      "roofline_confidence": "<low|medium|high|'' if none>",
-     "byte_reduction_levers": ["only when headroom_class=saturated; see step 1d"]}
+     "suspect": false}
   ],
-  "drop_list": [{"short_name": "...", "why": "below Amdahl threshold"}],
+  "drop_list": [{"short_name": "...", "why": "below Amdahl threshold | roofline_pct >= target_eff (copy skip_reason)"}],
   "order_of_work": ["config fast path first", "then h0 (GEMM #1)", "then k0", "..."],
   "strategy_path": "<EVAL_DIR>/strategy.md"
 }
@@ -317,7 +328,7 @@ Return JSON:
 ## PHASE=plan_milestone  (between milestones, decide what to do next / whether to stop)
 
 Inputs: `EVAL_DIR`, `ROUND`, `BUDGET_REMAINING`, `CURRENT_THROUGHPUT`, `BASELINE_THROUGHPUT`,
-`NOISE_BAND_PCT`, **`MILESTONE_MIN_PCT`** (the pct_gpu_time bar; default 5), `MIN_KERNEL_TASKS`,
+`NOISE_BAND_PCT`, **`MILESTONE_MIN_PCT`** (the pct_gpu_time bar; default 2), `MIN_KERNEL_TASKS`,
 `DISPATCHED_SO_FAR`, `BELOW_MIN_FLOOR` (bool), latest `PROFILE_TOPN` (re-profiled after the last accepted
 change), `HISTORY`, `SKILL_DIR`.
 
@@ -329,6 +340,12 @@ change), `HISTORY`, `SKILL_DIR`.
    the floor**. If no editable kernel clears the bar, set `stop=true` with that reason (the floor does not
    force sub-threshold work). The orchestrator also post-filters by this bar, so sub-threshold
    nominations are dropped anyway — don't waste them.
+2b. **Roofline gate (HARD — also overrides the floor):** clearing the pct bar is necessary, not
+   sufficient. Do NOT nominate a kernel whose roofline entry says `roofline_pct >= target_eff` on a
+   full-confidence verdict (step 1c) — it has no recoverable time, so tuning it cannot move e2e no
+   matter how large its share. The confidence carve-outs in 1c apply here unchanged: `suspect`,
+   `unknown` and low-confidence entries are **never** gated out, only ordered. The orchestrator
+   post-filters on this predicate too. If nothing clears BOTH gates, set `stop=true` with that reason.
 3. **Floor rule (only among above-bar kernels):** if `BELOW_MIN_FLOOR` is true AND there ARE editable
    kernels `>= MILESTONE_MIN_PCT`, nominate enough of those fresh `kernel_candidates` to progress toward
    the floor — draw from the broad above-bar editable pool (gated-delta sub-kernels chunk_h / chunk_o /
@@ -337,12 +354,11 @@ change), `HISTORY`, `SKILL_DIR`.
 4. **Amdahl stop rule:** estimate remaining headroom = Σ over untouched above-bar editable kernels of
    `(pct_gpu_time × plausible_speedup_fraction)`. If the best remaining candidate can't plausibly move
    e2e beyond the noise band, set `stop=true`.
+   Sum over kernels that clear BOTH gates (2 and 2b) — a saturated kernel contributes nothing to the
+   remaining headroom, which is the point of gating it.
    **If a roofline prior is available at `confidence` ≥ medium** (`profile_roofline_json`, step 1c),
    prefer its `expected_e2e_gain_pct` over a guessed `plausible_speedup_fraction` — it is derived from a
-   measured ceiling rather than a class prior. It still may not PRUNE a candidate: use it to ORDER the
-   remaining pool and to justify `stop`. Never stop solely because roofline says headroom is small while
-   a large `pct_gpu_time` kernel remains untouched — such a kernel routes to the byte-reduction track
-   (step 1d) instead.
+   measured ceiling rather than a class prior.
 5. Issue concrete directions: exact callable to extract (`module:attr`) + candidate backends, citing the
    profile entry + pct_gpu_time. **Use HISTORY only to ORDER/diversify (deprioritize a direction that
    already showed no e2e gain THIS run, prefer a different kernel or a different mechanism) — NEVER as a

--- a/e2e_workflow/scripts/test_analysis_skill_off_identical.js
+++ b/e2e_workflow/scripts/test_analysis_skill_off_identical.js
@@ -66,8 +66,14 @@ if (m) {
     `-> the spread can never shadow another input`);
 }
 
-// 3) Consumers must treat the prior as optional and advisory.
-ok(/ADVISORY|advisory/.test(src), 'gating block documents the prior as advisory');
+// 3) Consumers must treat the prior as optional, and the gating block must state the ONE way it is
+//    not advisory: `roofline_pct >= target_eff` prunes. INDEX.md's skill contract allows exactly one
+//    such gate and only if it is declared where the skill is wired in.
+ok(/ADVISORY|advisory/.test(src), 'gating block documents the prior as advisory for ordering');
+ok(/target_eff/.test(src.slice(0, src.indexOf('ANALYSIS_SKILL_INPUTS'))),
+  'gating block declares the one gate (target_eff) rather than claiming it never prunes');
+ok(!/never prunes a candidate/.test(src),
+  'the pre-gate "never prunes a candidate" claim is gone -- it would now be false');
 for (const [role, phrase] of [['profiler', 'ANALYSIS_SKILL_DIR'], ['system_architect', 'ANALYSIS_SKILL_DIR']]) {
   const roleSrc = fs.readFileSync(path.join(ROOT, 'e2e_workflow', 'roles', `${role}.md`), 'utf8');
   ok(roleSrc.includes(phrase), `roles/${role}.md consumes ${phrase}`);

--- a/e2e_workflow/scripts/test_roofline_gate.js
+++ b/e2e_workflow/scripts/test_roofline_gate.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Regression guard for the roofline skip gate (no GPU, no model needed).
+//
+// The gate reverses a doctrine the orchestrator held until now ("NEVER prune a candidate on
+// roofline"): a kernel whose measured `roofline_pct` is at or above its class `target_eff` has no
+// recoverable time, so it is dropped from BOTH optimization tracks however large it is. That makes
+// `rooflineSkip` capable of deleting the single biggest kernel in a profile, which is exactly why
+// its confidence carve-outs are the load-bearing part of this file: a MODELLING failure
+// (`suspect`, clamped, unclassified, low-confidence) must never read as "already optimal".
+//
+// `rooflineSkip` is EXTRACTED from the real source rather than reimplemented here, so the test
+// cannot pass while the shipped predicate drifts. The two call sites are checked structurally.
+//
+// Run:  node e2e_workflow/scripts/test_roofline_gate.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..'); // .../GEAK
+const WORKFLOW = path.join(ROOT, 'e2e_workflow', 'e2e_workflow.js');
+
+let failures = 0;
+const ok = (cond, msg) => { if (!cond) { console.error('  FAIL:', msg); failures++; } else console.log('  ok:', msg); };
+
+const src = fs.readFileSync(WORKFLOW, 'utf8');
+
+// ---------------------------------------------------------------- extract the shipped predicate
+const gStart = src.indexOf('const ROOFLINE_TARGET_EFF =');
+const gEnd = src.indexOf('const PRE_FLAGGED_HEADS =');
+ok(gStart !== -1 && gEnd !== -1 && gStart < gEnd, 'roofline gate block located in e2e_workflow.js');
+if (gStart === -1 || gEnd === -1) { console.error('cannot continue'); process.exit(1); }
+
+const rooflineSkip = new Function(
+  src.slice(gStart, gEnd) + '\n return { rooflineSkip, ROOFLINE_TARGET_EFF };')().rooflineSkip;
+
+// A full-confidence, genuinely saturated MoE head — 26% of GPU time, and still skipped.
+const SATURATED = {
+  short_name: 'fused_moe_kernel', pct_gpu_time: 26.45, op_kind: 'moe',
+  roofline_pct: 0.88, target_eff: 0.85, headroom_class: 'saturated',
+  roofline_confidence: 'high', suspect: false,
+};
+const withOut = (k) => { const c = { ...SATURATED }; delete c[k]; return c; };
+
+console.log('\n-- the gate fires on a full-confidence saturated verdict');
+ok(rooflineSkip(SATURATED) !== null, 'roofline 0.88 >= target 0.85 -> skipped');
+ok(/0\.880 >= target_eff 0\.850/.test(rooflineSkip(SATURATED)),
+  'reason states both numbers, so the report can be audited');
+ok(rooflineSkip({ ...SATURATED, roofline_pct: 0.85 }) !== null, 'the bar is >=, not >');
+ok(rooflineSkip({ ...SATURATED, roofline_pct: 0.8499 }) === null, 'just below the bar -> optimized');
+ok(rooflineSkip({ ...SATURATED, roofline_pct: 0.84, headroom_class: 'saturated' }) === null,
+  'saturated-but-below-target is still optimized: the class banding is NOT the gate');
+
+console.log('\n-- a modelling failure never deletes a kernel');
+ok(rooflineSkip({ ...SATURATED, suspect: true, roofline_pct: 1.0 }) === null,
+  'suspect (clamped byte model) -> never skipped, even at a clamped 1.00');
+ok(rooflineSkip({ ...SATURATED, headroom_class: 'unknown' }) === null,
+  'headroom_class=unknown (dispatch-bound / infeasible) -> never skipped');
+ok(rooflineSkip(withOut('headroom_class')) === null, 'missing headroom_class -> never skipped');
+ok(rooflineSkip({ ...SATURATED, roofline_confidence: 'low' }) === null,
+  'confidence=low -> never skipped (an unvalidated peak reads ~2x high)');
+ok(rooflineSkip(withOut('roofline_confidence')) === null, 'missing confidence -> never skipped');
+ok(rooflineSkip({ ...SATURATED, skip_optimization: false }) === null,
+  'an explicit skip_optimization=false from the skill is honoured over the local recompute');
+
+console.log('\n-- degradation: no analysis skill, no gate');
+ok(rooflineSkip({ short_name: 'k', pct_gpu_time: 40.0 }) === null,
+  'a bare candidate (analysis_skill=none) is never skipped -> pre-feature behavior preserved');
+ok(rooflineSkip(null) === null && rooflineSkip(undefined) === null, 'null/undefined are safe');
+ok(rooflineSkip({ ...SATURATED, roofline_pct: 'n/a' }) === null, 'non-numeric roofline_pct is safe');
+ok(rooflineSkip({ ...SATURATED, roofline_pct: 0 }) === null, 'roofline_pct=0 is absence, not 0%');
+
+console.log('\n-- target_eff resolution');
+ok(rooflineSkip({ ...withOut('target_eff'), roofline_pct: 0.88 }) !== null,
+  'no target_eff on the candidate -> falls back to the op_kind table (moe=0.85)');
+ok(rooflineSkip({ ...withOut('target_eff'), op_kind: 'attn', roofline_pct: 0.70 }) !== null,
+  'attn falls back to 0.60, so 0.70 is over the bar');
+ok(rooflineSkip({ ...withOut('target_eff'), op_kind: 'moe', roofline_pct: 0.70 }) === null,
+  'the same 0.70 is UNDER the moe bar -> class-specific, not one global number');
+ok(rooflineSkip({ ...withOut('target_eff'), op_kind: 'reduce_scatter', roofline_pct: 0.99 }) === null,
+  'an unknown op class has no bar -> no skip (a guess must not drop a kernel)');
+ok(rooflineSkip({ ...withOut('target_eff'), op_kind: '', classification: 'dense gemm',
+  roofline_pct: 0.90 }) !== null, 'classification is read when op_kind is absent');
+ok(rooflineSkip({ ...SATURATED, target_eff: 0.95, roofline_pct: 0.90 }) === null,
+  "a recalibrated per-candidate target_eff wins over the table (SKILL.md §8 rule 5)");
+
+// ---------------------------------------------------------------- both call sites are wired
+// The gate is only worth anything if it is actually consulted on both tracks. These are structural
+// checks: admitHeads and the milestone planner are orchestration, not executable standalone.
+console.log('\n-- the gate is consulted on both tracks');
+const heads = src.slice(src.indexOf('function admitHeads('),
+  src.indexOf('function admitHeads(') + 6000);
+ok(/rooflineSkip\(head\)/.test(heads), 'head track: admitHeads() calls rooflineSkip');
+ok(/gate: 'roofline_saturated'/.test(heads),
+  'a skipped head is recorded in PRE_FLAGGED_HEADS, so it stays visible in the final report');
+ok(heads.indexOf('rooflineSkip(head)') < heads.indexOf('prepareHeadSelection'),
+  'the gate runs BEFORE the head is admitted, not after a budget is spent');
+
+ok(/const planCands = planCandsRaw\.filter\(c => !belowBar\(c\) && !rooflineSkip\(c\)\)/.test(src),
+  'milestone track: the plan filter applies both the %GPU bar and the roofline gate');
+ok(/const skipped = planCandsRaw\.filter\(c => belowBar\(c\) \|\| rooflineSkip\(c\)\)/.test(src),
+  'and both reasons land in the same skipped-kernel log line');
+
+console.log('\n-- the %GPU bar moved 5% -> 2%');
+ok(/A\.milestone_min_pct != null \? A\.milestone_min_pct : 2/.test(src), 'MILESTONE_MIN_PCT default 2');
+ok(/A\.head_threshold_pct != null \? A\.head_threshold_pct : 2/.test(src), 'HEAD_THRESHOLD_PCT default 2');
+
+console.log(failures ? `\n${failures} FAILURE(S)` : '\nall roofline-gate checks passed');
+process.exit(failures ? 1 : 0);

--- a/e2e_workflow/scripts/tests/test_roofline_skill.py
+++ b/e2e_workflow/scripts/tests/test_roofline_skill.py
@@ -5,8 +5,8 @@ Two things are locked here.
 1. **Calibration against a real run.** The numbers below are the measured profile of
    Qwen3.5-35B-A3B-FP8 on gfx950 / vLLM / TP1 / isl-osl 1k / conc 64 — a run whose outcome we know.
    The skill must reproduce the call it would have made:
-     fused_moe   26.45% GPU, ~88% of roofline -> saturated, ~1.02x attainable  (measured: 1.047x
-                 isolated, -0.064% e2e -> the budget spent there was wasted)
+     fused_moe   26.45% GPU, ~88% of roofline -> at/above the 0.85 MoE target -> SKIPPED entirely
+                 (measured: 1.047x isolated, -0.064% e2e -> the budget spent there was wasted)
      paged_attn   8.86% GPU, ~18% of roofline -> underperforming, >1.4x        (measured: 1.56x isolated)
    The load-bearing assertion is `test_rankings_disagree`: ranking by pct_gpu_time puts MoE first,
    ranking by roofline headroom puts attention first. That inversion is the entire point of the skill.
@@ -15,6 +15,7 @@ Two things are locked here.
    so a bad peak table / unmodellable op / impossible result / missing counter cannot fail a run.
 """
 import os
+import re
 import sys
 import unittest
 
@@ -101,15 +102,21 @@ class TestCalibrationMoE(unittest.TestCase):
         # measured e2e was -0.064%, i.e. inside the 0.5% noise band -> prediction must agree
         self.assertLess(m["expected_e2e_gain_pct"], 1.0)
 
-    def test_88pct_against_a_90pct_target_is_saturated_not_moderate(self):
+    def test_88pct_against_an_85pct_target_is_saturated_not_moderate(self):
         """Regression: banding on target_eff, not on the raw roofline.
 
-        Classifying 0.88 against a 0.90 target as `moderate` would route this head back to the
+        Classifying 0.88 against a 0.85 target as `moderate` would route this head back to the
         kernel track — exactly the wasted budget this skill exists to prevent.
         """
-        self.assertEqual(rt.classify_headroom(0.88, 0.90), "saturated")
-        self.assertEqual(rt.classify_headroom(0.60, 0.90), "moderate")
-        self.assertEqual(rt.classify_headroom(0.20, 0.90), "underperforming")
+        self.assertEqual(rt.classify_headroom(0.88, 0.85), "saturated")
+        self.assertEqual(rt.classify_headroom(0.60, 0.85), "moderate")
+        self.assertEqual(rt.classify_headroom(0.20, 0.85), "underperforming")
+
+    def test_saturated_head_is_skipped_outright(self):
+        """The doctrine reversal: 0.88 >= the 0.85 MoE target -> no optimization budget at all."""
+        m = _moe_metrics()
+        self.assertTrue(m["skip_optimization"])
+        self.assertIn("target_eff", m["skip_reason"])
 
 
 class TestCalibrationAttention(unittest.TestCase):
@@ -121,9 +128,11 @@ class TestCalibrationAttention(unittest.TestCase):
         self.assertGreater(a["attainable_speedup"], 1.4)
 
     def test_prediction_brackets_the_measured_speedup(self):
-        """target_eff=0.50 predicts ~1.7-2.8x; the squad measured 1.56x. A prior that predicted
+        """target_eff=0.60 predicts ~2.1-3.4x; the squad measured 1.56x. A prior that predicted
         below the measured value would be the dangerous direction (it under-ranks real work)."""
-        self.assertGreaterEqual(_attn_metrics()["attainable_speedup"], 1.56)
+        a = _attn_metrics()
+        self.assertGreaterEqual(a["attainable_speedup"], 1.56)
+        self.assertFalse(a["skip_optimization"])   # 18% of roofline is nowhere near the 0.60 bar
 
 
 class TestBoundTypeByUtilization(unittest.TestCase):
@@ -141,8 +150,8 @@ class TestBoundTypeByUtilization(unittest.TestCase):
         self.assertGreater(a["attainable_speedup"], 1.4)
 
     def test_saturated_memory_head_stays_memory_bound(self):
-        """A genuinely bandwidth-bound head (high hbm_util) keeps bound_type='memory' so it routes to
-        the byte-reduction track, not the occupancy track."""
+        """A genuinely bandwidth-bound head (high hbm_util) keeps bound_type='memory', so the
+        Architect reads a bandwidth wall rather than an occupancy problem."""
         m = _moe_metrics()
         self.assertEqual(m["bound_type"], "memory")
         self.assertGreaterEqual(m["hbm_util"], 0.60)
@@ -196,6 +205,9 @@ class TestDegradation(unittest.TestCase):
         self.assertEqual(m["headroom_class"], "unknown")
         self.assertEqual(m["attainable_speedup"], 1.0)
         self.assertEqual(m["expected_e2e_gain_pct"], 0.0)
+        # and, load-bearing since the gate went hard: a clamped 1.00 >= 0.85 must NOT skip the kernel
+        self.assertFalse(m["skip_optimization"])
+        self.assertEqual(m["skip_reason"], "")
         self.assertIn("bytes_upper_bound", m)          # what the model violated, for stage C
         self.assertLess(m["bytes_upper_bound"], m["bytes_est"])
 
@@ -204,10 +216,11 @@ class TestDegradation(unittest.TestCase):
         bandwidth or math. Emit bound_type='latency' and no verdict — the lever is fusion."""
         p = _peaks()
         m = rt.roofline_metrics(1e5, 1e5, 2e-6, p["hbm_bw_bytes_s"],
-                                rt.peak_flops_for(p, "bf16"), 0.875, pct_gpu_time=4.9)
+                                rt.peak_flops_for(p, "bf16"), 0.85, pct_gpu_time=1.9)
         self.assertEqual(m["bound_type"], "latency")
         self.assertEqual(m["headroom_class"], "unknown")
         self.assertEqual(m["expected_e2e_gain_pct"], 0.0)
+        self.assertFalse(m["skip_optimization"])   # no verdict is never a reason to skip
         self.assertIn("fusion", m["note"])
 
     def test_bound_type_is_a_closed_set(self):
@@ -216,7 +229,7 @@ class TestDegradation(unittest.TestCase):
         p = _peaks()
         cases = [_moe_metrics(), _attn_metrics(), _moe_metrics(all_experts=True),
                  rt.roofline_metrics(1e5, 1e5, 2e-6, p["hbm_bw_bytes_s"],
-                                     rt.peak_flops_for(p, "bf16"), 0.875)]
+                                     rt.peak_flops_for(p, "bf16"), 0.85)]
         for m in cases:
             self.assertIn(m["bound_type"], rt.BOUND_TYPES, m.get("note", ""))
 
@@ -231,6 +244,13 @@ class TestHeadScoping(unittest.TestCase):
     def test_below_bar_is_skipped_not_degraded(self):
         sel = [e["short_name"] for e in rt.select_entries(self.ENTRIES, min_pct_gpu=5.0)]
         self.assertEqual(sel, ["big", "mid", "bar"])   # sorted desc, sub-bar absent entirely
+
+    def test_default_scope_tracks_the_run_bar(self):
+        """The skill's scope must match the orchestrator's 2% bar: a 1.7% kernel is now gated on
+        roofline, so it must HAVE a roofline entry rather than being invisible to the analysis."""
+        self.assertEqual(rt.DEFAULT_MIN_PCT_GPU, 2.0)
+        sel = [e["short_name"] for e in rt.select_entries(self.ENTRIES)]
+        self.assertEqual(sel, ["big", "mid", "bar"])
 
     def test_top_n_cap(self):
         self.assertEqual(len(rt.select_entries(self.ENTRIES, min_pct_gpu=0.0, top_n=2)), 2)
@@ -280,21 +300,46 @@ class TestHeadScoping(unittest.TestCase):
 
 
 class TestSkillDocConsistency(unittest.TestCase):
-    """The helper's priors must not drift from the SKILL.md table that documents them."""
+    """The helper's priors must not drift from the two other places that restate them.
+
+    `target_eff` stopped being an advisory prior: it is the skip bar, so a drift between the helper,
+    the doc an agent executes, and the orchestrator's own fallback table would silently change which
+    kernels a run optimizes.
+    """
+
+    EXPECTED = {"gemm": 0.85, "moe": 0.85, "elementwise": 0.85, "attn": 0.60}
 
     def test_target_eff_matches_skill_md(self):
         skill_md = os.path.join(os.path.dirname(PEAKS_MD), "SKILL.md")
         with open(skill_md, encoding="utf-8") as fh:
             text = fh.read()
-        self.assertEqual(rt.TARGET_EFF["gemm"], 0.90)
-        self.assertEqual(rt.TARGET_EFF["moe"], 0.90)
-        self.assertEqual(rt.TARGET_EFF["attn"], 0.50)
-        for frag in ("dense GEMM | **0.90**", "MoE / grouped GEMM | **0.90**",
-                     "attention decode (paged) | **0.50**"):
+        self.assertEqual(dict(rt.TARGET_EFF), self.EXPECTED)
+        for frag in ("dense GEMM | **0.85**", "MoE / grouped GEMM | **0.85**",
+                     "elementwise / norm / quant | **0.85**",
+                     "attention decode (paged) | **0.60**"):
             self.assertIn(frag, text, "SKILL.md target_eff table drifted from roofline_tools.TARGET_EFF")
 
+    def test_target_eff_matches_the_orchestrator_fallback_table(self):
+        """`e2e_workflow.js` carries its own copy for candidates that arrive without `target_eff`."""
+        js = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__)))), "e2e_workflow.js")
+        with open(js, encoding="utf-8") as fh:
+            line = [ln for ln in fh if "const ROOFLINE_TARGET_EFF" in ln]
+        self.assertEqual(len(line), 1, "expected exactly one ROOFLINE_TARGET_EFF definition")
+        found = dict((k, float(v)) for k, v in
+                     re.findall(r"(\w+)\s*:\s*([0-9.]+)", line[0].split("{", 1)[1]))
+        self.assertEqual(found, self.EXPECTED,
+                         "e2e_workflow.js ROOFLINE_TARGET_EFF drifted from roofline_tools.TARGET_EFF")
+
+    def test_skip_gate_predicate_is_documented(self):
+        """INDEX.md's contract allows exactly ONE gate, and only if its predicate is written down."""
+        with open(os.path.join(os.path.dirname(PEAKS_MD), "SKILL.md"), encoding="utf-8") as fh:
+            text = fh.read()
+        self.assertIn("skip_optimization = (headroom_class != \"unknown\") and (not suspect) "
+                      "and (roofline_pct >= target_eff)", text)
+
     def test_workload_contract_is_stated(self):
-        """The hard constraint the byte-reduction track must not violate."""
+        """The hard constraint every lever this skill routes to must not violate."""
         with open(os.path.join(os.path.dirname(PEAKS_MD), "SKILL.md"), encoding="utf-8") as fh:
             text = fh.read()
         self.assertIn("must not be changed", text)


### PR DESCRIPTION
Two changes to what a run spends its budget on.

1. Roofline 85% becomes a gate, not just an ordering hint. 

   The skill has been able to say "this kernel is already at the wall" since it landed, but the Architect was explicitly told to ignore that as a drop criterion ("NEVER prune a candidate on roofline") and to reroute a saturated head to a byte-reduction track instead. The reference run is what that costs: fused_moe at 26.45% of GPU time and ~88% of its roofline took a full optimization slot and returned -0.064% e2e -- inside the noise band.

   Now a kernel with `roofline_pct >= target_eff` is not optimized at all, on either track, however large it is. The byte-reduction fallback is removed rather than kept as a consolation route: an algorithmic change (fusing an adjacent op, fp8->fp4 weights) is the Architect's call on its own merits, not something a roofline number should route into.

   Class targets are now gemm/moe/elementwise 0.85 and attn 0.60 (was 0.90/0.90/0.875/0.50). These stopped being advisory priors the moment they became the skip bar, so they are held in sync across all three places that state them -- roofline_tools.TARGET_EFF, SKILL.md section 7, and the orchestrator's fallback table -- by test_roofline_skill.py.

   The gate can delete the biggest kernel in a profile, so it fires ONLY on a full-confidence verdict. `suspect`, `headroom_class=unknown`, a missing or `low` confidence, or an unknown op class all fall through to ordinary Amdahl ordering. This is not defensive padding: SKILL.md section 6 L3 clamps an infeasible byte model to 1.00 (the real fused_moe all-expert case does exactly this), and section 8 documents that an unvalidated compute peak reads a 43%-of-roofline kernel as 85%. Either would silently drop the run's whole workload.

2. The %GPU bar drops from 5% to 2%.

   `head_threshold_pct`, `milestone_min_pct` and the skill's own analysis scope move together. The last one is load-bearing rather than cosmetic: leaving it at 5 would gate 2-5% kernels on a roofline entry that was never computed for them.

Not changed: `expected_e2e_gain_pct` keeps its existing formula, and `classify_headroom` keeps its three bands. `saturated` still means `>= 0.9*target`, so a kernel between 0.9*target and target is classified saturated and still optimized -- the band and the gate are deliberately different lines.

Skipped kernels are recorded, not dropped from the record: heads go through PRE_FLAGGED_HEADS with `gate: 'roofline_saturated'` and milestone kernels share the existing skipped-kernel log line, so a run that skipped its largest kernel says so instead of looking like it found nothing.

`analysis_skill=none` is unaffected -- with no roofline fields on a candidate the gate cannot fire, and test_analysis_skill_off_identical.js still passes.

Tests: test_roofline_skill.py grows the skip-gate cases and the three-way target sync check; new test_roofline_gate.js extracts the shipped `rooflineSkip` from source (not a reimplementation) and pins the confidence carve-outs plus both call sites, wired into ci-l0-checks.yml.