### PR TITLE
Fix rocminfo CU detection reading the CPU agent, not the GPU

### DIFF
--- a/kernel_workflow/knowledge/amd_instinct.md
+++ b/kernel_workflow/knowledge/amd_instinct.md
@@ -10,9 +10,12 @@ values + your measured benchmark over any number written here (this table is a d
 reference material in this workflow):
 
 ```bash
-rocminfo 2>/dev/null | grep -m1 -oE 'gfx[0-9a-f]+'          # arch id: gfx942 (CDNA3) | gfx950 (CDNA4)
-rocminfo 2>/dev/null | grep -m1 -iE 'Compute Unit'          # CU count on THIS device
-rocm-smi --showproductname 2>/dev/null | grep -iE 'MI3'     # marketing name (MI300X/325X/350X/355X/...)
+# rocminfo lists the CPU agent FIRST, so a bare `grep -m1 'Compute Unit'` returns the CPU CORE
+# COUNT, not the GPU's. Scope every field to the gfx agent:
+rocminfo 2>/dev/null | awk '/^ *Name: *gfx/{print $2; exit}'                        # gfx target
+rocminfo 2>/dev/null | awk '/Name:.*gfx/{f=1} f&&/Compute Unit:/{print $3; exit}'   # CU count
+rocminfo 2>/dev/null | awk '/Name:.*gfx/{f=1} f&&/Wavefront Size:/{print $3; exit}' # wavefront
+rocminfo 2>/dev/null | awk '/Name:.*gfx/{f=1} f&&/Marketing Name:/{$1=$2=""; print; exit}'
 rocm-smi --showmeminfo vram 2>/dev/null | head              # HBM capacity
 ```
 - The `gfx` id is what matters for code paths (fp8 format, MFMA shapes, MX support). The CU count is


### PR DESCRIPTION
## The bug

`amd_instinct.md` §0 is the "detect THIS box first" recipe. Its CU line was:

```bash
rocminfo 2>/dev/null | grep -m1 -iE 'Compute Unit'          # CU count on THIS device
```

`grep -m1` returns the **first** match, and rocminfo lists the **CPU agent first**. So
this reports host CPU cores, not GPU compute units. On an Strix Halo APU it yields 32 where the GPU has 40.

## The fix

Every field is scoped to the gfx agent with awk:

```bash
rocminfo 2>/dev/null | awk '/^ *Name: *gfx/{print $2; exit}'                        # gfx target
rocminfo 2>/dev/null | awk '/Name:.*gfx/{f=1} f&&/Compute Unit:/{print $3; exit}'   # CU count
rocminfo 2>/dev/null | awk '/Name:.*gfx/{f=1} f&&/Wavefront Size:/{print $3; exit}' # wavefront
rocminfo 2>/dev/null | awk '/Name:.*gfx/{f=1} f&&/Marketing Name:/{$1=$2=""; print; exit}'
```

## Verification

On a real box, agents enumerate as CPU(32) / gfx1151(40) / aie2p(0): the old command
returns **32** CUs, the new one returns **40** CUs, wavefront **32**, marketing name "AMD Radeon 8060S Graphics".

On another machine, rocminfo provided
```
  agent 1: AMD          type=CPU   Compute Unit=192
  agent 2: AMD          type=CPU   Compute Unit=192
  agent 3: gfx942       type=GPU   Compute Unit=304
```
and before this PR, we detected "Compute Unit  : 192",
where the correct values is "Compute Unit  : 304"
```

- CI L0 pytest list: 1967 passed, 5 skipped, 85 subtests; coverage 97.52% vs the 97% gate
