### PR TITLE
fix(kb): key the materialized recipe scalar by the store metric

### DIFF
--- a/kb/store_local.py
+++ b/kb/store_local.py
@@ -286,7 +286,7 @@ class LocalKBStore(object):
         if not isinstance(candidate, Candidate):
             champion_id = str(self.champion(canonical_id).get("session_id") or "")
             candidate = Candidate(session_id, knowledge,
-                                  finite_speedup(knowledge.get("speedup")),
+                                  finite_speedup(knowledge.get(self.metric)),
                                   session_id == champion_id)
 
         os.makedirs(destination, exist_ok=True)
@@ -303,7 +303,12 @@ class LocalKBStore(object):
             recipe.update({"canonical_id": canonical_id, "session_id": session_id,
                            "is_champion": candidate.is_champion,
                            "champion": candidate.is_champion})
-            recipe.setdefault("speedup", candidate.speedup)
+            # Keyed by self.metric, not by the literal "speedup": Candidate.speedup holds
+            # whatever scalar THIS store ranks on, so on the e2e lane's exact rung (metric
+            # `throughput_tok_s`) the literal writes a tokens/sec number into a bundle field
+            # that every reader takes for a ratio. RemoteKBStore.materialize() already keys it
+            # this way, and the two planes have to produce the same bundle.
+            recipe.setdefault(self.metric, candidate.speedup)
             _write_json(os.path.join(staging, RECIPE_FILENAME), recipe)
             _replace_directory(staging, bundle)
             staging = ""

--- a/kb/tests/test_store_local.py
+++ b/kb/tests/test_store_local.py
@@ -239,6 +239,44 @@ def test_materialize_accepts_a_bare_session_id(tmp_path):
     assert os.path.isfile(os.path.join(bundle, "files", "patch.diff"))
 
 
+def test_materialize_keys_the_recipe_scalar_by_this_store_metric(tmp_path):
+    """A non-speedup store must not label its ranking scalar `speedup`.
+
+    The e2e lane's exact-workload rung ranks on absolute `throughput_tok_s`, so Candidate.speedup
+    there holds tokens/sec. Writing it into the bundle under the literal `speedup` hands the next
+    reader a four-digit ratio for a run that recorded no ratio at all.
+    """
+    store = LocalKBStore(tmp_path / "store", metric="throughput_tok_s", promote_floor=0.0)
+    store.write(CID, "sid-1", {"schema": "geak.e2e.v1", "throughput_tok_s": 4321.0,
+                               "value": {"direction": "tp8"}}, artifacts(tmp_path, "a"))
+    bundle = store.materialize(CID, store.candidates(CID, limit=1)[0], str(tmp_path / "cache"))
+    recipe = json.loads(open(os.path.join(bundle, "recipe.json")).read())
+    assert recipe["throughput_tok_s"] == 4321.0
+    assert "speedup" not in recipe
+
+
+def test_materialize_by_bare_session_id_reads_this_store_metric(tmp_path):
+    """The bare-id path builds its own Candidate; it has to rank it the way candidates() does."""
+    store = LocalKBStore(tmp_path / "store", metric="throughput_tok_s", promote_floor=0.0)
+    store.write(CID, "sid-1", {"schema": "geak.e2e.v1", "throughput_tok_s": 4321.0,
+                               "value": {"direction": "tp8"}}, artifacts(tmp_path, "a"))
+    bundle = store.materialize(CID, "sid-1", str(tmp_path / "cache"))
+    recipe = json.loads(open(os.path.join(bundle, "recipe.json")).read())
+    assert recipe["throughput_tok_s"] == 4321.0
+    assert "speedup" not in recipe
+
+
+def test_materialize_still_carries_speedup_on_a_speedup_ranked_store(tmp_path):
+    """The kernel lane's default is unchanged: a document with no scalar gets the ranked one."""
+    store = LocalKBStore(tmp_path / "store")
+    document = knowledge()
+    document.pop("speedup")
+    store.write(CID, "sid-1", document, artifacts(tmp_path, "a"))
+    bundle = store.materialize(CID, "sid-1", str(tmp_path / "cache"))
+    recipe = json.loads(open(os.path.join(bundle, "recipe.json")).read())
+    assert recipe["speedup"] is None
+
+
 def test_materialize_refuses_a_candidate_that_is_not_there(tmp_path):
     with pytest.raises(KBStoreError):
         LocalKBStore(tmp_path / "store").materialize(CID, "sid-missing", str(tmp_path / "cache"))


### PR DESCRIPTION
## Summary

* `LocalKBStore.materialize()` wrote its ranking number into `recipe.json` under the literal `"speedup"` regardless of what the store was ranking on. `Candidate.speedup` holds whichever scalar the store was opened with, so on the e2e read path (throughput by default, on every rung) a tokens/sec value came out labeled as a speedup.
* `RemoteKBStore.materialize()` already keys this off `self.metric` (`kb/store_remote.py:191`), so the two planes were producing different bundles from the same input. Both literals now use `self.metric`, which is also what `candidates()`, `champion_speedup()` and `promote()` do in the same file.
* The kernel lane ranks on `speedup`, so its bundles are unchanged.

## Test plan

Three regression tests added to `kb/tests/test_store_local.py`, which is already in the L0 pytest list and runs on the GPU-free ubuntu job:

* a throughput-ranked store must not put a `speedup` key in `recipe.json`
* the bare-session-id path has to read the store's metric too, same as `candidates()`
* a speedup-ranked store still gets its scalar carried into the bundle, so the kernel lane's behaviour is pinned

The first two fail on `main` and pass with the change:

```
FAILED kb/tests/test_store_local.py::test_materialize_keys_the_recipe_scalar_by_this_store_metric
FAILED kb/tests/test_store_local.py::test_materialize_by_bare_session_id_reads_this_store_metric
2 failed, 41 passed, 1 skipped
```

After:

```
43 passed, 1 skipped in 1.25s
```

I also ran the wider set that touches this store, `kb/tests`, `test_e2e_store.py`, `test_kb_retract.py`, `test_experience_store.py` and `test_kb_loop_offline.py`: 296 passed, 3 failed. Those 3 fail the same way on a clean checkout of `main` on my machine and look like Windows path issues, they're unrelated to this change. `ruff check` is clean on both files.

## Related issues

Fixes #465
